### PR TITLE
Various meta improvements

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/events/entity/EntityHealsScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/entity/EntityHealsScriptEvent.java
@@ -31,8 +31,7 @@ public class EntityHealsScriptEvent extends BukkitScriptEvent implements Listene
     // @Context
     // <context.amount> returns the amount the entity healed.
     // <context.entity> returns the dEntity that healed.
-    // <context.reason> returns the cause of the entity healing. Can be: REGEN, SATIATED, EATING, ENDER_CRYSTAL,
-    // MAGIC, MAGIC_REGEN, WITHER_SPAWN, WITHER, CUSTOM
+    // <context.reason> returns the cause of the entity healing. Can be: <@link url http://bit.ly/2GTtxsf>
     //
     // @Determine
     // Element(Decimal) to set the amount of health the entity receives.

--- a/plugin/src/main/java/net/aufdemrand/denizen/objects/dEntity.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/objects/dEntity.java
@@ -2191,6 +2191,7 @@ public class dEntity implements dObject, Adjustable, EntityFormObject {
         // @group attributes
         // @description
         // Returns the maximum duration of the last damage taken by the entity.
+        // -->
         if (attribute.startsWith("last_damage.max_duration")) {
             return new Duration((long) getLivingEntity().getMaximumNoDamageTicks())
                     .getAttribute(attribute.fulfill(2));
@@ -2471,9 +2472,7 @@ public class dEntity implements dObject, Adjustable, EntityFormObject {
         // @group properties
         // @description
         // Returns the phase an EnderDragon is currently in.
-        // Valid phases: CIRCLING, STRAFING, FLY_TO_PORTAL, LAND_ON_PORTAL, LEAVE_PORTAL,
-        // BREATH_ATTACK, SEARCH_FOR_BREATH_ATTACK_TARGET, ROAR_BEFORE_ATTACK,
-        // CHARGE_PLAYER, DYING, HOVER.
+        // Valid phases: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EnderDragon.Phase.html>
         // -->
         if (attribute.startsWith("dragon_phase") && getBukkitEntity() instanceof EnderDragon) {
             return new Element(((EnderDragon) getLivingEntity()).getPhase().name())

--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -1871,6 +1871,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         // <e@entity.last_damage.amount>
         // <e@entity.last_damage.cause>
         // <e@entity.last_damage.duration>
+        // <e@entity.last_damage.max_duration>
         //
         // @Usage
         // Use to hurt the player for 1 HP.
@@ -2722,7 +2723,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         // For a list of all sounds, check https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Sound.html
         //
         // @Tags
-        // None
+        // <server.list_sounds>
         //
         // @Usage
         // Use to play a sound for a player

--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/containers/core/BukkitWorldScriptHelper.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/containers/core/BukkitWorldScriptHelper.java
@@ -211,7 +211,7 @@ public class BukkitWorldScriptHelper implements Listener {
     // <context.item> returns the dItem the player has clicked on.
     // <context.inventory> returns the dInventory.
     // <context.cursor_item> returns the item the Player is clicking with.
-    // <context.click> returns an Element with the name of the click type.
+    // <context.click> returns an Element with the name of the click type. Click type list: <@link url http://bit.ly/2IjY198>
     // <context.slot_type> returns an Element with the name of the slot type that was clicked.
     // <context.slot> returns an Element with the number of the slot that was clicked.
     // <context.raw_slot> returns an Element with the raw number of the slot that was clicked.


### PR DESCRIPTION
- Use more Spigot JavaDocs enum links
- Fix meta for `<e@entity.last_damage.max_duration>`
- Add `<server.list_sounds>` to related tags for `- playsound` command