### PR TITLE
A change to add a DURABILITY check for a held item in a requirement.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ Denizen.iml
 .idea
 bin/
 lib/
+target/
+.settings/
 
 # Compiled source #
 ###################

--- a/src/net/aufdemrand/denizen/utilities/GetPlayer.java
+++ b/src/net/aufdemrand/denizen/utilities/GetPlayer.java
@@ -446,7 +446,51 @@ public class GetPlayer {
 
 
 
+	/**
+	 * Checks the held item's durability using the given operator evaluated against an amount.
+	 * 
+	 * @param  thePlayer  the Player whose inventory shall be checked.
+	 * @param  operator the comparative operator to use to check the value against.  Could be a greater than (&gt;), less than (&lt;), or equal to (=) symbol.
+	 * @param  theAmount  the String representation of the value to check against.  Could be a simple number, or a number ending in a percentage symbol (%).
+	 * @param  negativeRequirement  Set to true if this is a negative (-) requirement.
+	 * @return Whether the conditions were met or failed.
+	 */
+	public boolean checkDurability(Player thePlayer, String operator, String theAmount, boolean negativeRequirement)
+	{
+		boolean outcome = false;
+		
+		short max = thePlayer.getItemInHand().getType().getMaxDurability();
+		//Bukkit reports durability as the amount of damage on the item.
+		short currentDurability = (short)(max - thePlayer.getItemInHand().getDurability());
+		short amount = -1;
 
+		//This is a percentage check, so figure out the actual amount (rounded) of the percentage of the max durability.
+		if(theAmount.endsWith("%"))	{
+			float percent = Float.parseFloat(theAmount.substring(0,theAmount.length()-1))/100;
+			amount = (short)Math.round( max * percent);
+		}
+		//Simple value check, so just use the number
+		else {
+			amount = Short.parseShort(theAmount);
+		}
+		
+		if(">".equals(operator)) {
+			outcome = currentDurability > amount;
+		}
+		else if("<".equals(operator)) {
+			outcome = currentDurability < amount;
+		}
+		else if("=".equals(operator)) {
+			outcome = currentDurability == amount;
+		}
+		
+		// Invert for negative checks.
+		if(negativeRequirement) outcome = !outcome;
+		
+		return outcome;
+	}
+
+	
 
 
 	/**

--- a/src/net/aufdemrand/denizen/utilities/GetRequirements.java
+++ b/src/net/aufdemrand/denizen/utilities/GetRequirements.java
@@ -2,6 +2,7 @@ package net.aufdemrand.denizen.utilities;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import net.aufdemrand.denizen.Denizen;
 
@@ -20,7 +21,7 @@ public class GetRequirements {
 	public enum Requirement {
 		NONE, NAME, WEARING, ITEM, HOLDING, TIME, PRECIPITATION, ACTIVITY, FINISHED, SCRIPT, FAILED,
 		STORMY, SUNNY, HUNGER, WORLD, PERMISSION, LEVEL, GROUP, MONEY, POTIONEFFECT, PRECIPITATING,
-		STORMING 
+		STORMING, DURABILITY
 	}
 
 
@@ -141,6 +142,24 @@ public class GetRequirements {
 				for(String arg : arguments) if (arg != null) thePermissions.add(arg);
 				thePermissions.remove(0);   /* Remove the command from the list */
 				if (Denizen.getPlayer.checkPermissions((Player) theEntity, thePermissions, negativeRequirement)) numberMet++;
+				break;
+
+			case DURABILITY:  // (-)DURABILITY [>,<,=] [#|#%]
+				if(arguments[1] == null
+						|| arguments[2] == null) {
+					Bukkit.getLogger().info("Denizen: Invalid DURABILITY requirement in the script " + theScript + ".  Should have 2 arguments.");
+				}
+				else if (!">".equals(arguments[1]) 
+						&& !"<".equals(arguments[1])
+						&& !"=".equals(arguments[1])){
+					Bukkit.getLogger().info("Denizen: Invalid DURABILITY requirement in the script " + theScript + ".  First argument should be >, <, or =.");					
+				}
+				else if (!Pattern.matches("[0-9]{1,}|[0-9]{1,3}%", arguments[2])){
+					Bukkit.getLogger().info("Denizen: Invalid DURABILITY requirement in the script " + theScript + ".  Second argument should be a number, or a percentage.");					
+				}
+				else {
+					if (Denizen.getPlayer.checkDurability((Player) theEntity, arguments[1], arguments[2], negativeRequirement)) numberMet++;
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
You can now specify a DURABILITY check in a trigger script as a
requirement.  the DURABILITY check requires two parameters.  The first
parameter is a >, <, or = symbol denoting the type of check to perform
against the current item's remaining durability.  The second parameter
is either a simple number value compared against the item's durability,
or a percentage of the item's max durability.  The percentage must be a
3 digit or less number with a percent sign (%) following it, as in this
example:

'Durability Check':
Type: Trigger
Requirements:
Mode: All
List:
- DURABILITY > 50%

The above would trigger if the held item's remaining durability is
greater than 50% of it's max durability.
