### PR TITLE
Fixes broken pose command.

### DIFF
--- a/src/main/java/net/aufdemrand/denizen/scripts/commands/npc/PoseCommand.java
+++ b/src/main/java/net/aufdemrand/denizen/scripts/commands/npc/PoseCommand.java
@@ -56,7 +56,7 @@ public class PoseCommand extends AbstractCommand {
             throw new InvalidArgumentsException("This command requires an NPC!");
 
         // It also requires a pose ID
-        if (!scriptEntry.hasObject("id"))
+        if (!scriptEntry.hasObject("pose_id"))
                 throw new InvalidArgumentsException("No ID specified!");
 
         // Set default objects


### PR DESCRIPTION
The scriptEntry object name that is registered does not match what is checked, so the exception is always thrown. The rest of the references seem fine. Fixes it on my server.
