### PR TITLE
Workaround for interruptions

### DIFF
--- a/src/main/java/net/aufdemrand/denizen/scripts/triggers/core/ChatTrigger.java
+++ b/src/main/java/net/aufdemrand/denizen/scripts/triggers/core/ChatTrigger.java
@@ -202,11 +202,11 @@ public class ChatTrigger extends AbstractTrigger implements Listener {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        
+
         if (wasInterrupted) {
             Thread.currentThread().interrupt();
         }
-        
+
         if (cancelled == null)
             return;
         event.setCancelled(cancelled);


### PR DESCRIPTION
Basically check it before we start and restore it when we're done.
