### PR TITLE
Implement per-world ticking/non-ticking view distance

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -1,8 +1,10 @@
 package com.denizenscript.denizen.paper;
 
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizen.paper.events.*;
 import com.denizenscript.denizen.paper.properties.EntityCanTick;
+import com.denizenscript.denizen.paper.properties.WorldViewDistance;
 import com.denizenscript.denizen.paper.tags.PaperTagBase;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import com.denizenscript.denizencore.events.ScriptEvent;
@@ -25,6 +27,7 @@ public class PaperModule {
 
         // Properties
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);
+        PropertyParser.registerProperty(WorldViewDistance.class, WorldTag.class);
 
         // Paper Tags
         new PaperTagBase();

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/WorldViewDistance.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/WorldViewDistance.java
@@ -1,0 +1,127 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.WorldTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+
+public class WorldViewDistance implements Property {
+
+    public static boolean describes(ObjectTag world) {
+        return world instanceof WorldTag;
+    }
+
+    public static WorldViewDistance getFrom(ObjectTag world) {
+        if (!describes(world)) {
+            return null;
+        }
+        return new WorldViewDistance((WorldTag) world);
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "view_distance", "no_tick_view_distance"
+    };
+
+    private WorldViewDistance(WorldTag world) {
+        this.world = world;
+    }
+
+    WorldTag world;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return null;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <WorldTag.view_distance>
+        // @returns ElementTag(Number)
+        // @mechanism WorldTag.view_distance
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns the view distance of this world. Chunks are tracked inside this radius.
+        // -->
+        PropertyParser.<WorldViewDistance>registerTag("view_distance", (attribute, world) -> {
+            return new ElementTag(world.world.getWorld().getViewDistance());
+        });
+
+        // <--[tag]
+        // @attribute <WorldTag.no_tick_view_distance>
+        // @returns ElementTag(Number)
+        // @mechanism WorldTag.no_tick_view_distance
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns the non-ticking view distance of this world. Chunks will not be tracked between the world's view distance and its non-ticking view distance.
+        // This allows your world to have a higher visual view distance without impacting performance.
+        // -->
+        PropertyParser.<WorldViewDistance>registerTag("no_tick_view_distance", (attribute, world) -> {
+            return new ElementTag(world.world.getWorld().getNoTickViewDistance());
+        });
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object WorldTag
+        // @name view_distance
+        // @input ElementTag(Number)
+        // @Plugin Paper
+        // @description
+        // Sets this world's view distance. All chunks within this radius will be tracked by the server.
+        // Input should be a number from 2 to 32. To allow for a larger untracked radius, use <@link mechanism WorldTag.no_tick_view_distance>
+        // @tags
+        // <WorldTag.view_distance>
+        // <server.view_distance>
+        // -->
+        if (mechanism.matches("view_distance") && mechanism.requireInteger()) {
+            int distance = mechanism.getValue().asInt();
+            if (distance < 2 || distance > 32) {
+                Debug.echoError("View distance must be a number from 2 to 32!");
+            }
+            else {
+                world.getWorld().setViewDistance(distance);
+            }
+        }
+
+        // <--[mechanism]
+        // @object WorldTag
+        // @name no_tick_view_distance
+        // @input ElementTag(Number)
+        // @Plugin Paper
+        // @description
+        // Sets this world's non-ticking view distance. Chunks will not be tracked between the world's view distance and its non-ticking view distance.
+        // This allows your world to have a higher visual view distance without impacting performance.
+        // Input should be a number from 2 to 32. Provide no input to reset this to the world's view distance.
+        // NOTE: This should generally be set to a value higher than the world's view distance. Setting it lower may cause odd chunk issues.
+        // @tags
+        // <WorldTag.no_tick_view_distance>
+        // -->
+        if (mechanism.matches("no_tick_view_distance")) {
+            if (!mechanism.hasValue()) {
+                world.getWorld().setNoTickViewDistance(-1);
+            }
+            else if (mechanism.requireInteger()) {
+                int distance = mechanism.getValue().asInt();
+                if (distance < 2 || distance > 32) {
+                    Debug.echoError("View distance must be a number from 2 to 32!");
+                }
+                else {
+                    world.getWorld().setNoTickViewDistance(distance);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Demo video: https://streamable.com/feslnu

Implements paper's latest no-tick view distance addition in the form of new world mecs/tags, letting you set it per-world on the fly.

Servers with an already-restricted view distance should set the no-tick distance higher on world initialization.

Servers that are lucky enough to have a high view distance should consider making that their new no-tick view distance and decreasing the normal view distance for easy performance gainz. Depending on the type of server, you can drop the ticking view distance down to the minimum 2/3 chunks with very little noticeable impact from a player perspective.

Tested & left some notes in the tags so people don't have to experiment like I did.