### PR TITLE
Add server.current_tick tag

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -13,6 +13,7 @@ import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
+import com.denizenscript.denizencore.events.core.TickScriptEvent;
 import com.denizenscript.denizencore.objects.*;
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.utilities.Settings;
@@ -1056,6 +1057,18 @@ public class ServerTagBase {
         // -->
         if (attribute.startsWith("available_processors")) {
             event.setReplacedObject(new ElementTag(Runtime.getRuntime().availableProcessors())
+                    .getObjectAttribute(attribute.fulfill(1)));
+        }
+
+        // <--[tag]
+        // @attribute <server.current_tick>
+        // @returns ElementTag(Number)
+        // @description
+        // Returns the number of ticks since the server was started.
+        // Note that this is NOT an indicator for server uptime, as ticks fluctuate based on server lag.
+        // -->
+        if (attribute.startsWith("current_tick")) {
+            event.setReplacedObject(new ElementTag(TickScriptEvent.instance.ticks)
                     .getObjectAttribute(attribute.fulfill(1)));
         }
 


### PR DESCRIPTION
Simply exposes the tick context in the `on tick` event to all scripts, since using that event is a very quick way to overload your server. My specific use case is getting the exact number of ticks between certain events firing in a way that isn't influenced by lag.

Testing:
```
> ex narrate <server.current_tick>
[21:06:48 INFO]: Executing Denizen script command...
[21:06:48 INFO]:  Starting InstantQueue 'EXCOMMAND_NecessaryYeaLicense'...
[21:06:48 INFO]: +- Queue 'EXCOMMAND_NecessaryYeaLicense' Executing: (line 1) NARRATE <server.current_tick> ---------+
[21:06:48 INFO]:  Filled tag <server.current_tick> with '780'.
[21:06:48 INFO]: +> Executing 'NARRATE': Narrating='780'  Targets='null'
[21:06:48 INFO]: 780
```

