### PR TITLE
Make apple_enchanted not usuable on 1.13+

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/Denizen.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/Denizen.java
@@ -870,7 +870,9 @@ public class Denizen extends JavaPlugin implements DenizenImplementation {
             PropertyParser.registerProperty(InventoryTitle.class, dInventory.class);
 
             // register core dItem properties
-            PropertyParser.registerProperty(ItemApple.class, dItem.class);
+            if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_12_R1)) {
+                PropertyParser.registerProperty(ItemApple.class, dItem.class);
+            }
             PropertyParser.registerProperty(ItemBaseColor.class, dItem.class);
             PropertyParser.registerProperty(ItemBook.class, dItem.class);
             PropertyParser.registerProperty(ItemDisplayname.class, dItem.class);


### PR DESCRIPTION
The `golden_apple` item is split into `golden_apple` and `enchanted_golden_apple` on 1.13. This tag/mec does nothing to the `golden_apple` item.