### PR TITLE
Soundless exp changing for the "experience" command

### DIFF
--- a/src/main/java/net/aufdemrand/denizen/scripts/commands/player/ExperienceCommand.java
+++ b/src/main/java/net/aufdemrand/denizen/scripts/commands/player/ExperienceCommand.java
@@ -26,12 +26,20 @@ public class ExperienceCommand extends AbstractCommand {
     public static void setLevel(Player player, int level){player.setTotalExperience(0);player.setLevel(0);player.setExp(0);if (level > 0)player.giveExp(getExpToLevel(level));}
     public static void giveExperience(Player player, int exp){final int currentExp = getTotalExperience(player);player.setTotalExperience(0);player.setLevel(0);player.setExp(0);final int newexp = currentExp + exp;if (newexp > 0)player.giveExp(newexp);}
 
+    /* Tail recursive way to count the level for the given exp, maybe better with iteration */
+    public static int countLevel(int exp, int toLevel, int level){if (exp < toLevel){return level;} else {return countLevel(exp - toLevel, getTotalExpToLevel(level+2) - getTotalExpToLevel(level+1), ++level);}}
+    /* Setting the new level and exp using the setExp and setLevel methods, should be soundless (not yet tested) */
+    public static void setSoundlessTotalExperience(Player player, int exp) {player.setTotalExperience(0);player.setLevel(0);player.setExp(0); if (exp > 0) {final int level = countLevel(exp, 17, 0);player.setLevel(level); player.setExp((getTotalExpToLevel(level)-exp)/getExpToLevel(level+1));}}
+    /* Adding experience using the setExp and setLevel methods, should be soundless (not tested) */
+    public static void giveSoundlessExperience(Player player, int exp){final int currentExp = getTotalExperience(player);player.setTotalExperience(0);player.setLevel(0);player.setExp(0);final int newexp = currentExp + exp;if (newexp > 0){final int level = countLevel(currentExp + exp, 17, 0);player.setLevel(level); player.setExp((getTotalExpToLevel(level)-exp)/getExpToLevel(level+1));}}
+
     @Override
     public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
 
         int amount = 0;
         Type type = Type.SET;
         boolean level = false;
+        boolean soundless = false;
 
         for (String arg : scriptEntry.getArguments()) {
 
@@ -44,13 +52,17 @@ public class ExperienceCommand extends AbstractCommand {
 
             else if(aH.matchesArg("LEVEL", arg))
                 level = true;
+            
+            else if(aH.matchesArg("SOUNDLESS", arg))
+                soundless = true;
 
             else throw new InvalidArgumentsException("Unknown argument '" + arg + "'");
         }
 
         scriptEntry.addObject("quantity", amount)
                 .addObject("type", type)
-                .addObject("level", level);
+                .addObject("level", level)
+                .addObject("soundless", soundless);
 
     }
 
@@ -61,6 +73,7 @@ public class ExperienceCommand extends AbstractCommand {
         Type type = (Type) scriptEntry.getObject("type");
         Integer quantity = (Integer) scriptEntry.getObject("quantity");
         Boolean level = (Boolean) scriptEntry.getObject("level");
+        Boolean sound = !((Boolean) scriptEntry.getObject("soundless"));
 
         dB.report(scriptEntry, name, aH.debugObj("Type", type.toString())
             + aH.debugObj("Quantity", level ? quantity.toString() + " levels" : quantity.toString())
@@ -72,22 +85,28 @@ public class ExperienceCommand extends AbstractCommand {
             case SET:
                 if(level)
                     setLevel(player, quantity);
-                else
+                else if ( sound )
                     setTotalExperience(player, quantity);
+                else
+                    setSoundlessTotalExperience(player, quantity);
                 break;
 
             case GIVE:
                 if(level)
                     setLevel(player, player.getLevel() + quantity);
-                else
+                else if ( sound )
                     giveExperience(player, quantity);
+                else
+                	giveSoundlessExperience(player, quantity);
                 break;
 
             case TAKE:
                 if(level)
                     setLevel(player, player.getLevel() - quantity);
-                else
+                else if ( sound )
                     giveExperience(player, -quantity);
+                else
+                	giveSoundlessExperience(player, -quantity);
                 break;
         }
 


### PR DESCRIPTION
This is an really small "feature" allowing to change soundless the experience of a player not using the "giveExp" method, that probably always triggers a sound event, as if you collect exp.

I've only tested it in the main(String[] args) environment, not InGame
