### PR TITLE
Code cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialLevel.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialLevel.java
@@ -51,7 +51,7 @@ public class MaterialLevel implements Property {
         // @returns ElementTag(Number)
         // @group properties
         // @description
-        // Returns the maximum level for a Levelled material (like water, lava, and cauldrons), cake, beehives, and snow.
+        // Returns the maximum level for a Levelled material (like water, lava, cauldrons, cake, beehives, and snow).
         // -->
         PropertyParser.<MaterialLevel>registerTag("maximum_level", (attribute, material) -> {
             return new ElementTag(material.getMax());

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/GroupCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/GroupCommand.java
@@ -53,7 +53,7 @@ public class GroupCommand extends AbstractCommand {
     //
     // @Usage
     // Use to set a player to the Member group in the Creative world.
-    // - group set Member w@Creative
+    // - group set Member <world[Creative]>
     // -->
 
     private enum Action {ADD, REMOVE, SET}

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/GameRuleCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/GameRuleCommand.java
@@ -33,11 +33,11 @@ public class GameRuleCommand extends AbstractCommand {
     //
     // @Usage
     // Use to disable fire spreading in world "Adventure".
-    // - gamerule w@Adventure doFireTick false
+    // - gamerule <world[Adventure]> doFireTick false
     //
     // @Usage
     // Use to avoid mobs from destroying blocks (creepers, endermen...) and picking items up (zombies, skeletons...) in world "Adventure".
-    // - gamerule w@Adventure mobGriefing false
+    // - gamerule <world[Adventure]> mobGriefing false
     // -->
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/LightCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/LightCommand.java
@@ -43,11 +43,11 @@ public class LightCommand extends AbstractCommand {
     //
     // @Usage
     // Use to create a bright light at a noted location.
-    // - light l@MyFancyLightOfWool 15
+    // - light MyFancyLightOfWool 15
     //
     // @Usage
     // Use to reset the brightness of the location to its original state.
-    // - light l@MyFancyLightOfWool reset
+    // - light MyFancyLightOfWool reset
     // -->
 
     @Override


### PR DESCRIPTION
Just removes three uses of raw object notation and suggested a change in the MaterialTag.level tag's formatting for the list.