### PR TITLE
Add `npc opens <block>` event

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.events.block.*;
 import com.denizenscript.denizen.events.entity.*;
 import com.denizenscript.denizen.events.item.*;
 import com.denizenscript.denizen.events.npc.NPCNavigationScriptEvent;
+import com.denizenscript.denizen.events.npc.NPCOpensScriptEvent;
 import com.denizenscript.denizen.events.npc.NPCSpawnScriptEvent;
 import com.denizenscript.denizen.events.npc.NPCStuckScriptEvent;
 import com.denizenscript.denizen.events.player.*;
@@ -23,6 +24,7 @@ public class ScriptEventRegistry {
 
     public static void registerCitizensEvents() {
         ScriptEvent.registerScriptEvent(NPCNavigationScriptEvent.class);
+        ScriptEvent.registerScriptEvent(NPCOpensScriptEvent.class);
         ScriptEvent.registerScriptEvent(NPCSpawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(NPCStuckScriptEvent.class);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
@@ -22,6 +22,8 @@ public class NPCOpensScriptEvent extends BukkitScriptEvent implements Listener {
     //
     // @Location true
     //
+    // @Cancellable true
+    //
     // @Triggers when an NPC opens a door or gate.
     //
     // @Context

--- a/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
@@ -1,0 +1,84 @@
+package com.denizenscript.denizen.events.npc;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.NPCTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import net.citizensnpcs.api.event.NPCOpenDoorEvent;
+import net.citizensnpcs.api.event.NPCOpenGateEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class NPCOpensScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // npc opens <block>
+    //
+    // @Group NPC
+    //
+    // @Location true
+    //
+    // @Triggers when an NPC opens a door or gate.
+    //
+    // @Context
+    // <context.location> returns the location of the door or gate opened.
+    //
+    // @NPC Always.
+    //
+    // -->
+
+    public NPCOpensScriptEvent() {
+        instance = this;
+        registerCouldMatcher("npc opens <block>");
+    }
+
+    public static NPCOpensScriptEvent instance;
+    public NPCTag npc;
+    public LocationTag location;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!tryLocation(location, path.eventArgLowerAt(2))) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "NPCDoor";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(null, npc);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("location")) {
+            return location;
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void NPCOpenDoor(NPCOpenDoorEvent event) {
+        npc = new NPCTag(event.getNPC());
+        location = new LocationTag(event.getDoor().getLocation());
+        fire(event);
+    }
+
+    @EventHandler
+    public void NPCOpenGate(NPCOpenGateEvent event) {
+        npc = new NPCTag(event.getNPC());
+        location = new LocationTag(event.getGate().getLocation());
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.events.npc;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -44,7 +45,7 @@ public class NPCOpensScriptEvent extends BukkitScriptEvent implements Listener {
         if (!runInCheck(path, location)) {
             return false;
         }
-        if (!tryLocation(location, path.eventArgLowerAt(2))) {
+        if (!tryMaterial(new MaterialTag(location.getBlock()), path.eventArgLowerAt(2))) {
             return false;
         }
         return super.matches(path);


### PR DESCRIPTION
Adds a `npc opens <block>` event, to work with the new (Citizens) pathfinder's ability to open doors.