### PR TITLE
Allowed for mcMMO related player tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
 			<url>http://maven.sk89q.com/repo/</url>
 		</repository>
 		<repository>
+			<id>mcmmo-repo</id>
+			<url>http://repo.mcmmo.info/</url>
+		</repository>
+		<repository>
 			<id>comphenix-rep</id>
 			<url>http://repo.comphenix.net/content/groups/public</url>
 		</repository>
@@ -91,6 +95,12 @@
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldguard</artifactId>
 			<version>5.6.6-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.gmail.nossr50.mcMMO</groupId>
+			<artifactId>mcMMO</artifactId>
+			<version>1.4.00-dev4</version>
 			<scope>provided</scope>
 		</dependency>
         <dependency>

--- a/src/main/java/net/aufdemrand/denizen/tags/core/PlayerTags.java
+++ b/src/main/java/net/aufdemrand/denizen/tags/core/PlayerTags.java
@@ -15,6 +15,9 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.inventory.ItemStack;
 
+import com.gmail.nossr50.datatypes.PlayerProfile;
+import com.gmail.nossr50.skills.utilities.SkillType;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -290,6 +293,26 @@ public class PlayerTags implements Listener {
                         event.setReplaced(Depends.economy.currencyNamePlural());
             } else {
                 dB.echoError("No economy loaded! Have you installed Vault and a compatible economy plugin?");
+            }
+
+        // Basic functionality for checking player's mcMMO skill levels
+        // Seemed safest to add them as a separate player tag than in XP
+        // Possible improvements: More precise specifiers, total mcMMO levels, ability info
+        } else if (type.equals("MMO")) {
+            if(Depends.mmo != null) {
+            	if (subType.equals("LEVEL")) {
+            	    PlayerProfile profile = Depends.mmo.getPlayerProfile(p.getName());
+            	    if(profile != null) {
+            	    	SkillType skill = aH.getSkillTypeFrom(subTypeContext);
+            		    if(skill != null)
+            		        event.setReplaced(String.valueOf(profile.getSkillLevel(skill)));
+            		} else {
+                        dB.echoError("Could not find " + p.getName() + "'s mcMMO data!");
+            	    }
+     
+                }
+            } else {
+                dB.echoError("McMMO not loaded! Have you installed the mcMMO plugin?");
             }
 
         } else if (type.equals("IS_OP")) {

--- a/src/main/java/net/aufdemrand/denizen/utilities/Depends.java
+++ b/src/main/java/net/aufdemrand/denizen/utilities/Depends.java
@@ -10,11 +10,13 @@ import net.milkbowl.vault.permission.Permission;
 
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
+import com.gmail.nossr50.mcMMO;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 
 public class Depends {
 
 	public static WorldGuardPlugin worldGuard = null;
+	public static mcMMO mmo = null;
 	public static Citizens citizens = null;
 	
     public static Economy economy = null;
@@ -28,6 +30,7 @@ public class Depends {
         setupPermissions();
         setupChat();
         setupWorldGuard();
+        setupMMO();
         setupCitizens();
         setupProtocolManager();
     }
@@ -81,6 +84,14 @@ public class Depends {
         }
     	worldGuard = (WorldGuardPlugin) Bukkit.getServer().getPluginManager().getPlugin("WorldGuard");
     	return worldGuard != null;
+    }
+    
+    private boolean setupMMO() {
+        if (Bukkit.getServer().getPluginManager().getPlugin("mcMMO") == null) {
+            return false;
+        }
+    	mmo = (mcMMO) Bukkit.getServer().getPluginManager().getPlugin("mcMMO");
+    	return mmo != null;
     }
 	
     private boolean setupCitizens() {

--- a/src/main/java/net/aufdemrand/denizen/utilities/arguments/aH.java
+++ b/src/main/java/net/aufdemrand/denizen/utilities/arguments/aH.java
@@ -14,6 +14,8 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
+import com.gmail.nossr50.skills.utilities.SkillType;
+
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -605,6 +607,28 @@ public class aH {
             dB.echoError("Unable to build a duration with this information! Provided: '" + arg + "'.");
         return duration;
     }
+    
+    /**
+     * <p>Returns an mcMMO SkillType.
+     *
+     * <p>Accounts for the format <tt>Skill:Name</tt>.</p>
+     *
+     * <p>Provides a line of dB output if returning null.</p>
+     *
+     * @param arg the argument to check
+     * @return a SkillType or null
+     *
+     */
+    public static SkillType getSkillTypeFrom(String arg) {
+        if (arg == null) return null;
+        SkillType skill = null;
+        try {
+            skill = SkillType.valueOf(arg);
+        } catch(IllegalArgumentException e) {
+            dB.echoError("Invalid skill! Failed to find a matching mcMMO SkillType.");
+        }
+        return skill;
+    }
 
     /**
      * <p>Used to determine if a dScript argument string is a valid double format. Uses
@@ -915,7 +939,6 @@ public class aH {
                     "Perhaps a replaceable Tag has failed to fill in a valid value?");
         return false;
     }
-
 
     final private static Pattern regex = Pattern.compile("[^\\s\"']+|\"([^\"]*)\"|'([^']*)'");
 


### PR DESCRIPTION
Might be a few accidental tabs here and there, and could possibly benefit from being expanded upon a bit, but at the moment it accurately handles the tag:

<player.mmo.level[skill_name]>

And debugs for errors in formatting, lack of mcMMO, and incorrect skill names.
