### PR TITLE
Added visibility to pre-load mechanism list

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -73,7 +73,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject {
 
     // List a mechanism here if it can be safely run before spawn.
     public static HashSet<String> earlyValidMechanisms = new HashSet<>(Arrays.asList(
-            "max_health", "health_data", "health"
+            "max_health", "health_data", "health", "visible"
     ));
 
     private static final Map<UUID, Entity> rememberedEntities = new HashMap<>();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -73,7 +73,9 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject {
 
     // List a mechanism here if it can be safely run before spawn.
     public static HashSet<String> earlyValidMechanisms = new HashSet<>(Arrays.asList(
-            "max_health", "health_data", "health", "visible"
+            "max_health", "health_data", "health", "visible",
+            "armor_pose", "arms", "base_plate", "is_small",
+            "velocity", "age", "is_using_riptide"
     ));
 
     private static final Map<UUID, Entity> rememberedEntities = new HashMap<>();


### PR DESCRIPTION
Fixes the tick when an armor_stand is visible before applying the mechanism in a script.