### PR TITLE
Add display_name mechanism

### DIFF
--- a/src/main/java/net/aufdemrand/denizen/objects/dPlayer.java
+++ b/src/main/java/net/aufdemrand/denizen/objects/dPlayer.java
@@ -1345,7 +1345,22 @@ public class dPlayer implements dObject, Adjustable {
             getPlayerEntity().setPlayerListName(value.asString());
             return;
         }
-
+        
+        // <--[mechanism]
+        // @object dPlayer
+        // @name display_name
+        // @input Element
+        // @description
+        // Sets the name displayed for the player when chatting. Can be overridden 
+        // by plugins like Essentials if they are not configured correctly
+        // @tags
+        // <player.name.display>
+        // -->
+        if (mechanism.matches("display_name")) {
+            getPlayerEntity().setDisplayName(value.asString());
+            return;
+        }
+        
         // <--[mechanism]
         // @object dPlayer
         // @name time


### PR DESCRIPTION
Sets the name displayed for the player when chatting. Can be overridden
by plugins like Essentials if they are not configured correctly
