### PR TITLE
Mega PR, now split into commits

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -27,13 +27,15 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(new PlayerClicksFakeEntityScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerEquipsArmorScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerJumpsPaperScriptEventImpl());
-        ScriptEvent.registerScriptEvent(new PlayerSpectatesEntityScriptEvent());
-        ScriptEvent.registerScriptEvent(new PlayerStopsSpectatingScriptEvent());
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {
+            ScriptEvent.registerScriptEvent(new PlayerSpectatesEntityScriptEvent());
+            ScriptEvent.registerScriptEvent(new PlayerStopsSpectatingScriptEvent());
             ScriptEvent.registerScriptEvent(new PreEntitySpawnScriptEvent());
         }
         ScriptEvent.registerScriptEvent(new ProjectileCollideScriptEvent());
-        ScriptEvent.registerScriptEvent(new TNTPrimesScriptEvent());
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {
+            ScriptEvent.registerScriptEvent(new TNTPrimesScriptEvent());
+        }
         ScriptEvent.registerScriptEvent(new UnknownCommandScriptEvent());
 
         // Properties

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -17,6 +17,7 @@ public class PaperModule {
 
         // Events
         ScriptEvent.registerScriptEvent(new EntityKnocksbackEntityScriptEvent());
+        ScriptEvent.registerScriptEvent(new EntityPathfindScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerBeaconEffectScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerEquipsArmorScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerJumpsPaperScriptEventImpl());

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -24,6 +24,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(new ExperienceOrbMergeScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerAbsorbsExperienceScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerBeaconEffectScriptEvent());
+        ScriptEvent.registerScriptEvent(new PlayerClicksFakeEntityScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerEquipsArmorScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerJumpsPaperScriptEventImpl());
         ScriptEvent.registerScriptEvent(new PlayerSpectatesEntityScriptEvent());

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizen.paper.events.*;
 import com.denizenscript.denizen.paper.properties.EntityCanTick;
+import com.denizenscript.denizen.paper.properties.EntityExperienceOrb;
 import com.denizenscript.denizen.paper.properties.WorldViewDistance;
 import com.denizenscript.denizen.paper.tags.PaperTagBase;
 import com.denizenscript.denizen.utilities.debugging.Debug;
@@ -19,6 +20,8 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(new EntityKnocksbackEntityScriptEvent());
         ScriptEvent.registerScriptEvent(new EntityPathfindScriptEvent());
         ScriptEvent.registerScriptEvent(new EntityShootsBowPaperScriptEventImpl());
+        ScriptEvent.registerScriptEvent(new ExperienceOrbMergeScriptEvent());
+        ScriptEvent.registerScriptEvent(new PlayerAbsorbsExperienceScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerBeaconEffectScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerEquipsArmorScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerJumpsPaperScriptEventImpl());
@@ -29,6 +32,7 @@ public class PaperModule {
 
         // Properties
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityExperienceOrb.class, EntityTag.class);
         PropertyParser.registerProperty(WorldViewDistance.class, WorldTag.class);
 
         // Paper Tags

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -1,11 +1,12 @@
 package com.denizenscript.denizen.paper;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizen.paper.events.*;
-import com.denizenscript.denizen.paper.properties.EntityCanTick;
-import com.denizenscript.denizen.paper.properties.EntityExperienceOrb;
-import com.denizenscript.denizen.paper.properties.WorldViewDistance;
+import com.denizenscript.denizen.paper.properties.*;
 import com.denizenscript.denizen.paper.tags.PaperTagBase;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import com.denizenscript.denizencore.events.ScriptEvent;
@@ -27,13 +28,19 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(new PlayerJumpsPaperScriptEventImpl());
         ScriptEvent.registerScriptEvent(new PlayerSpectatesEntityScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerStopsSpectatingScriptEvent());
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {
+            ScriptEvent.registerScriptEvent(new PreEntitySpawnScriptEvent());
+        }
         ScriptEvent.registerScriptEvent(new ProjectileCollideScriptEvent());
         ScriptEvent.registerScriptEvent(new TNTPrimesScriptEvent());
 
         // Properties
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExperienceOrb.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityFromSpawner.class, EntityTag.class);
+        PropertyParser.registerProperty(EntitySpawnLocation.class, EntityTag.class);
         PropertyParser.registerProperty(WorldViewDistance.class, WorldTag.class);
