### PR TITLE
had to change \\ in GetScripts to File.seperator

### DIFF
--- a/src/net/aufdemrand/denizen/utilities/GetScript.java
+++ b/src/net/aufdemrand/denizen/utilities/GetScript.java
@@ -34,11 +34,11 @@ public class GetScript {
 
 		Denizen plugin = (Denizen) Bukkit.getPluginManager().getPlugin("Denizen");		
 		
-		PrintWriter pw = new PrintWriter(new FileOutputStream(plugin.getDataFolder() + "\\read-only-scripts.yml"));
+		PrintWriter pw = new PrintWriter(new FileOutputStream(plugin.getDataFolder() + File.separator + "read-only-scripts.yml"));
 
-		plugin.getServer().broadcastMessage(plugin.getDataFolder() + "\\scripts");
+		plugin.getServer().broadcastMessage(plugin.getDataFolder() + File.separator + "scripts");
 		
-		File file = new File(plugin.getDataFolder() + "\\scripts");
+		File file = new File(plugin.getDataFolder() + File.separator + "scripts");
 		File[] files = file.listFiles();
 		for (int i = 0; i < files.length; i++) {
 


### PR DESCRIPTION
\ only works on Windows systems, and will cause all Linux systems to write a file called Denizens\read-only-scrits.yml which is placed in the plugins folder (this is not a Directory and filename) it is a single filename as far as linux is concerned, so it will not find Denizens/read-only-scripts.yml. So I changed as many references to \ as I could and put in File.seperator to make this work universally with any OS.
