### PR TITLE
Add (traits:<trait>|...) to Create command for NPCs.

### DIFF
--- a/src/main/java/net/aufdemrand/denizen/scripts/commands/CommandRegistry.java
+++ b/src/main/java/net/aufdemrand/denizen/scripts/commands/CommandRegistry.java
@@ -562,7 +562,7 @@ public class CommandRegistry implements dRegistry {
 
         // <--[command]
         // @Name Create
-        // @Syntax create [<entity>] [<name>] (<location>)
+        // @Syntax create [<entity>] [<name>] (<location>) (traits:<trait>|...)
         // @Required 1
         // @Stable experimental
         // @Short Creates a new NPC, and optionally spawns it at a location.

--- a/src/main/java/net/aufdemrand/denizen/scripts/commands/npc/CreateCommand.java
+++ b/src/main/java/net/aufdemrand/denizen/scripts/commands/npc/CreateCommand.java
@@ -9,6 +9,8 @@ import net.aufdemrand.denizen.utilities.debugging.dB;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.event.DespawnReason;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.trait.Trait;
+
 import org.bukkit.Location;
 
 /**
@@ -32,12 +34,17 @@ public class CreateCommand extends AbstractCommand {
                 scriptEntry.addObject("entity_type", ent);
             }
 
-            else if (!scriptEntry.hasObject("spawn_location") &&
-                    arg.matchesArgumentType(dLocation.class))
+            else if (!scriptEntry.hasObject("spawn_location")
+                    && arg.matchesArgumentType(dLocation.class))
                 scriptEntry.addObject("spawn_location", arg.asType(dLocation.class));
 
             else if (!scriptEntry.hasObject("name"))
                 scriptEntry.addObject("name", arg.asElement());
+            
+            else if (!scriptEntry.hasObject("traits")
+                    && arg.matches("t, trait, traits")
+                    && arg.matchesArgumentType(dList.class))
+                scriptEntry.addObject("traits", arg.asType(dList.class));
 
             else arg.reportUnhandled();
         }
@@ -50,8 +57,10 @@ public class CreateCommand extends AbstractCommand {
         Element name = (Element) scriptEntry.getObject("name");
         dEntity type = (dEntity) scriptEntry.getObject("entity_type");
         dLocation loc = (dLocation) scriptEntry.getObject("spawn_location");
+        dList traits = (dList) scriptEntry.getObject("traits");
 
-        dB.report(scriptEntry, getName(), name.debug() + type.debug() + (loc != null ? loc.debug() : ""));
+        dB.report(scriptEntry, getName(), name.debug() + type.debug() + (loc != null ? loc.debug() : "") 
+                + (traits != null ? traits.debug() : ""));
 
         // Add the created NPC into the script entry so it can be utilized if need be.
         scriptEntry.addObject("created_npc", dNPC.mirrorCitizensNPC(CitizensAPI.getNPCRegistry()
@@ -59,6 +68,15 @@ public class CreateCommand extends AbstractCommand {
 
         if (loc != null)
             ((dNPC) scriptEntry.getObject("created_npc")).getCitizen().spawn(loc);
+        if (traits != null) {
+            for (String trait_name : traits) {
+                Trait trait = CitizensAPI.getTraitFactory().getTrait(trait_name);
+                if (trait != null)
+                    ((dNPC) scriptEntry.getObject("created_npc")).getCitizen().addTrait(trait);
+                else
+                    dB.echoError("Could not add trait to NPC: " + trait_name);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
This is pretty simple... it just adds the ability to create NPCs with Traits.

For example, `- create skeleton Skelly traits:sneaking|sentry`
