### PR TITLE
Change Byte.valueof(theData) to (byte) Integer.parseInt(theData).. the o...

### DIFF
--- a/src/main/java/net/aufdemrand/denizen/utilities/GetPlayer.java
+++ b/src/main/java/net/aufdemrand/denizen/utilities/GetPlayer.java
@@ -427,7 +427,7 @@ public class GetPlayer {
 
 					if (thePlayer.getItemInHand().getTypeId() == Integer.valueOf(theItem)
 							&& thePlayer.getItemInHand().getAmount() >= Integer.valueOf(theAmount)
-							&& thePlayer.getItemInHand().getData().getData() == Byte.valueOf(theData)) 
+							&& thePlayer.getItemInHand().getData().getData() == (byte)Integer.parseInt(theData)) 
 						outcome = true;
 
 				}


### PR DESCRIPTION
...rginal will work with normal Vanilla data values, but as spout uses higher values (assumed) this causes a parse error.
