### PR TITLE
turtle_egg_materialdata

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -723,6 +723,21 @@ public class MaterialTag implements ObjectTag, Adjustable {
         });
 
         // <--[tag]
+        // @attribute <MaterialTag.is_egg>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is a turtle egg.
+        // When this returns true, <@link tag MaterialTag.egg_count>,
+        // <@link tag MaterialTag.egg_max>, <@link tag MaterialTag.egg_min>,
+        // <@link tag MaterialTag.egg_stage>, and
+        // <@link tag MaterialTag.egg_stage_max> are accessible.
+        // -->
+        registerTag("is_egg", (attribute, object) -> {
+            return new ElementTag(MaterialTurtleEggCount.describes(object));
+        });
+
+        // <--[tag]
         // @attribute <MaterialTag.is_flammable>
         // @returns ElementTag(Boolean)
         // @description

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -163,6 +163,8 @@ public class PropertyRegistry {
             PropertyParser.registerProperty(MaterialSnowable.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialSwitchable.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialSwitchFace.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialTurtleEggCount.class, MaterialTag.class);
+            PropertyParser.registerProperty(MaterialTurtleEggStage.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialWaterlogged.class, MaterialTag.class);
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialTurtleEggCount.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialTurtleEggCount.java
@@ -1,0 +1,124 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.block.data.type.TurtleEgg;
+
+public class MaterialTurtleEggCount implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof TurtleEgg;
+    }
+
+    public static MaterialTurtleEggCount getFrom(ObjectTag _material) {
+        if (!describes(_material)) {
+            return null;
+        }
+        else {
+            return new MaterialTurtleEggCount((MaterialTag) _material);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "egg_count"
+    };
+
+    private MaterialTurtleEggCount(MaterialTag _material) {
+        material = _material;
+    }
+
+    MaterialTag material;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <MaterialTag.egg_count>
+        // @returns ElementTag(Number)
+        // @mechanism MaterialTag.egg_count
+        // @group properties
+        // @description
+        // Returns the amount of eggs in a turtle egg material.
+        // -->
+        PropertyParser.<MaterialTurtleEggCount>registerTag("egg_count", (attribute, material) -> {
+            return new ElementTag(material.getCurrent());
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.egg_max>
+        // @returns ElementTag(Number)
+        // @group properties
+        // @description
+        // Returns the maximum amount of eggs allowed in a turtle egg material.
+        // -->
+        PropertyParser.<MaterialTurtleEggCount>registerTag("egg_max", (attribute, material) -> {
+            return new ElementTag(material.getMax());
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.egg_min>
+        // @returns ElementTag(Number)
+        // @group properties
+        // @description
+        // Returns the minimum amount of eggs allowed in a turtle egg material.
+        // -->
+        PropertyParser.<MaterialTurtleEggCount>registerTag("egg_min", (attribute, material) -> {
+            return new ElementTag(material.getMin());
+        });
+
+    }
+
+    public TurtleEgg getTurtleEgg() {
+        return (TurtleEgg) material.getModernData().data;
+    }
+
+    public int getCurrent() {
+        return getTurtleEgg().getEggs();
+    }
+
+    public int getMax() {
+        return getTurtleEgg().getMaximumEggs();
+    }
+
+    public int getMin() {
+        return getTurtleEgg().getMinimumEggs();
+    }
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(getCurrent());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "egg_count";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name egg_count
+        // @input ElementTag(Number)
+        // @description
+        // Sets the amount of eggs in a turtle egg material.
+        // @tags
+        // <MaterialTag.egg_count>
+        // -->
+        if (mechanism.matches("egg_count") && mechanism.requireInteger()) {
+            int count = mechanism.getValue().asInt();
+            if (count < getMin() || count > getMax()) {
+                Debug.echoError("Egg count value '" + count + "' is not valid. Must be between " + getMin() + " and " + getMax() + ".");
+                return;
+            }
+            getTurtleEgg().setEggs(count);
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialTurtleEggStage.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialTurtleEggStage.java
@@ -1,0 +1,112 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.block.data.type.TurtleEgg;
+
+public class MaterialTurtleEggStage implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof TurtleEgg;
+    }
+
+    public static MaterialTurtleEggStage getFrom(ObjectTag _material) {
+        if (!describes(_material)) {
+            return null;
+        }
+        else {
+            return new MaterialTurtleEggStage((MaterialTag) _material);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "egg_stage"
+    };
+
+    private MaterialTurtleEggStage(MaterialTag _material) {
+        material = _material;
+    }
+
+    MaterialTag material;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <MaterialTag.egg_stage_max>
+        // @returns ElementTag(Number)
+        // @group properties
+        // @description
+        // Returns the maximum allowed hatching stage for a turtle egg material.
+        // -->
+        PropertyParser.<MaterialTurtleEggStage>registerTag("egg_stage_max", (attribute, material) -> {
+            return new ElementTag(material.getHatchMax());
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.egg_stage>
+        // @returns ElementTag(Number)
+        // @group properties
+        // @description
+        // Returns the egg hatching stage for a turtle egg material.
+        // -->
+        PropertyParser.<MaterialTurtleEggStage>registerTag("egg_stage", (attribute, material) -> {
+            return new ElementTag(material.getHatch());
+        });
+
+    }
+
+    public TurtleEgg getTurtleEgg() {
+        return (TurtleEgg) material.getModernData().data;
+    }
+
+    public int getCurrent() {
+        return getTurtleEgg().getEggs();
+    }
+
+    public int getHatchMax() {
+        return getTurtleEgg().getMaximumHatch();
+    }
+
+    public int getHatch() {
+        return getTurtleEgg().getHatch();
+    }
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(getCurrent());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "egg_stage";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name egg_stage
+        // @input ElementTag(Number)
+        // @description
+        // Sets the egg hatching stage for a turtle egg material.
+        // @tags
+        // <MaterialTag.egg_stage>
+        // -->
+        if (mechanism.matches("egg_stage") && mechanism.requireInteger()) {
+            int count = mechanism.getValue().asInt();
+            if (count < 0 || count > getHatchMax()) {
+                Debug.echoError("Egg hatch stage value '" + count + "' is not valid. Must be between 0 and " + getHatchMax() + ".");
+                return;
+            }
+            getTurtleEgg().setHatch(count);
+        }
+    }
+}


### PR DESCRIPTION
Adds two mechanisms and five tags.

One notable notice I had was that Spigot's TurtleEgg interface defines the 'hatch' methods for the egg material as:
`'hatch' is the number of turtles which may hatch from these eggs.`
This is incorrect as it's actually the hatching stage of the egg. Verified by watching the eggs hatch; A sea turtle egg nest containing four eggs with the hatching stage of `2` hatches four turtles.