### PR TITLE
Improvements to fakeequip - better self-support and a couple patched bugs

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/FakeEquipCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/FakeEquipCommand.java
@@ -25,15 +25,15 @@ public class FakeEquipCommand extends AbstractCommand {
 
     public FakeEquipCommand() {
         setName("fakeequip");
-        setSyntax("fakeequip [<entity>|...] (for:<player>|...) [duration:<duration>/reset] (hand:<item>) (offhand:<item>) (head:<item>) (chest:<item>) (legs:<item>) (boots:<item>)");
-        setRequiredArguments(2, 9);
+        setSyntax("fakeequip [<entity>|...] (for:<player>|...) (duration:<duration>/reset) (hand:<item>) (offhand:<item>) (head:<item>) (chest:<item>) (legs:<item>) (boots:<item>)");
+        setRequiredArguments(1, 9);
         isProcedural = false;
     }
 
     // <--[command]
     // @Name FakeEquip
-    // @Syntax fakeequip [<entity>|...] (for:<player>|...) [duration:<duration>/reset] (hand:<item>) (offhand:<item>) (head:<item>) (chest:<item>) (legs:<item>) (boots:<item>)
-    // @Required 2
+    // @Syntax fakeequip [<entity>|...] (for:<player>|...) (duration:<duration>/reset) (hand:<item>) (offhand:<item>) (head:<item>) (chest:<item>) (legs:<item>) (boots:<item>)
+    // @Required 1
     // @Maximum 9
     // @Short Fake-equips items and armor on a list of entities for players to see without real change.
     // @Group entity
@@ -47,7 +47,7 @@ public class FakeEquipCommand extends AbstractCommand {
     //
     // The changes will remain in place for as long as the duration is specified (even if the real equipment is changed).
     // The changes can be manually reset early by using the 'reset' argument.
-    // A duration of '0' means forever.
+    // If you do not provide a duration, the fake equipment will last until manually reset.
     // This does not persist across server restarts.
     //
     // Set the item to 'air' to unequip any slot.
@@ -124,9 +124,6 @@ public class FakeEquipCommand extends AbstractCommand {
         if (equipment.isEmpty() && !scriptEntry.hasObject("reset")) {
             throw new InvalidArgumentsException("Must specify equipment!");
         }
-        if (!scriptEntry.hasObject("duration") && !scriptEntry.hasObject("reset")) {
-            throw new InvalidArgumentsException("Must specify a duration, or 'reset'!");
-        }
         if (!scriptEntry.hasObject("for")) {
             PlayerTag player = Utilities.getEntryPlayer(scriptEntry);
             if (player == null) {
@@ -134,7 +131,6 @@ public class FakeEquipCommand extends AbstractCommand {
             }
             scriptEntry.addObject("for", Collections.singletonList(player));
         }
-        scriptEntry.defaultObject("duration", new DurationTag(10));
         scriptEntry.addObject("equipment", equipment);
     }
 

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/impl/network/handlers/DenizenPacketListenerImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/impl/network/handlers/DenizenPacketListenerImpl.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.nms.v1_16.impl.network.handlers;
 
 import com.denizenscript.denizen.nms.v1_16.impl.network.packets.PacketInResourcePackStatusImpl;
 import com.denizenscript.denizen.nms.v1_16.impl.network.packets.PacketInSteerVehicleImpl;
+import com.denizenscript.denizen.scripts.commands.entity.FakeEquipCommand;
 import com.denizenscript.denizen.utilities.packets.DenizenPacketHandler;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import io.netty.util.concurrent.Future;
@@ -16,6 +17,8 @@ import org.bukkit.event.player.PlayerJoinEvent;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.UUID;
 
 public class DenizenPacketListenerImpl extends AbstractListenerPlayInImpl {
 
@@ -54,6 +57,42 @@ public class DenizenPacketListenerImpl extends AbstractListenerPlayInImpl {
     @Override
     public void a(PacketPlayInBlockDig packet) {
         packetHandler.receiveDigPacket(player.getBukkitEntity());
+        super.a(packet);
+    }
+
+    @Override
+    public void a(PacketPlayInArmAnimation packet) {
+        HashMap<UUID, FakeEquipCommand.EquipmentOverride> playersMap = FakeEquipCommand.overrides.get(player.getUniqueID());
+        if (playersMap != null) {
+            FakeEquipCommand.EquipmentOverride override = playersMap.get(player.getUniqueID());
+            if (override != null && (override.hand != null || override.offhand != null)) {
+                player.getBukkitEntity().updateInventory();
+            }
+        }
+        super.a(packet);
+    }
+
+    @Override
+    public void a(PacketPlayInHeldItemSlot packet) {
+        HashMap<UUID, FakeEquipCommand.EquipmentOverride> playersMap = FakeEquipCommand.overrides.get(player.getUniqueID());
+        if (playersMap != null) {
+            FakeEquipCommand.EquipmentOverride override = playersMap.get(player.getUniqueID());
+            if (override != null && override.hand != null) {
+                Bukkit.getScheduler().runTaskLater(NMSHandler.getJavaPlugin(), player.getBukkitEntity()::updateInventory, 2);
+            }
+        }
+        super.a(packet);
+    }
+
+    @Override
+    public void a(PacketPlayInWindowClick packet) {
+        HashMap<UUID, FakeEquipCommand.EquipmentOverride> playersMap = FakeEquipCommand.overrides.get(player.getUniqueID());
+        if (playersMap != null) {
+            FakeEquipCommand.EquipmentOverride override = playersMap.get(player.getUniqueID());
+            if (override != null && packet.b() == 0) {
+                Bukkit.getScheduler().runTaskLater(NMSHandler.getJavaPlugin(), player.getBukkitEntity()::updateInventory, 1);
+            }
+        }
         super.a(packet);
     }
 


### PR DESCRIPTION
Tested this to the best of my ability, on myself and with another test player. The things each packet interception covers are:
- PacketPlayOutEntityStatus: status 55 is sent to other players when a living entity swaps their hand/offhand, cancelled it if they have any faked items in hand/offhand and am just sending an equipment packet instead
- PacketPlayOutWindowItems: sent whenever the inventory refreshes. contains the entire inventory, including armor
- PacketPlayOutSetSlot: sent whenever a single-item change happens in the inventory
- PacketPlayInArmAnimation: covers dropping items, equipping armor from the hotbar/offhand, etc
- PacketPlayInHeldItemSlot: covers hotbar scrolling. a faked item in a hand slot will follow your selected item so it always appears like you are holding the item. needed to wait 2 ticks here because 1 tick would randomly fail to update.
- PacketPlayInWindowClick: covers inventory clicks made by the player. leaves faked equipment and items in their slot instead of having them vanish

I also made it so the duration was optional because I really hate duration:0. There was also a bug where if you did a reset, a double reset was queued because the duration defaulted to 10 seconds internally.