### PR TITLE
Player's main hand support

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -153,6 +153,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerAnimatesScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerBreaksBlockScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerBreaksItemScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerChangesMainHandScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerChangesGamemodeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerChangesSignScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerChangesWorldScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
@@ -1,0 +1,84 @@
+package com.denizenscript.denizen.events.player;
+
+import com.denizenscript.denizen.objects.*;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerChangedMainHandEvent;
+import org.bukkit.inventory.MainHand;
+
+import java.util.Arrays;
+
+public class PlayerChangesMainHandScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player changes main hand
+    //
+    // @Regex ^on player changes main hand$
+    //
+    // @Group Player
+    //
+    // @Triggers when a player changes their main hand.
+    //
+    // @Context
+    // <context.old_hand> returns the player's old main hand, either LEFT or RIGHT.
+    // <context.hand> returns the player's new main hand.
+    //
+    // @Player Always.
+    //
+    // -->
+
+    public PlayerChangesMainHandScriptEvent() {
+        instance = this;
+    }
+
+    public static PlayerChangesMainHandScriptEvent instance;
+    public PlayerChangedMainHandEvent event;
+
+    @Override
+    public boolean couldMatch(ScriptPath path) {
+        if (!path.eventLower.startsWith("player changes main hand")) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "PlayerChangesMainHand";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(PlayerTag.mirrorBukkitPlayer(event.getPlayer()), null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "old_hand":
+                return new ElementTag(event.getMainHand().toString());
+            // workaround for spigot bug
+            case "hand":
+                return new ElementTag(event.getMainHand() == MainHand.LEFT ? "RIGHT" : "LEFT");
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onPlayerChangesMainHand(PlayerChangedMainHandEvent event) {
+        this.event = event;
+        fire(event);
+    }
+
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
@@ -32,7 +32,7 @@ public class PlayerChangesMainHandScriptEvent extends BukkitScriptEvent implemen
     //
     // @Context
     // <context.old_hand> returns the player's old main hand, either LEFT or RIGHT.
-    // <context.hand> returns the player's new main hand.
+    // <context.new_hand> returns the player's new main hand.
     //
     // @Player Always.
     //
@@ -69,7 +69,7 @@ public class PlayerChangesMainHandScriptEvent extends BukkitScriptEvent implemen
             case "old_hand":
                 return new ElementTag(event.getMainHand().toString());
             // workaround for spigot bug
-            case "hand":
+            case "new_hand":
                 return new ElementTag(event.getMainHand() == MainHand.LEFT ? "RIGHT" : "LEFT");
         }
         return super.getContext(name);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
@@ -60,7 +60,7 @@ public class PlayerChangesMainHandScriptEvent extends BukkitScriptEvent implemen
 
     @Override
     public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(PlayerTag.mirrorBukkitPlayer(event.getPlayer()), null);
+        return new BukkitScriptEntryData(event.getPlayer());
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
@@ -71,5 +71,4 @@ public class PlayerChangesMainHandScriptEvent extends BukkitScriptEvent implemen
         this.event = event;
         fire(event);
     }
-
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerChangesMainHandScriptEvent.java
@@ -24,8 +24,6 @@ public class PlayerChangesMainHandScriptEvent extends BukkitScriptEvent implemen
     // @Events
     // player changes main hand
     //
-    // @Regex ^on player changes main hand$
-    //
     // @Group Player
     //
     // @Triggers when a player changes their main hand.
@@ -40,18 +38,11 @@ public class PlayerChangesMainHandScriptEvent extends BukkitScriptEvent implemen
 
     public PlayerChangesMainHandScriptEvent() {
         instance = this;
+        registerCouldMatcher("player changes main hand");
     }
 
     public static PlayerChangesMainHandScriptEvent instance;
     public PlayerChangedMainHandEvent event;
-
-    @Override
-    public boolean couldMatch(ScriptPath path) {
-        if (!path.eventLower.startsWith("player changes main hand")) {
-            return false;
-        }
-        return true;
-    }
 
     @Override
     public String getName() {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -1691,6 +1691,16 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             return null;
         });
 
+        // <--[tag]
+        // @attribute <PlayerTag.main_hand>
+        // @returns ElementTag
+        // @description
+        // Returns the player's main hand, either LEFT or RIGHT.
+        // -->
+        registerOnlineOnlyTag(ElementTag.class, "main_hand", (attribute, object) -> {
+            return new ElementTag(object.getPlayerEntity().getMainHand().toString());
+        });
+
         /////////////////////
         //   CITIZENS ATTRIBUTES
         /////////////////


### PR DESCRIPTION
## Additions

- `PlayerTag.main_hand` tag
- `player changes main hand` event

### Notes

- Possible spigot bug with `PlayerChangedMainHandEvent#getMainHand()`: returns the *old* main hand. Simple workaround provided, both old_hand and hand are available in context.