### PR TITLE
Work in progress entity goals PR

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -42,6 +42,10 @@ public class PaperModule {
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExperienceOrb.class, EntityTag.class);
         PropertyParser.registerProperty(EntityFromSpawner.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_15)) {
+            PropertyParser.registerProperty(EntityBeeGoal.class, EntityTag.class);
+            PropertyParser.registerProperty(EntityMobGoal.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntitySpawnLocation.class, EntityTag.class);
         PropertyParser.registerProperty(WorldViewDistance.class, WorldTag.class);
         PropertyParser.registerProperty(PlayerAffectsMonsterSpawning.class, PlayerTag.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityBeeGoal.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityBeeGoal.java
@@ -1,0 +1,89 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Bee;
+
+public class EntityBeeGoal implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Bee;
+    }
+
+    public static EntityBeeGoal getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityBeeGoal((EntityTag) entity);
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "remove_bee_goal"
+    };
+
+    private EntityBeeGoal(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return null;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.bee_goals>
+        // @returns ListTag
+        // @mechanism EntityTag.remove_bee_goal
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns all of the bee-specific goals applied to this entity.
+        // Note that some of these may appear as magic unknown values, and are subject to change in future versions of Paper.
+        // -->
+        PropertyParser.<EntityBeeGoal>registerTag("bee_goals", (attribute, entity) -> {
+            ListTag goals = new ListTag();
+            for (Goal<Bee> goal : Bukkit.getMobGoals().getAllGoals((Bee) entity.entity.getBukkitEntity())) {
+                if (goal.getKey().getEntityClass().equals(Bee.class)) {
+                    goals.add(goal.getKey().getNamespacedKey().getKey());
+                }
+            }
+            return goals;
+        });
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name remove_bee_goal
+        // @input ElementTag
+        // @Plugin Paper
+        // @description
+        // Removes the specified goal from this entity.
+        // Note that adding vanilla goals back to an entity is currently unsupported.
+        // @tags
+        // <EntityTag.bee_goals>
+        // -->
+        if (mechanism.matches("remove_bee_goal") && mechanism.hasValue()) {
+            Bukkit.getMobGoals().removeGoal((Bee) entity.getBukkitEntity(), GoalKey.of(Bee.class, NamespacedKey.minecraft(mechanism.getValue().asString())));
+        }
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityMobGoal.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityMobGoal.java
@@ -1,0 +1,89 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Mob;
+
+public class EntityMobGoal implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Mob;
+    }
+
+    public static EntityMobGoal getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        return new EntityMobGoal((EntityTag) entity);
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "remove_mob_goal"
+    };
+
+    private EntityMobGoal(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return null;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.mob_goals>
+        // @returns ListTag
+        // @mechanism EntityTag.remove_mob_goal
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns all of the mob-specific goals applied to this entity.
+        // Note that some of these may appear as magic unknown values, and are subject to change in future versions of Paper.
+        // -->
+        PropertyParser.<EntityMobGoal>registerTag("mob_goals", (attribute, entity) -> {
+            ListTag goals = new ListTag();
+            for (Goal<Mob> goal : Bukkit.getMobGoals().getAllGoals((Mob) entity.entity.getBukkitEntity())) {
+                if (goal.getKey().getEntityClass().equals(Mob.class)) {
+                    goals.add(goal.getKey().getNamespacedKey().getKey());
+                }
+            }
+            return goals;
+        });
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name remove_mob_goal
+        // @input ElementTag
+        // @Plugin Paper
+        // @description
+        // Removes the specified goal from this entity.
+        // Note that adding vanilla goals back to an entity is currently unsupported.
+        // @tags
+        // <EntityTag.mob_goals>
+        // -->
+        if (mechanism.matches("remove_mob_goal") && mechanism.hasValue()) {
+            Bukkit.getMobGoals().removeGoal((Mob) entity.getBukkitEntity(), GoalKey.of(Mob.class, NamespacedKey.minecraft(mechanism.getValue().asString())));
+        }
+    }
+}


### PR DESCRIPTION
These aren't exactly easy to work with, but at least they're being exposed via Paper API instead of loads of nms we'd have to keep track of. Paper has no way to add vanilla goals to entities at the time, so this covers getting and removing goals.

Paper *does* support adding your own custom mob goals, which could be plenty of fun to have as script containers in the future.

Just looking for whether this is a good way to implement goals before continuing