### PR TITLE
Make custom items work as ingredients in custom recipes, also small tag-fix to <l@location.inventory>

### DIFF
--- a/src/main/java/net/aufdemrand/denizen/objects/dLocation.java
+++ b/src/main/java/net/aufdemrand/denizen/objects/dLocation.java
@@ -277,8 +277,9 @@ public class dLocation extends org.bukkit.Location implements dObject {
 
     public dInventory getInventory() {
         BlockState block = getBlock().getState();
-        if (block instanceof InventoryHolder)
+        if (block instanceof InventoryHolder) {
             return new dInventory((InventoryHolder) block);
+        }
         else return null;
     }
 
@@ -394,7 +395,7 @@ public class dLocation extends org.bukkit.Location implements dObject {
         // block is not a container, returns null.
         // -->
         if (attribute.startsWith("inventory")) {
-            return getInventory().getAttribute(attribute);
+            return getInventory().getAttribute(attribute.fulfill(1));
         }
 
         // <--[tag]

--- a/src/main/java/net/aufdemrand/denizen/objects/dMaterial.java
+++ b/src/main/java/net/aufdemrand/denizen/objects/dMaterial.java
@@ -335,11 +335,41 @@ public class dMaterial implements dObject {
      *
      */
     public static boolean matches(String arg) {
-        if (arg.toUpperCase().matches("(?:m@)?RANDOM"))
+
+        if (arg.toUpperCase().matches("(?:M@)?RANDOM"))
             return true;
 
         Matcher m = materialPattern.matcher(arg);
-        return m.matches();
+
+        if (m.matches()) {
+
+            // If this argument is in an integer, return true if it does not
+            // exceed the number of materials in Bukkit
+            if (aH.matchesInteger(m.group(1))) {
+                if (aH.getIntegerFrom(arg) < Material.values().length)
+                    return true;
+            }
+
+            // Check if this argument matches a Material or a special stored
+            // dMaterial's name
+            else {
+                // Iterate through Materials
+                for (Material material : Material.values()) {
+                    if (material.name().equalsIgnoreCase(m.group(1))) {
+                        return true;
+                    }
+                }
+
+                // Iterate through dMaterials
+                for (dMaterials material : dMaterials.values()) {
+                    if (material.name().equalsIgnoreCase(m.group(1))) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
In my very first contribution to denizen i want to add a solution for making custom items from itemscripts work as ingredients for other itemscript recipes.
I therefore made the dMaterial.matches function more strict to only accept valid materials, and I used it to check recipe contents.

Recipes like

```
- i@Brownstick|i@Dice|air
- white_wool|stick|white_wool
- i@Beerbottle|stone|i@Yellowstick
```

are possible now.

I also saw a small typo in the &lt;l@location.inventory&gt; tag after I saw issue 523, should be fixed now.
