### PR TITLE
fix remove_enchaments 

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/objects/properties/item/ItemEnchantments.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/objects/properties/item/ItemEnchantments.java
@@ -216,7 +216,9 @@ public class ItemEnchantments implements Property {
             }
             else {
                 for (Enchantment ench : item.getItemStack().getEnchantments().keySet()) {
-                    item.getItemStack().removeEnchantment(ench);
+                    if (names == null || names.contains(CoreUtilities.toLowerCase(ench.getName()))) {
+                        item.getItemStack().removeEnchantment(ench);
+                    }
                 }
             }
         }


### PR DESCRIPTION
You supposedly can - adjust <i@item> remove_enchantments:a|b to remove only certain enchantments from an item. However, the mechanism only checks for values in books, hence other items have all their enchantments removed. This adds the if check on non-book items.