+        PropertyParser.registerProperty(PlayerAffectsMonsterSpawning.class, PlayerTag.class);
 
         // Paper Tags
         new PaperTagBase();

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -18,6 +18,7 @@ public class PaperModule {
         // Events
         ScriptEvent.registerScriptEvent(new EntityKnocksbackEntityScriptEvent());
         ScriptEvent.registerScriptEvent(new EntityPathfindScriptEvent());
+        ScriptEvent.registerScriptEvent(new EntityShootsBowPaperScriptEventImpl());
         ScriptEvent.registerScriptEvent(new PlayerBeaconEffectScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerEquipsArmorScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerJumpsPaperScriptEventImpl());

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -33,6 +33,7 @@ public class PaperModule {
         }
         ScriptEvent.registerScriptEvent(new ProjectileCollideScriptEvent());
         ScriptEvent.registerScriptEvent(new TNTPrimesScriptEvent());
+        ScriptEvent.registerScriptEvent(new UnknownCommandScriptEvent());
 
         // Properties
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityPathfindScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityPathfindScriptEvent.java
@@ -1,0 +1,116 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.destroystokyo.paper.event.entity.EntityPathfindEvent;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class EntityPathfindScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // entity pathfinds
+    // <entity> pathfinds
+    //
+    // @Regex ^on [^\s]+ pathfinds$
+    //
+    // @Switch in:<area> to only process the event if it occurred within a specified area.
+    // @Switch to:<area> to only process the event if the entity is pathfinding into a specified area.
+    // @Switch at:<entity> to only process the event when the entity is pathfinding at a specified entity.
+    //
+    // @Plugin Paper
+    //
+    // @Cancellable true
+    //
+    // @Triggers when an entity starts pathfinding towards a location or entity.
+    //
+    // @Context
+    // <context.entity> returns the EntityTag that is pathfinding.
+    // <context.location> returns the LocationTag that is being pathfound to.
+    // <context.target> returns the EntityTag that is being targeted, if any.
+    //
+    // @Player when the target entity is a player.
+    //
+    // @NPC when the target entity is an NPC.
+    //
+    // -->
+
+    public EntityPathfindScriptEvent() {
+        instance = this;
+    }
+
+    public static EntityPathfindScriptEvent instance;
+
+    public EntityTag entity;
+    public EntityTag target;
+    public EntityPathfindEvent event;
+
+    @Override
+    public boolean couldMatch(ScriptPath path) {
+        return path.eventArgLowerAt(1).equals("pathfinds");
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!tryEntity(entity, path.eventArgLowerAt(0))) {
+            return false;
+        }
+        if (!runInCheck(path, entity.getLocation())) {
+            return false;
+        }
+        if (!runInCheck(path, event.getLoc(), "to")) {
+            return false;
+        }
+        String at = path.switches.get("at");
+        if (at != null && !tryEntity(target, at)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "EntityPathfinds";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(
+                target != null && target.isPlayer() ? target.getDenizenPlayer() : null,
+                target != null && target.isCitizensNPC() ? target.getDenizenNPC() : null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("entity")) {
+            return entity.getDenizenObject();
+        }
+        else if (name.equals("target") && target != null) {
+            return target.getDenizenObject();
+        }
+        else if (name.equals("location")) {
+            return new LocationTag(event.getLoc());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onEntityPathfind(EntityPathfindEvent event) {
+        this.event = event;
+        Entity entity = event.getEntity();
+        Entity target = event.getTargetEntity();
+        this.entity = new EntityTag(entity);
+        this.target = target != null ? new EntityTag(target) : null;
+        EntityTag.rememberEntity(entity);
+        EntityTag.rememberEntity(target);
+        fire(event);
+        EntityTag.forgetEntity(entity);
+        EntityTag.forgetEntity(target);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityPathfindScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityPathfindScriptEvent.java
@@ -103,14 +103,9 @@ public class EntityPathfindScriptEvent extends BukkitScriptEvent implements List
     @EventHandler
     public void onEntityPathfind(EntityPathfindEvent event) {
         this.event = event;
-        Entity entity = event.getEntity();
+        this.entity = new EntityTag(event.getEntity());
         Entity target = event.getTargetEntity();
-        this.entity = new EntityTag(entity);
         this.target = target != null ? new EntityTag(target) : null;
-        EntityTag.rememberEntity(entity);
-        EntityTag.rememberEntity(target);
         fire(event);
-        EntityTag.forgetEntity(entity);
-        EntityTag.forgetEntity(target);
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityShootsBowPaperScriptEventImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityShootsBowPaperScriptEventImpl.java
@@ -1,0 +1,48 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.entity.EntityShootsBowEvent;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.DenizenAPI;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class EntityShootsBowPaperScriptEventImpl extends EntityShootsBowEvent {
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        if (determinationObj instanceof ElementTag && !isDefaultDetermination(determinationObj)) {
+            String determination = determinationObj.toString();
+            String lower = CoreUtilities.toLowerCase(determination);
+            if (lower.equals("keep_item")) {
+                event.setConsumeArrow(false);
+                return true;
+            }
+        }
+        return super.applyDetermination(path, determinationObj);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("item")) {
+            return new ItemTag(event.getArrowItem());
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public void fire() {
+        super.fire();
+        if (!event.getConsumeArrow() && entity.isPlayer()) {
+            final Player p = entity.getPlayer();
+            Bukkit.getScheduler().scheduleSyncDelayedTask(DenizenAPI.getCurrentInstance(), new Runnable() {
+                @Override
+                public void run() {
+                    p.updateInventory();
+                }
+            }, 1);
+        }
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityShootsBowPaperScriptEventImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityShootsBowPaperScriptEventImpl.java
@@ -18,6 +18,15 @@ public class EntityShootsBowPaperScriptEventImpl extends EntityShootsBowEvent {
             String lower = CoreUtilities.toLowerCase(determination);
             if (lower.equals("keep_item")) {
                 event.setConsumeArrow(false);
+                if (entity.isPlayer()) {
+                    final Player p = entity.getPlayer();
+                    Bukkit.getScheduler().scheduleSyncDelayedTask(DenizenAPI.getCurrentInstance(), new Runnable() {
+                        @Override
+                        public void run() {
+                            p.updateInventory();
+                        }
+                    }, 1);
+                }
                 return true;
             }
         }
@@ -30,19 +39,5 @@ public class EntityShootsBowPaperScriptEventImpl extends EntityShootsBowEvent {
             return new ItemTag(event.getArrowItem());
         }
         return super.getContext(name);
-    }
-
-    @Override
-    public void fire() {
-        super.fire();
-        if (!event.getConsumeArrow() && entity.isPlayer()) {
-            final Player p = entity.getPlayer();
-            Bukkit.getScheduler().scheduleSyncDelayedTask(DenizenAPI.getCurrentInstance(), new Runnable() {
-                @Override
-                public void run() {
-                    p.updateInventory();
-                }
-            }, 1);
-        }
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ExperienceOrbMergeScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ExperienceOrbMergeScriptEvent.java
@@ -1,0 +1,87 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.destroystokyo.paper.event.entity.ExperienceOrbMergeEvent;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ExperienceOrbMergeScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // experience orbs merge
+    //
+    // @Regex ^on experience orbs merge$
+    //
+    // @Switch in:<area> to only process the event if it occurred within a specified area.
+    //
+    // @Plugin Paper
+    //
+    // @Cancellable true
+    //
+    // @Triggers when two experience orbs are about to merge.
+    //
+    // @Context
+    // <context.target> returns the EntityTag of the orb that will absorb the other experience orb.
+    // <context.source> returns the EntityTag of the orb that will be removed and merged into the target.
+    //
+    // -->
+
+    public ExperienceOrbMergeScriptEvent() {
+        instance = this;
+    }
+
+    public static ExperienceOrbMergeScriptEvent instance;
+    public ExperienceOrbMergeEvent event;
+
+    @Override
+    public boolean couldMatch(ScriptPath path) {
+        return path.eventLower.startsWith("experience orbs merge");
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, event.getMergeTarget().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "ExperienceOrbsMerge";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(null, null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("target")) {
+            return new EntityTag(event.getMergeTarget());
+        }
+        else if (name.equals("source")) {
+            return new EntityTag(event.getMergeSource());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void experienceOrbsMerge(ExperienceOrbMergeEvent event) {
+        Entity target = event.getMergeTarget();
+        Entity source = event.getMergeSource();
+        EntityTag.rememberEntity(target);
+        EntityTag.rememberEntity(source);
+        this.event = event;
+        fire(event);
+        EntityTag.forgetEntity(target);
+        EntityTag.forgetEntity(source);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ExperienceOrbMergeScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ExperienceOrbMergeScriptEvent.java
@@ -75,13 +75,10 @@ public class ExperienceOrbMergeScriptEvent extends BukkitScriptEvent implements 
 
     @EventHandler
     public void experienceOrbsMerge(ExperienceOrbMergeEvent event) {
-        Entity target = event.getMergeTarget();
-        Entity source = event.getMergeSource();
-        EntityTag.rememberEntity(target);
-        EntityTag.rememberEntity(source);
         this.event = event;
+        Entity target = event.getMergeTarget();
+        EntityTag.rememberEntity(target);
         fire(event);
         EntityTag.forgetEntity(target);
-        EntityTag.forgetEntity(source);
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerAbsorbsExperienceScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerAbsorbsExperienceScriptEvent.java
@@ -1,0 +1,84 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.destroystokyo.paper.event.player.PlayerPickupExperienceEvent;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerAbsorbsExperienceScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player absorbs experience
+    //
+    // @Regex ^on player absorbs experience$
+    //
+    // @Switch in:<area> to only process the event if it occurred within a specified area.
+    //
+    // @Plugin Paper
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a player is absorbing an experience orb.
+    //
+    // @Context
+    // <context.entity> returns the EntityTag of the experience orb.
+    //
+    // @Player Always.
+    //
+    // -->
+
+    public PlayerAbsorbsExperienceScriptEvent() {
+        instance = this;
+    }
+
+    public static PlayerAbsorbsExperienceScriptEvent instance;
+    public PlayerPickupExperienceEvent event;
+
+    @Override
+    public boolean couldMatch(ScriptEvent.ScriptPath path) {
+        return path.eventLower.startsWith("player absorbs experience");
+    }
+
+    @Override
+    public boolean matches(ScriptEvent.ScriptPath path) {
+        if (!runInCheck(path, event.getPlayer().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "PlayerAbsorbsExperience";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(new PlayerTag(event.getPlayer()), null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("entity")) {
+            return new EntityTag(event.getExperienceOrb());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void absorbsExperience(PlayerPickupExperienceEvent event) {
+        this.event = event;
+        Entity entity = event.getExperienceOrb();
+        EntityTag.rememberEntity(entity);
+        fire(event);
+        EntityTag.forgetEntity(entity);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerAbsorbsExperienceScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerAbsorbsExperienceScriptEvent.java
@@ -8,7 +8,6 @@ import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import com.destroystokyo.paper.event.player.PlayerPickupExperienceEvent;
-import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -76,9 +75,6 @@ public class PlayerAbsorbsExperienceScriptEvent extends BukkitScriptEvent implem
     @EventHandler
     public void absorbsExperience(PlayerPickupExperienceEvent event) {
         this.event = event;
-        Entity entity = event.getExperienceOrb();
-        EntityTag.rememberEntity(entity);
         fire(event);
-        EntityTag.forgetEntity(entity);
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerClicksFakeEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerClicksFakeEntityScriptEvent.java
@@ -29,6 +29,7 @@ public class PlayerClicksFakeEntityScriptEvent extends BukkitScriptEvent impleme
     //
     // @Context
     // <context.entity> returns the EntityTag of the entity that was clicked. Note that this entity is not being tracked by the server, so many operations may not be possible on it.
+    // This will return null if the player clicks a fake entity that was not spawned via <@link command fakespawn>.
     // <context.hand> returns an ElementTag of the hand used to click.
     // <context.click_type> returns an ElementTag of the click type (left/right).
     //

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerClicksFakeEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerClicksFakeEntityScriptEvent.java
@@ -1,0 +1,99 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.entity.FakeEntity;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerClicksFakeEntityScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player clicks fake entity
+    // player (right/left) clicks fake entity
+    //
+    // @Regex ^on player ([^\s]+ )?clicks fake entity$
+    //
+    // @Switch in:<area> to only process the event if it occurred within a specified area.
+    //
+    // @Plugin Paper
+    //
+    // @Triggers when a player clicks a fake entity, one that is only shown to the player and not tracked by the server.
+    //
+    // @Context
+    // <context.entity> returns the EntityTag of the entity that was clicked. Note that this entity is not being tracked by the server, so many operations may not be possible on it.
+    // <context.hand> returns an ElementTag of the hand used to click.
+    // <context.click_type> returns an ElementTag of the click type (left/right).
+    //
+    // @Player Always.
+    //
+    // -->
+
+    public PlayerClicksFakeEntityScriptEvent() {
+        instance = this;
+    }
+
+    public static PlayerClicksFakeEntityScriptEvent instance;
+    public PlayerUseUnknownEntityEvent event;
+
+    @Override
+    public boolean couldMatch(ScriptEvent.ScriptPath path) {
+        return path.eventLower.startsWith("player clicks fake")
+                || path.eventLower.startsWith("player right clicks fake")
+                || path.eventLower.startsWith("player left clicks fake");
+    }
+
+    @Override
+    public boolean matches(ScriptEvent.ScriptPath path) {
+        if (path.eventArgLowerAt(1).equals("left") && !event.isAttack()) {
+            return false;
+        }
+        else if (path.eventArgLowerAt(1).equals("right") && event.isAttack()) {
+            return false;
+        }
+        if (!runInCheck(path, event.getPlayer().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "PlayerClicksFakeEntity";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(new PlayerTag(event.getPlayer()), null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("entity")) {
+            FakeEntity fakeEntity = FakeEntity.getFakeEntityFor(event.getPlayer().getUniqueId(), event.getEntityId());
+            if (fakeEntity != null) {
+                return fakeEntity.entity;
+            }
+        }
+        else if (name.equals("hand")) {
+            return new ElementTag(event.getHand().name());
+        }
+        else if (name.equals("click_type")) {
+            return new ElementTag(event.isAttack() ? "left" : "right");
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void clickFakeEntity(PlayerUseUnknownEntityEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PreEntitySpawnScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PreEntitySpawnScriptEvent.java
@@ -1,0 +1,112 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
+import com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PreEntitySpawnScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // entity prespawns
+    // entity prespawns (because <cause>)
+    // <entity> prespawns
+    // <entity> prespawns (because <cause>)
+    //
+    // @Regex ^on [^\s]+ prespawns( because [^\s]+)?$
+    //
+    // @Switch in:<area> to only process the event if it occurred within a specified area.
+    //
+    // @Cancellable true
+    //
+    // @Warning This event may fire very rapidly, and only fires for NATURAL and SPAWNER reasons.
+    //
+    // @Triggers before a mob spawns and before the mob is created for spawning. Note that this has a limited number of use cases.
+    // The intent of this event is to save server resources for blanket mob banning/limiting scripts. Use the entity spawn event as a backup.
+    //
+    // @Context
+    // <context.entity> returns the EntityTag that will be spawned. Note that this entity will not be spawned yet, so usage will be limited.
+    // <context.location> returns the LocationTag the entity will spawn at.
+    // <context.reason> returns an ElementTag of the reason for spawning. Currently, this event only fires for NATURAL and SPAWNER reasons.
+    // <context.spawner_location> returns the LocationTag of the spawner's location if this mob is spawning from a spawner.
+    //
+    // -->
+
+    public PreEntitySpawnScriptEvent() {
+        instance = this;
+    }
+
+    public static PreEntitySpawnScriptEvent instance;
+    public EntityTag entity;
+    public LocationTag location;
+    public PreCreatureSpawnEvent event;
+
+    @Override
+    public boolean couldMatch(ScriptPath path) {
+        return path.eventArgLowerAt(1).equals("prespawns");
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!tryEntity(entity, path.eventArgLowerAt(0))) {
+            return false;
+        }
+        if (path.eventArgLowerAt(2).equals("because")
+                && !path.eventArgLowerAt(3).equalsIgnoreCase(event.getReason().name())) {
+            return false;
+        }
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "PreEntitySpawn";
+    }
+
+    @Override
+    public void cancellationChanged() {
+        event.setShouldAbortSpawn(cancelled);
+        super.cancellationChanged();
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(null, null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("entity")) {
+            return entity;
+        }
+        else if (name.equals("location")) {
+            return location;
+        }
+        else if (name.equals("reason")) {
+            return new ElementTag(event.getReason().name());
+        }
+        else if (name.equals("spawner_location") && event instanceof PreSpawnerSpawnEvent) {
+            return new LocationTag(((PreSpawnerSpawnEvent) event).getSpawnerLocation());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onPreCreatureSpawn(PreCreatureSpawnEvent event) {
+        this.entity = new EntityTag(event.getType());
+        this.location = new LocationTag(event.getSpawnLocation());
+        this.event = event;
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/UnknownCommandScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/UnknownCommandScriptEvent.java
@@ -1,0 +1,144 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.denizencore.objects.ArgumentHelper;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.CommandMinecart;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.command.UnknownCommandEvent;
+
+import java.util.Arrays;
+
+public class UnknownCommandScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // command unknown
+    //
+    // @Regex ^on command unknown$
+    //
+    // @Plugin Paper
+    //
+    // @Cancellable true
+    //
+    // @Triggers when an unknown command is processed by the server.
+    //
+    // @Context
+    // <context.message> returns an ElementTag of the message to be shown to the command sender.
+    // <context.command> returns the command name as an Element.
+    // <context.raw_args> returns any args used as an Element.
+    // <context.args> returns a ListTag of the arguments.
+    // <context.source_type> returns the source of the command. Can be: PLAYER, SERVER, COMMAND_BLOCK, or COMMAND_MINECART.
+    // <context.command_block_location> returns the command block's location (if the command was run from one).
+    // <context.command_minecart> returns the EntityTag of the command minecart (if the command was run from one).
+    //
+    // @Determine
+    // ElementTag to change the message returned to the command sender.
+    // "NONE" to cancel the message.
+    //
+    // @Player when the command sender is a player.
+    //
+    // -->
+
+    public UnknownCommandScriptEvent() {
+        instance = this;
+    }
+
+    public static UnknownCommandScriptEvent instance;
+    public UnknownCommandEvent event;
+    public String command;
+    public String rawArgs;
+    public String sourceType;
+
+    @Override
+    public boolean couldMatch(ScriptEvent.ScriptPath path) {
+        return path.eventLower.startsWith("command unknown");
+    }
+
+    @Override
+    public String getName() {
+        return "CommandUnknown";
+    }
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        if (determinationObj instanceof ElementTag) {
+            String determination = determinationObj.toString();
+            if (CoreUtilities.toLowerCase(determination).equals("none")) {
+                event.setMessage(null);
+            }
+            else {
+                event.setMessage(determination);
+            }
+            return true;
+        }
+        return super.applyDetermination(path, determinationObj);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getSender() instanceof Player ? new PlayerTag((Player) event.getSender()) : null, null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("command")) {
+            return new ElementTag(command);
+        }
+        else if (name.equals("raw_args")) {
+            return new ElementTag(rawArgs);
+        }
+        else if (name.equals("args")) {
+            return new ListTag(Arrays.asList(ArgumentHelper.buildArgs(rawArgs)));
+        }
+        else if (name.equals("server")) {
+            return new ElementTag(sourceType.equals("server"));
+        }
+        else if (name.equals("source_type")) {
+            return new ElementTag(sourceType);
+        }
+        else if (name.equals("command_block_location") && sourceType.equals("command_block")) {
+            return new LocationTag(((BlockCommandSender) event.getSender()).getBlock().getLocation());
+        }
+        else if (name.equals("command_minecart") && sourceType.equals("command_minecart")) {
+            return new EntityTag((CommandMinecart) event.getSender());
+        }
+        else if (name.equals("message")) {
+            return new ElementTag(event.getMessage());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void unknownCommandEvent(UnknownCommandEvent event) {
+        this.event = event;
+        String[] splitCommand = event.getCommandLine().split(" ", 2);
+        this.command = splitCommand[0];
+        this.rawArgs = splitCommand.length > 1 ? splitCommand[1] : "";
+        if (event.getSender() instanceof Player) {
+            this.sourceType = "player";
+        }
+        else if (event.getSender() instanceof BlockCommandSender) {
+            this.sourceType = "command_block";
+        }
+        else if (event.getSender() instanceof CommandMinecart) {
+            this.sourceType = "command_minecart";
+        }
+        else {
+            this.sourceType = "server";
+        }
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityExperienceOrb.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityExperienceOrb.java
@@ -1,0 +1,104 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ExperienceOrb;
+
+import java.util.UUID;
+
+public class EntityExperienceOrb implements Property {
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof ExperienceOrb;
+    }
+
+    public static EntityExperienceOrb getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityExperienceOrb((EntityTag) entity);
+    }
+
+    private EntityExperienceOrb(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return null;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.xp_spawn_reason>
+        // @returns ElementTag
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // If the entity is an experience orb, returns its spawn reason.
+        // Valid spawn reasons can be found at <@link url https://papermc.io/javadocs/paper/org/bukkit/entity/ExperienceOrb.SpawnReason.html>
+        // -->
+        PropertyParser.<EntityExperienceOrb>registerTag("xp_spawn_reason", (attribute, entity) -> {
+            return new ElementTag(((ExperienceOrb) entity.entity.getBukkitEntity()).getSpawnReason().name());
+        });
+
+        // <--[tag]
+        // @attribute <EntityTag.xp_trigger>
+        // @returns EntityTag
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // If the entity is an experience orb, returns the entity that triggered it spawning (if any).
+        // For example, if a player killed an entity this would return the player.
+        // -->
+        PropertyParser.<EntityExperienceOrb>registerTag("xp_trigger", (attribute, entity) -> {
+            UUID uuid = ((ExperienceOrb) entity.entity.getBukkitEntity()).getTriggerEntityId();
+            if (uuid == null) {
+                return null;
+            }
+            Entity e = EntityTag.getEntityForID(uuid);
+            if (e == null) {
+                return null;
+            }
+            return new EntityTag(e);
+        });
+
+        // <--[tag]
+        // @attribute <EntityTag.xp_source>
+        // @returns EntityTag
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // If the entity is an experience orb, returns the entity that it was created from (if any).
+        // For example, if the xp orb was spawned from breeding this would return the baby.
+        // -->
+        PropertyParser.<EntityExperienceOrb>registerTag("xp_source", (attribute, entity) -> {
+            UUID uuid = ((ExperienceOrb) entity.entity.getBukkitEntity()).getSourceEntityId();
+            if (uuid == null) {
+                return null;
+            }
+            Entity e = EntityTag.getEntityForID(uuid);
+            if (e == null) {
+                return null;
+            }
+            return new EntityTag(e);
+        });
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFromSpawner.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFromSpawner.java
@@ -1,0 +1,56 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+
+public class EntityFromSpawner implements Property {
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag;
+    }
+
+    public static EntityFromSpawner getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityFromSpawner((EntityTag) entity);
+    }
+
+    private EntityFromSpawner(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return null;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.from_spawner>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns whether the entity was spawned from a spawner.
+        // -->
+        PropertyParser.<EntityFromSpawner>registerTag("from_spawner", (attribute, entity) -> {
+            return new ElementTag(entity.entity.getBukkitEntity().fromMobSpawner());
+        });
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySpawnLocation.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySpawnLocation.java
@@ -1,0 +1,59 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.Location;
+
+public class EntitySpawnLocation implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag;
+    }
+
+    public static EntitySpawnLocation getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntitySpawnLocation((EntityTag) entity);
+    }
+
+    private EntitySpawnLocation(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return null;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.spawn_location>
+        // @returns LocationTag
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns the initial spawn location of this entity.
+        // -->
+        PropertyParser.<EntitySpawnLocation>registerTag("spawn_location", (attribute, entity) -> {
+            Location loc = entity.entity.getBukkitEntity().getOrigin();
+            return loc != null ? new LocationTag(loc) : null;
+        });
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PlayerAffectsMonsterSpawning.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PlayerAffectsMonsterSpawning.java
@@ -1,0 +1,76 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+
+public class PlayerAffectsMonsterSpawning implements Property {
+    public static boolean describes(ObjectTag player) {
+        return player instanceof PlayerTag
+                && ((PlayerTag) player).isOnline();
+    }
+
+    public static PlayerAffectsMonsterSpawning getFrom(ObjectTag player) {
+        if (!describes(player)) {
+            return null;
+        }
+        return new PlayerAffectsMonsterSpawning((PlayerTag) player);
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "affects_monster_spawning"
+    };
+
+    private PlayerAffectsMonsterSpawning(PlayerTag player) {
+        this.player = player;
+    }
+
+    PlayerTag player;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return null;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <PlayerTag.affects_monster_spawning>
+        // @returns ElementTag(Boolean)
+        // @mechanism PlayerTag.affects_monster_spawning
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns whether the player affects monster spawning. When false, no monsters will spawn naturally because of this player.
+        // -->
+        PropertyParser.<PlayerAffectsMonsterSpawning>registerTag("affects_monster_spawning", (attribute, player) -> {
+            return new ElementTag(player.player.getPlayerEntity().getAffectsSpawning());
+        });
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name affects_monster_spawning
+        // @input ElementTag(Boolean)
+        // @Plugin Paper
+        // @description
+        // Sets whether this player affects monster spawning. When false, no monsters will spawn naturally because of this player.
+        // @tags
+        // <PlayerTag.affects_monster_spawning>
+        // -->
+        if (mechanism.matches("affects_monster_spawning") && mechanism.requireBoolean()) {
+            player.getPlayerEntity().setAffectsSpawning(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -82,7 +82,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(new EntityTamesScriptEvent());
         ScriptEvent.registerScriptEvent(new EntityTargetsScriptEvent());
         ScriptEvent.registerScriptEvent(new EntityTeleportScriptEvent());
-        ScriptEvent.registerScriptEvent(new EntityTransformScriptEvent());
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {
+            ScriptEvent.registerScriptEvent(new EntityTransformScriptEvent());
+        }
         ScriptEvent.registerScriptEvent(new EntityUnleashedScriptEvent());
         ScriptEvent.registerScriptEvent(new FireworkBurstsScriptEvent());
         ScriptEvent.registerScriptEvent(new HangingBreaksScriptEvent());

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -71,7 +71,9 @@ public class ScriptEventRegistry {
             ScriptEvent.registerScriptEvent(new EntityPotionEffectScriptEvent());
         }
         ScriptEvent.registerScriptEvent(new EntityResurrectScriptEvent());
-        ScriptEvent.registerScriptEvent(new EntityShootsBowEvent());
+        if (!Denizen.supportsPaper) {
+            ScriptEvent.registerScriptEvent(new EntityShootsBowEvent());
+        }
         ScriptEvent.registerScriptEvent(new EntitySpawnerSpawnScriptEvent());
         ScriptEvent.registerScriptEvent(new EntitySpawnScriptEvent());
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -145,6 +145,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(new PlayerLeashesEntityScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerLeavesBedScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerLevelsUpScriptEvent());
+        ScriptEvent.registerScriptEvent(new PlayerLocaleChangeScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerLoginScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerMendsItemScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerOpensInvScriptEvent());

--- a/plugin/src/main/java/com/denizenscript/denizen/events/core/CommandScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/core/CommandScriptEvent.java
@@ -68,7 +68,7 @@ public class CommandScriptEvent extends BukkitScriptEvent implements Listener {
 
     @Override
     public boolean couldMatch(ScriptPath path) {
-        return path.eventArgLowerAt(1).equals("command") || path.eventArgLowerAt(0).equals("command");
+        return path.eventArgLowerAt(1).equals("command") || (path.eventArgLowerAt(0).equals("command") && !path.eventArgLowerAt(1).equals("unknown"));
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityShootsBowEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityShootsBowEvent.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.events.entity;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.Conversion;
+import com.denizenscript.denizen.utilities.DenizenAPI;
 import com.denizenscript.denizen.utilities.entity.Position;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
@@ -10,7 +11,9 @@ import com.denizenscript.denizencore.objects.*;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityShootBowEvent;
@@ -39,9 +42,11 @@ public class EntityShootsBowEvent extends BukkitScriptEvent implements Listener 
     // <context.projectile> returns a EntityTag of the projectile.
     // <context.bow> returns the ItemTag of the bow used to shoot.
     // <context.force> returns the force of the shot.
+    // <context.item> returns an ItemTag of the shot projectile, if any (on Paper servers only).
     //
     // @Determine
     // ListTag(EntityTag) to change the projectile(s) being shot. (Note that in certain cases, determining an arrow may not be valid).
+    // "KEEP_ITEM" to keep the projectile item on shooting it (on Paper servers only).
     //
     // @Player when the entity that shot the bow is a player.
     //
@@ -143,6 +148,20 @@ public class EntityShootsBowEvent extends BukkitScriptEvent implements Listener 
             return projectile;
         }
         return super.getContext(name);
+    }
+
+    @Override
+    public void cancellationChanged() {
+        if (cancelled && entity.isPlayer()) {
+            final Player p = entity.getPlayer();
+            Bukkit.getScheduler().scheduleSyncDelayedTask(DenizenAPI.getCurrentInstance(), new Runnable() {
+                @Override
+                public void run() {
+                    p.updateInventory();
+                }
+            }, 1);
+        }
+        super.cancellationChanged();
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerClicksBlockScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerClicksBlockScriptEvent.java
@@ -119,13 +119,14 @@ public class PlayerClicksBlockScriptEvent extends BukkitScriptEvent implements L
         return true;
     }
 
-    private static final HashSet<String> matchHelpList = new HashSet<>(Arrays.asList("at", "entity", "npc", "player", "vehicle", "projectile", "hanging"));
+    private static final HashSet<String> matchHelpList = new HashSet<>(Arrays.asList("at", "entity", "npc", "player", "vehicle", "projectile", "hanging", "fake"));
 
     @Override
     public boolean couldMatch(ScriptPath path) {
-        return (path.eventLower.startsWith("player clicks")
-                || path.eventLower.startsWith("player left clicks")
-                || (path.eventLower.startsWith("player right clicks")
+        return ((path.eventLower.startsWith("player clicks")
+                && !path.eventArgLowerAt(2).equals("fake"))
+                || (path.eventLower.startsWith("player left clicks")
+                || path.eventLower.startsWith("player right clicks")
                 && !matchHelpList.contains(path.eventArgLowerAt(3))
                 && !EntityTag.matches(path.eventArgLowerAt(3))))
                 && couldMatchIn(path.eventLower);  // Avoid matching "clicks in inventory"

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerLocaleChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerLocaleChangeScriptEvent.java
@@ -1,0 +1,65 @@
+package com.denizenscript.denizen.events.player;
+
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerLocaleChangeEvent;
+
+public class PlayerLocaleChangeScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player locale change
+    //
+    // @Regex ^on player locale change$
+    //
+    // @Triggers when a player changes their locale in their client settings.
+    //
+    // @Context
+    // <context.new_locale> returns an ElementTag of the player's new locale.
+    //
+    // @Player Always.
+    //
+    // -->
+
+    public PlayerLocaleChangeScriptEvent() {
+        instance = this;
+    }
+
+    public static PlayerLocaleChangeScriptEvent instance;
+    public PlayerLocaleChangeEvent event;
+
+    @Override
+    public boolean couldMatch(ScriptPath path) {
+        return path.eventLower.startsWith("player locale change");
+    }
+
+    @Override
+    public String getName() {
+        return "PlayerLocaleChange";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(new PlayerTag(event.getPlayer()), null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("new_locale")) {
+            return new ElementTag(event.getLocale());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onPlayerLocaleChange(PlayerLocaleChangeEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRightClicksEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRightClicksEntityScriptEvent.java
@@ -48,7 +48,7 @@ public class PlayerRightClicksEntityScriptEvent extends BukkitScriptEvent implem
             return false;
         }
         String clickedEntity = path.eventArgLowerAt(3);
-        if (clickedEntity.equals("block") || (MaterialTag.matches(clickedEntity) && !EntityTag.matches(clickedEntity))) {
+        if (clickedEntity.equals("fake") || clickedEntity.equals("block") || (MaterialTag.matches(clickedEntity) && !EntityTag.matches(clickedEntity))) {
             return false;
         }
         return true;

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -1,14 +1,26 @@
 package com.denizenscript.denizen.nms.interfaces;
 
 import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
+import com.denizenscript.denizencore.objects.Mechanism;
 import org.bukkit.Chunk;
+import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
 import java.util.*;
 
 public abstract class PlayerHelper {
+
+    public Entity sendEntitySpawn(Player player, EntityType entityType, Location location, ArrayList<Mechanism> mechanisms) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void sendEntityDestroy(Player player, Entity entity) {
+        throw new UnsupportedOperationException();
+    }
 
     public abstract int getFlyKickCooldown(Player player);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -11,6 +11,7 @@ import com.denizenscript.denizen.utilities.blocks.FakeBlock;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizen.utilities.entity.BossBarHelper;
+import com.denizenscript.denizen.utilities.entity.FakeEntity;
 import com.denizenscript.denizen.utilities.packets.DenizenPacketHandler;
 import com.denizenscript.denizen.utilities.packets.ItemChangeMessage;
 import com.denizenscript.denizencore.objects.*;
@@ -2398,6 +2399,24 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject {
                 }
             }
             return null;
+        });
+
+        // <--[tag]
+        // @attribute <PlayerTag.fake_entities>
+        // @returns ListTag(EntityTag)
+        // @description
+        // Returns a list of fake entities the player can see, as set by <@link command fakespawn>.
+        // Note that these entities are not being tracked by the server, so many operations may not be possible on them.
+        // -->
+        registerTag("fake_entities", (attribute, object) -> {
+            ListTag list = new ListTag();
+            FakeEntity.FakeEntityMap map = FakeEntity.entityMap.get(object.getOfflinePlayer().getUniqueId());
+            if (map != null) {
+                for (Map.Entry<Integer, FakeEntity> entry : map.byId.entrySet()) {
+                    list.addObject(entry.getValue().entity);
+                }
+            }
+            return list;
         });
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -1581,6 +1581,16 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject {
             return new ElementTag(NMSHandler.getPlayerHelper().getPlayerBrand(object.getPlayerEntity()));
         });
 
+        // <--[tag]
+        // @attribute <PlayerTag.locale>
+        // @returns ElementTag
+        // @description
+        // Returns the current locale of the player.
+        // -->
+        registerOnlineOnlyTag("locale", (attribute, object) -> {
+            return new ElementTag(object.getPlayerEntity().getLocale());
+        });
+
         /////////////////////
         //   INVENTORY ATTRIBUTES
         /////////////////

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -109,7 +109,12 @@ public class EntityColor implements Property {
             return PandaHelper.getColor(colored);
         }
         else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14) && type == EntityType.ARROW) {
-            return new ColorTag(((Arrow) colored).getColor()).identify();
+            try {
+                return new ColorTag(((Arrow) colored.getBukkitEntity()).getColor()).identify();
+            }
+            catch (Exception e) {
+                return null;
+            }
         }
         else { // Should never happen
             return null;
@@ -247,7 +252,7 @@ public class EntityColor implements Property {
                 PandaHelper.setColor(colored, mechanism.getValue().asString());
             }
             else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14) && type == EntityType.ARROW) {
-                ((Arrow) colored).setColor(mechanism.valueAsType(ColorTag.class).getColor());
+                ((Arrow) colored.getBukkitEntity()).setColor(mechanism.valueAsType(ColorTag.class).getColor());
             }
             else { // Should never happen
                 Debug.echoError("Could not apply color '" + mechanism.getValue().toString() + "' to entity of type " + type.name() + ".");

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -123,6 +123,9 @@ public class BukkitCommandRegistry extends CommandRegistry {
         }
         registerCommand(CompassCommand.class);
         registerCommand(ExperienceCommand.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_15)) {
+            registerCommand(FakeSpawnCommand.class);
+        }
         registerCommand(GlowCommand.class);
         registerCommand(GroupCommand.class);
         registerCommand(ItemCooldownCommand.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/FakeSpawnCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/FakeSpawnCommand.java
@@ -13,7 +13,7 @@ import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class FakeSpawnCommand extends AbstractCommand {
@@ -45,6 +45,9 @@ public class FakeSpawnCommand extends AbstractCommand {
     // Optionally, specify how long the fake entity should remain for.
     // If unspecified, will default to 10 seconds.
     // After the duration is up, the entity will be removed from the player(s).
+    //
+    // @Tags
+    // <PlayerTag.fake_entities>
     //
     // @Usage
     // Use to show a fake creeper in front of the attached player.
@@ -79,9 +82,7 @@ public class FakeSpawnCommand extends AbstractCommand {
         }
 
         if (!scriptEntry.hasObject("players") && Utilities.entryHasPlayer(scriptEntry)) {
-            List<PlayerTag> players = new ArrayList<>();
-            players.add(Utilities.getEntryPlayer(scriptEntry));
-            scriptEntry.defaultObject("players", players);
+            scriptEntry.defaultObject("players", Arrays.asList(Utilities.getEntryPlayer(scriptEntry)));
         }
 
         if (!scriptEntry.hasObject("location")) {
@@ -102,8 +103,8 @@ public class FakeSpawnCommand extends AbstractCommand {
     @Override
     public void execute(ScriptEntry scriptEntry) {
 
-        EntityTag entity = (EntityTag) scriptEntry.getObject("entity");
-        LocationTag location = (LocationTag) scriptEntry.getObject("location");
+        EntityTag entity = scriptEntry.getObjectTag("entity");
+        LocationTag location = scriptEntry.getObjectTag("location");
         List<PlayerTag> players = (List<PlayerTag>) scriptEntry.getObject("players");
         DurationTag duration = scriptEntry.getObjectTag("duration");
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/FakeSpawnCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/FakeSpawnCommand.java
@@ -1,0 +1,117 @@
+package com.denizenscript.denizen.scripts.commands.player;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.entity.FakeEntity;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
+import com.denizenscript.denizencore.objects.*;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeSpawnCommand extends AbstractCommand {
+
+    public FakeSpawnCommand() {
+        setName("fakespawn");
+        setSyntax("fakespawn [<entity>] [<location>] (players:<player>|...) (d:<duration>{10s})");
+        setRequiredArguments(2, 4);
+    }
+
+    // <--[command]
+    // @Name FakeSpawn
+    // @Syntax fakespawn [<entity>] [<location>] (players:<player>|...) (d:<duration>{10s})
+    // @Required 2
+    // @Maximum 4
+    // @Short Makes the player see a fake entity spawn that didn't actually happen.
+    // @Group player
+    //
+    // @Description
+    // Makes the player see a fake entity spawn that didn't actually happen.
+    // This means that the server will not track the entity,
+    // and players not included in the command will not see the entity.
+    //
+    // You must specify a location and an entity to spawn.
+    //
+    // Optionally, specify a list of players to show the entity to.
+    // If unspecified, will default to the linked player.
+    //
+    // Optionally, specify how long the fake entity should remain for.
+    // If unspecified, will default to 10 seconds.
+    // After the duration is up, the entity will be removed from the player(s).
+    //
+    // @Usage
+    // Use to show a fake creeper in front of the attached player.
+    // - fakespawn creeper <player.forward[5]>
+    //
+    // -->
+
+    @Override
+    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
+
+        for (Argument arg : scriptEntry.getProcessedArgs()) {
+
+            if (!scriptEntry.hasObject("players")
+                    && arg.matchesPrefix("to", "players")) {
+                scriptEntry.addObject("players", arg.asType(ListTag.class).filter(PlayerTag.class, scriptEntry));
+            }
+            else if (arg.matchesPrefix("d", "duration")
+                    && arg.matchesArgumentType(DurationTag.class)) {
+                scriptEntry.addObject("duration", arg.asType(DurationTag.class));
+            }
+            else if (!scriptEntry.hasObject("entity")
+                    && arg.matchesArgumentType(EntityTag.class)) {
+                scriptEntry.addObject("entity", arg.asType(EntityTag.class));
+            }
+            else if (!scriptEntry.hasObject("location")
+                    && arg.matchesArgumentType(LocationTag.class)) {
+                scriptEntry.addObject("location", arg.asType(LocationTag.class));
+            }
+            else {
+                arg.reportUnhandled();
+            }
+        }
+
+        if (!scriptEntry.hasObject("players") && Utilities.entryHasPlayer(scriptEntry)) {
+            List<PlayerTag> players = new ArrayList<>();
+            players.add(Utilities.getEntryPlayer(scriptEntry));
+            scriptEntry.defaultObject("players", players);
+        }
+
+        if (!scriptEntry.hasObject("location")) {
+            throw new InvalidArgumentsException("Must specify a valid location!");
+        }
+
+        if (!scriptEntry.hasObject("players")) {
+            throw new InvalidArgumentsException("Must have a valid, online player attached!");
+        }
+
+        if (!scriptEntry.hasObject("entity")) {
+            throw new InvalidArgumentsException("Must specify a valid entity!");
+        }
+
+        scriptEntry.defaultObject("duration", new DurationTag(10));
+    }
+
+    @Override
+    public void execute(ScriptEntry scriptEntry) {
+
+        EntityTag entity = (EntityTag) scriptEntry.getObject("entity");
+        LocationTag location = (LocationTag) scriptEntry.getObject("location");
+        List<PlayerTag> players = (List<PlayerTag>) scriptEntry.getObject("players");
+        DurationTag duration = scriptEntry.getObjectTag("duration");
+
+        if (scriptEntry.dbCallShouldDebug()) {
+            Debug.report(scriptEntry, getName(), entity.debug() + location.debug() + duration.debug()
+                    + ArgumentHelper.debugList("players", players));
+        }
+
+        FakeEntity.showFakeEntityTo(players, entity, location, duration);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/FakeEntity.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/FakeEntity.java
@@ -1,0 +1,102 @@
+package com.denizenscript.denizen.utilities.entity;
+
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.DenizenAPI;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import org.bukkit.entity.Entity;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.*;
+
+public class FakeEntity {
+
+    public static class FakeEntityMap {
+
+        public Map<Integer, FakeEntity> byId = new HashMap<>();
+
+        public FakeEntity getOrAdd(PlayerTag player, LocationTag location, int id) {
+            FakeEntity entity = byId.get(id);
+            if (entity != null) {
+                return entity;
+            }
+            entity = new FakeEntity(player, location, id);
+            byId.put(id, entity);
+            return entity;
+        }
+
+        public void remove(FakeEntity entity) {
+            byId.remove(entity.id);
+        }
+    }
+
+    public final static Map<UUID, FakeEntityMap> entityMap = new HashMap<>();
+
+    public static FakeEntity getFakeEntityFor(UUID uuid, int id) {
+        FakeEntityMap map = entityMap.get(uuid);
+        if (map == null) {
+            return null;
+        }
+        return map.byId.get(id);
+    }
+
+    public PlayerTag player;
+    public int id;
+    public EntityTag entity;
+    public LocationTag location;
+    public BukkitTask currentTask = null;
+
+    private FakeEntity(PlayerTag player, LocationTag location, int id) {
+        this.player = player;
+        this.location = location;
+        this.id = id;
+    }
+
+    public static void showFakeEntityTo(List<PlayerTag> players, EntityTag entityTag, LocationTag location, DurationTag duration) {
+        for (PlayerTag player : players) {
+            if (!player.isOnline() || !player.isValid()) {
+                continue;
+            }
+            UUID uuid = player.getPlayerEntity().getUniqueId();
+            FakeEntity.FakeEntityMap playerEntities = entityMap.get(uuid);
+            if (playerEntities == null) {
+                playerEntities = new FakeEntity.FakeEntityMap();
+                entityMap.put(uuid, playerEntities);
+            }
+            Entity entity = NMSHandler.getPlayerHelper().sendEntitySpawn(player.getPlayerEntity(), entityTag.getBukkitEntityType(), location, entityTag.getWaitingMechanisms());
+            FakeEntity fakeEntity = playerEntities.getOrAdd(player, location, entity.getEntityId());
+            fakeEntity.updateEntity(new EntityTag(entity), duration);
+        }
+    }
+
+    public void cancelEntity() {
+        if (currentTask != null) {
+            currentTask.cancel();
+            currentTask = null;
+        }
+        if (player.isOnline()) {
+            NMSHandler.getPlayerHelper().sendEntityDestroy(player.getPlayerEntity(), entity.getBukkitEntity());
+        }
+        FakeEntity.FakeEntityMap mapping = entityMap.get(player.getOfflinePlayer().getUniqueId());
+        mapping.remove(this);
+    }
+
+    private void updateEntity(EntityTag entity, DurationTag duration) {
+        if (currentTask != null) {
+            currentTask.cancel();
+        }
+        this.entity = entity;
+        if (duration != null && duration.getTicks() > 0) {
+            currentTask = new BukkitRunnable() {
+                @Override
+                public void run() {
+                    currentTask = null;
+                    cancelEntity();
+                }
+            }.runTaskLater(DenizenAPI.getCurrentInstance(), duration.getTicks());
+        }
+    }
+}

--- a/v1_15/src/main/java/com/denizenscript/denizen/nms/v1_15/helpers/PlayerHelperImpl.java
+++ b/v1_15/src/main/java/com/denizenscript/denizen/nms/v1_15/helpers/PlayerHelperImpl.java
@@ -57,8 +57,6 @@ public class PlayerHelperImpl extends PlayerHelper {
             entity.safeAdjust(mechanism);
         }
 
-        EntityTag.rememberEntity(entity.getBukkitEntity());
-
         if (nmsEntity instanceof EntityLiving) {
             EntityLiving nmsLivingEntity = (EntityLiving) nmsEntity;
             conn.sendPacket(new PacketPlayOutSpawnEntityLiving(nmsLivingEntity));


### PR DESCRIPTION
== Spigot additions ==
- New `<PlayerTag.locale>` tag and `on player locale change` script event.
- Fixed a very minor bug that required end users to run an inventory update if they cancelled the `shoots bow` event for a player.
- Fixed exceptions thrown when trying to get/set an arrow entity's color.
- New `fakespawn` command. Use to show a temporary clientside-only entity to players. Includes a new `<PlayerTag.fake_entities>` tag to return the fake entities spawned for a player.

== Paper additions ==
- Expanded `entity shoots bow` event, now have access to `<context.item>` and a keep_item determination to keep the shot item.
- Added `on entity pathfinds` cancellable event for when any entity starts pathfinding to a location/entity.
- Added `on experience orbs merge` cancellable event for when two xp orbs attempt to combine.
- Added `on player absorbs experience` cancellable event for when a player is absorbing an xp orb.
- Added `on player clicks fake entity` event for when a player clicks a clientside entity spawned by the new `fakespawn` command.
- Added `on entity prespawns` as an earlier event to cancel before `on entity spawns` for performance gainz.
- Added `on command unknown` for when a player uses an unknown command, with an ElementTag determination to set the unknown message.
- Added `<EntityTag.from_spawner>` to determine whether an entity was spawned from a spawner
- Added `<EntityTag.spawn_location>` to determine the initial spawn location of the entity
- Added `<PlayerTag.affects_monster_spawning>` tag/mec pair to set whether monsters spawn naturally due to the player.
- Added `<EntityTag.xp_spawn_reason>`, `<EntityTag.xp_trigger>`, `<EntityTag.xp_source>` to grab some various extra info about experience orbs.

... I think that covers everything added.
Tested via a bunch of manual testing and some tasks/events here:
https://one.denizenscript.com/haste/68838

Tested booting this stuff up on 1.12 and included a commit that fixes some startup errors.