### PR TITLE
Add Paper tag base and tick_times tag

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.paper;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.paper.events.*;
 import com.denizenscript.denizen.paper.properties.EntityCanTick;
+import com.denizenscript.denizen.paper.tags.PaperTagBase;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
@@ -11,6 +12,7 @@ public class PaperModule {
 
     public static void init() {
         Debug.log("Loading Paper support module...");
+
         // Events
         ScriptEvent.registerScriptEvent(new EntityKnocksbackEntityScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerEquipsArmorScriptEvent());
@@ -19,7 +21,11 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(new PlayerStopsSpectatingScriptEvent());
         ScriptEvent.registerScriptEvent(new ProjectileCollideScriptEvent());
         ScriptEvent.registerScriptEvent(new TNTPrimesScriptEvent());
+
         // Properties
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);
+
+        // Paper Tags
+        new PaperTagBase();
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperTagBase.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperTagBase.java
@@ -29,8 +29,9 @@ public class PaperTagBase {
         // <--[tag]
         // @attribute <paper.tick_times>
         // @returns ListTag(DurationTag)
+        // @Plugin Paper
         // @description
-        // Returns a sample of the server's last 5s of tick times (in milliseconds).
+        // Returns a sample of the server's last 5s of tick times as a list of durations.
         // On average, a tick should take 50ms or less for a stable 20tps.
         // -->
         if (attribute.startsWith("tick_times")) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperTagBase.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperTagBase.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.paper.tags;
 
+import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.tags.TagRunnable;
 import com.denizenscript.denizencore.tags.Attribute;
@@ -27,7 +28,7 @@ public class PaperTagBase {
 
         // <--[tag]
         // @attribute <paper.tick_times>
-        // @returns ListTag
+        // @returns ListTag(DurationTag)
         // @description
         // Returns a sample of the server's last 5s of tick times (in milliseconds).
         // On average, a tick should take 50ms or less for a stable 20tps.
@@ -35,7 +36,7 @@ public class PaperTagBase {
         if (attribute.startsWith("tick_times")) {
             ListTag list = new ListTag();
             for (long time : Bukkit.getServer().getTickTimes()) {
-                list.add(String.valueOf(time / 1000000D));
+                list.addObject(new DurationTag(time / 1000000000D));
             }
             event.setReplacedObject(list.getObjectAttribute(attribute.fulfill(1)));
             return;

--- a/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperTagBase.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperTagBase.java
@@ -1,0 +1,44 @@
+package com.denizenscript.denizen.paper.tags;
+
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.tags.TagRunnable;
+import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ReplaceableTagEvent;
+import com.denizenscript.denizencore.tags.TagManager;
+import org.bukkit.Bukkit;
+
+public class PaperTagBase {
+
+    public PaperTagBase() {
+        TagManager.registerTagHandler(new TagRunnable.RootForm() {
+            @Override
+            public void run(ReplaceableTagEvent event) {
+                paperTag(event);
+            }
+        }, "paper");
+    }
+
+    public void paperTag(ReplaceableTagEvent event) {
+        if (!event.matches("paper") || event.replaced()) {
+            return;
+        }
+
+        Attribute attribute = event.getAttributes().fulfill(1);
+
+        // <--[tag]
+        // @attribute <paper.tick_times>
+        // @returns ListTag
+        // @description
+        // Returns a sample of the server's last 5s of tick times (in milliseconds).
+        // On average, a tick should take 50ms or less for a stable 20tps.
+        // -->
+        if (attribute.startsWith("tick_times")) {
+            ListTag list = new ListTag();
+            for (long time : Bukkit.getServer().getTickTimes()) {
+                list.add(String.valueOf(time / 1000000D));
+            }
+            event.setReplacedObject(list.getObjectAttribute(attribute.fulfill(1)));
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Paper recently added api to get the number of nanoseconds per tick, and added an `/mspt` command to view them in-game. This exposes more of that info to scripters.

```
> ex narrate <paper.tick_times.get[1].to[5]>
[03:19:32 INFO]: Executing Denizen script command...
[03:19:32 INFO]:  Starting InstantQueue 'EXCOMMAND_DisposalProgramIsaac'...
[03:19:32 INFO]: +- Queue 'EXCOMMAND_DisposalProgramIsaac' Executing: (line 1) NARRATE <paper.tick_times.get[1].to[5]> ---------+
[03:19:32 INFO]:  Filled tag <paper.tick_times.get[1].to[5]> with 'li@ 27.632 | 27.9509 | 27.6278 | 34.5609 | 32.2328'.
[03:19:32 INFO]: +> Executing 'NARRATE': Narrating='li@27.632|27.9509|27.6278|34.5609|32.2328'  Targets='null'
[03:19:32 INFO]: li@27.632|27.9509|27.6278|34.5609|32.2328
[03:19:32 INFO]:  Completing queue 'EXCOMMAND_DisposalProgramIsaac' in 0ms.
```