### PR TITLE
Add command_block_location/command_minecart contexts to custom commands

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/events/core/CommandSmartEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/core/CommandSmartEvent.java
@@ -2,6 +2,7 @@ package net.aufdemrand.denizen.events.core;
 
 import net.aufdemrand.denizen.objects.dCuboid;
 import net.aufdemrand.denizen.objects.dEntity;
+import net.aufdemrand.denizen.objects.dLocation;
 import net.aufdemrand.denizen.objects.dWorld;
 import net.aufdemrand.denizen.scripts.containers.core.BukkitWorldScriptHelper;
 import net.aufdemrand.denizen.utilities.DenizenAPI;
@@ -12,6 +13,9 @@ import net.aufdemrand.denizencore.objects.aH;
 import net.aufdemrand.denizencore.objects.dList;
 import net.aufdemrand.denizencore.objects.dObject;
 import net.aufdemrand.denizencore.utilities.CoreUtilities;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
@@ -109,13 +113,15 @@ public class CommandSmartEvent implements OldSmartEvent, Listener {
     //
     // @Regex ^on( [^\s]+)? command( in ((notable (cuboid|ellipsoid))|([^\s]+)))?$
     //
-    // @Triggers when a player or console runs a Bukkit command. This happens before
+    // @Triggers when a player, console, or command block/minecart runs a Bukkit command. This happens before
     // any code of established commands allowing scripters to 'override' existing commands.
     // @Context
     // <context.command> returns the command name as an Element.
     // <context.raw_args> returns any args used as an Element.
     // <context.args> returns a dList of the arguments.
     // <context.server> returns true if the command was run from the console.
+    // <context.command_block_location> returns the command block's location (if the command was run from one).
+    // <context.command_minecart> returns the dEntity of the command minecart (if the command was run from one).
     // <context.cuboids> DEPRECATED.
     //
     // @Determine
@@ -201,6 +207,14 @@ public class CommandSmartEvent implements OldSmartEvent, Listener {
         context.put("command", new Element(command));
         context.put("raw_args", new Element((message.split(" ").length > 1 ? event.getCommand().split(" ", 2)[1] : "")));
         context.put("server", Element.TRUE);
+
+        CommandSender sender = event.getSender();
+        if (sender instanceof BlockCommandSender) {
+            context.put("command_block_location", new dLocation(((BlockCommandSender) sender).getBlock().getLocation()));
+        }
+        else if (sender instanceof CommandMinecart) {
+            context.put("command_minecart", new dEntity((CommandMinecart) sender));
+        }
 
         String determination = BukkitWorldScriptHelper.doEvents(events, null, null, context);
 

--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/containers/core/CommandScriptContainer.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/containers/core/CommandScriptContainer.java
@@ -100,6 +100,8 @@ public class CommandScriptContainer extends ScriptContainer {
     //   # <context.raw_args> returns all the arguments as raw text.
     //   # <context.server> returns whether the server is running the command (a player if false).
     //   # <context.alias> returns the command alias being used.
+    //   # <context.command_block_location> returns the command block's location (if the command was run from one).
+    //   # <context.command_minecart> returns the dEntity of the command minecart (if the command was run from one).
     //   script:
     //   - if !<player.is_op||<context.server>> {
     //     - narrate "<red>You do not have permission for that command."

--- a/plugin/src/main/java/net/aufdemrand/denizen/utilities/DenizenCommand.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/utilities/DenizenCommand.java
@@ -1,6 +1,7 @@
 package net.aufdemrand.denizen.utilities;
 
 import net.aufdemrand.denizen.objects.dEntity;
+import net.aufdemrand.denizen.objects.dLocation;
 import net.aufdemrand.denizen.objects.dNPC;
 import net.aufdemrand.denizen.objects.dPlayer;
 import net.aufdemrand.denizen.scripts.containers.core.CommandScriptContainer;
@@ -11,9 +12,11 @@ import net.aufdemrand.denizencore.tags.TagManager;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.ChatColor;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.CommandMinecart;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -131,6 +134,12 @@ public class DenizenCommand extends Command {
         }
         else {
             context.put("server", Element.TRUE);
+            if (commandSender instanceof BlockCommandSender) {
+                context.put("command_block_location", new dLocation(((BlockCommandSender) commandSender).getBlock().getLocation()));
+            }
+            else if (commandSender instanceof CommandMinecart) {
+                context.put("command_minecart", new dEntity((CommandMinecart) commandSender));
+            }
         }
         if (Depends.citizens != null && npc == null) {
             NPC citizen = CitizensAPI.getDefaultNPCSelector().getSelected(commandSender);


### PR DESCRIPTION
This allows you to do some interesting things with command blocks, such as disabling them without a restart or auto-filling minecraft tags such as `@p, @e, @r, ...` by using the command event/command script containers. Tested & working.