### PR TITLE
Material properties - Aya's part

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -194,6 +194,7 @@ public class PropertyRegistry {
         // register core MaterialTag properties
         PropertyParser.registerProperty(MaterialAge.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialBlockType.class, MaterialTag.class);
+        PropertyParser.registerProperty(MaterialBrewingStand.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialCampfire.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialCount.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialDelay.class, MaterialTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -198,6 +198,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(MaterialCount.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialDelay.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialDirectional.class, MaterialTag.class);
+        PropertyParser.registerProperty(MaterialDistance.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialDrags.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialFaces.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialHalf.class, MaterialTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialBlockType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialBlockType.java
@@ -28,7 +28,8 @@ public class MaterialBlockType implements Property {
                 || data instanceof TechnicalPiston
                 || data instanceof Campfire
                 || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && (data instanceof PointedDripstone
-                                                                        || data instanceof CaveVinesPlant));
+                                                                        || data instanceof CaveVinesPlant))
+                || data instanceof Scaffolding;
     }
 
     public static MaterialBlockType getFrom(ObjectTag _material) {
@@ -64,6 +65,7 @@ public class MaterialBlockType implements Property {
         // For campfires, output is NORMAL or SIGNAL.
         // For pointed dripstone, output is BASE, FRUSTUM, MIDDLE, TIP, or TIP_MERGE.
         // For cave vines, output is NORMAL or BERRIES.
+        // For scaffolding, output is NORMAL or BOTTOM.
         // -->
         PropertyParser.<MaterialBlockType, ElementTag>registerStaticTag(ElementTag.class, "type", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -90,6 +92,10 @@ public class MaterialBlockType implements Property {
         return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && material.getModernData() instanceof CaveVinesPlant;
     }
 
+    public boolean isScaffolding() {
+        return material.getModernData() instanceof Scaffolding;
+    }
+
     public Slab getSlab() {
         return (Slab) material.getModernData();
     }
@@ -100,6 +106,10 @@ public class MaterialBlockType implements Property {
 
     public Campfire getCampfire() {
         return (Campfire) material.getModernData();
+    }
+
+    public Scaffolding getScaffolding() {
+        return (Scaffolding) material.getModernData();
     }
 
     /*public PointedDripstone getDripstone() { // TODO: 1.17
@@ -127,6 +137,9 @@ public class MaterialBlockType implements Property {
         else if (isCaveVines()) {
             return ((CaveVinesPlant) material.getModernData()).isBerries() ? "BERRIES" : "NORMAL"; // TODO: 1.17
         }
+        else if (isScaffolding()) {
+            return getScaffolding().isBottom() ? "BOTTOM" : "NORMAL";
+        }
         return null; // Unreachable.
     }
 
@@ -149,6 +162,7 @@ public class MaterialBlockType implements Property {
         // For campfires, input is NORMAL or SIGNAL.
         // For pointed dripstone, input is BASE, FRUSTUM, MIDDLE, TIP, or TIP_MERGE.
         // For cave vines, input is NORMAL or BERRIES.
+        // For scaffolding, input is NORMAL or BOTTOM.
         // @tags
         // <MaterialTag.type>
         // -->
@@ -167,6 +181,9 @@ public class MaterialBlockType implements Property {
             }
             else if (isCaveVines()) {
                 ((CaveVinesPlant) material.getModernData()).setBerries(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "berries")); // TODO: 1.17
+            }
+            else if (isScaffolding()) {
+                getScaffolding().setBottom(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "bottom"));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialBrewingStand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialBrewingStand.java
@@ -1,0 +1,147 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.ArgumentHelper;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.block.data.type.BrewingStand;
+
+import java.util.Set;
+
+public class MaterialBrewingStand implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData() instanceof BrewingStand;
+    }
+
+    public static MaterialBrewingStand getFrom(ObjectTag _material) {
+        if (!describes(_material)) {
+            return null;
+        }
+        else {
+            return new MaterialBrewingStand((MaterialTag) _material);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "bottles"
+    };
+
+    private MaterialBrewingStand(MaterialTag _material) {
+        material = _material;
+    }
+
+    MaterialTag material;
+
+    public static void registerTags() {
+        // <--[tag]
+        // @attribute <MaterialTag.bottles>
+        // @returns ListTag(ElementTag)
+        // @mechanism MaterialTag.bottles
+        // @group properties
+        // @description
+        // Returns a list of booleans that represent whether a slot in a brewing stand has a bottle.
+        // -->
+        PropertyParser.<MaterialBrewingStand, ListTag>registerStaticTag(ListTag.class, "bottles", (attribute, material) -> {
+            return material.getBottleBooleans();
+        });
+
+        // <--[tag]
+        // @attribute <MaterialTag.has_bottle[<#>]>
+        // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.bottles
+        // @group properties
+        // @description
+        // Returns whether the brewing stand has a bottle at the specified index.
+        // -->
+        PropertyParser.<MaterialBrewingStand, ElementTag>registerStaticTag(ElementTag.class, "has_bottle", (attribute, material) -> {
+            if (!attribute.hasParam() || !ArgumentHelper.matchesInteger(attribute.getParam())) {
+                attribute.echoError("Tag MaterialTag.has_bottle[...] must have a valid integer input.");
+                return null;
+            }
+            int index = attribute.getIntParam();
+            if (index <= 0 || index > material.getMaxBottles()) {
+                attribute.echoError("Index must be between 1 and " + material.getMaxBottles() + ".");
+                return null;
+            }
+            return new ElementTag(material.hasBottle(index-1));
+        });
+    }
+
+    public BrewingStand getBrewingStand() {
+        return (BrewingStand) material.getModernData();
+    }
+
+    public int getMaxBottles() {
+        return getBrewingStand().getMaximumBottles();
+    }
+
+    public Set<Integer> getBottles() {
+        return getBrewingStand().getBottles();
+    }
+
+    public ListTag getBottleBooleans() {
+        ListTag result = new ListTag();
+        for (int i = 0; i < getMaxBottles(); i++) {
+            result.addObject(new ElementTag(getBottles().contains(i)));
+        }
+        return result;
+    }
+
+    public boolean hasBottle(int index) {
+        return getBrewingStand().hasBottle(index);
+    }
+
+    public void setBottle(int index, boolean hasBottle) {
+        getBrewingStand().setBottle(index, hasBottle);
+    }
+
+    public void resetBottles() {
+        for (int i : getBottles()) {
+            setBottle(i, false);
+        }
+    }
+
+    @Override
+    public String getPropertyString() {
+        return getBottleBooleans().identify();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "bottles";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name bottles
+        // @input ListTag
+        // @description
+        // Sets the bottles in a brewing stand. Input is a list of booleans representing whether that slot has a bottle, specifying no value counts as false.
+        // @tags
+        // <MaterialTag.bottles>
+        // <MaterialTag.has_bottle[<#>]>
+        // -->
+        if (mechanism.matches("bottles")) {
+            ListTag bottles = mechanism.valueAsType(ListTag.class);
+            if (bottles.size() > getMaxBottles()) {
+                mechanism.echoError("Too many values specified! Brewing stand has a maximum of " + getMaxBottles() + " bottles.");
+                return;
+            }
+            resetBottles();
+            for (int i = 0; i < bottles.size(); i++) {
+                setBottle(i, new ElementTag(bottles.get(i)).asBoolean());
+            }
+        }
+    }
+
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialDistance.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialDistance.java
@@ -84,11 +84,11 @@ public class MaterialDistance implements Property {
         // -->
         if (mechanism.matches("distance") && mechanism.requireInteger()) {
             int distance = mechanism.getValue().asInt();
-            if (distance <= getMaxDistance()) {
+            if (distance >= 0 && distance <= getMaxDistance()) {
                 getScaffolding().setDistance(distance);
             }
             else {
-                mechanism.echoError("Distance must be less than or equal to " + getMaxDistance());
+                mechanism.echoError("Distance must be between 0 and " + getMaxDistance());
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialDistance.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialDistance.java
@@ -1,0 +1,95 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.block.data.type.Scaffolding;
+
+public class MaterialDistance implements Property {
+
+    public static boolean describes(Object material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData() instanceof Scaffolding;
+    }
+
+    public static MaterialDistance getFrom(ObjectTag _material) {
+        if (!describes(_material)) {
+            return null;
+        }
+        else {
+            return new MaterialDistance((MaterialTag) _material);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "distance"
+    };
+
+    private MaterialDistance(MaterialTag _material) {
+        material = _material;
+    }
+
+    MaterialTag material;
+
+    public static void registerTags() {
+        // <--[tag]
+        // @attribute <MaterialTag.distance>
+        // @returns ElementTag(Number)
+        // @mechanism MaterialTag.distance
+        // @group properties
+        // @description
+        // Returns the distance between a scaffolding block and the nearest scaffolding block placed above a 'bottom' scaffold.
+        // -->
+        PropertyParser.<MaterialDistance, ElementTag>registerStaticTag(ElementTag.class, "distance", (attribute, material) -> {
+            return new ElementTag(material.getDistance());
+        });
+    }
+
+    public Scaffolding getScaffolding() {
+        return (Scaffolding) material.getModernData();
+    }
+
+    public int getDistance() {
+        return getScaffolding().getDistance();
+    }
+
+    public int getMaxDistance() {
+        return getScaffolding().getMaximumDistance();
+    }
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(getScaffolding().getDistance());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "distance";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name distance
+        // @input ElementTag(Number)
+        // @description
+        // Sets the distance between a scaffolding block and the nearest scaffolding block placed above a 'bottom' scaffold.
+        // @tags
+        // <MaterialTag.distance>
+        // -->
+        if (mechanism.matches("distance") && mechanism.requireInteger()) {
+            int distance = mechanism.getValue().asInt();
+            if (distance <= getMaxDistance()) {
+                getScaffolding().setDistance(distance);
+            }
+            else {
+                mechanism.echoError("Distance must be less than or equal to " + getMaxDistance());
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
@@ -10,11 +10,7 @@ import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.type.BubbleColumn;
-import org.bukkit.block.data.type.Comparator;
-import org.bukkit.block.data.type.PistonHead;
-import org.bukkit.block.data.type.StructureBlock;
-import org.bukkit.block.data.type.SculkSensor;
+import org.bukkit.block.data.type.*;
 
 public class MaterialMode implements Property {
 
@@ -31,7 +27,8 @@ public class MaterialMode implements Property {
                 || data instanceof PistonHead
                 || data instanceof BubbleColumn
                 || data instanceof StructureBlock
-                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && data instanceof SculkSensor);
+                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && data instanceof SculkSensor)
+                || data instanceof DaylightDetector;
     }
 
     public static MaterialMode getFrom(ObjectTag _material) {
@@ -67,6 +64,7 @@ public class MaterialMode implements Property {
         // For bubble-columns, output is NORMAL or DRAG.
         // For structure-blocks, output is CORNER, DATA, LOAD, or SAVE.
         // For sculk-sensors, output is ACTIVE, COOLDOWN, or INACTIVE.
+        // For daylight-detectors, output is INVERTED or NORMAL.
         // -->
         PropertyParser.<MaterialMode, ElementTag>registerStaticTag(ElementTag.class, "mode", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -93,6 +91,10 @@ public class MaterialMode implements Property {
         return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && material.getModernData() instanceof SculkSensor;
     }
 
+    public boolean isDaylightDetector() {
+        return material.getModernData() instanceof DaylightDetector;
+    }
+
     public Comparator getComparator() {
         return (Comparator) material.getModernData();
     }
@@ -107,6 +109,10 @@ public class MaterialMode implements Property {
 
     public StructureBlock getStructureBlock() {
         return (StructureBlock) material.getModernData();
+    }
+
+    public DaylightDetector getDaylightDetector() {
+        return (DaylightDetector) material.getModernData();
     }
 
     /*public SculkSensor getSculkSensor() { // TODO 1.17
@@ -130,6 +136,9 @@ public class MaterialMode implements Property {
         else if (isSculkSensor()) {
             return ((SculkSensor) material.getModernData()).getPhase().name(); // TODO 1.17
         }
+        else if (isDaylightDetector()) {
+            return getDaylightDetector().isInverted() ? "INVERTED" : "NORMAL";
+        }
         return null; //Unreachable
     }
 
@@ -152,6 +161,7 @@ public class MaterialMode implements Property {
         // For bubble-columns, input is NORMAL or DRAG.
         // For structure-blocks, input is CORNER, DATA, LOAD, or SAVE.
         // For sculk-sensors, input is ACTIVE, COOLDOWN, or INACTIVE.
+        // For daylight-detectors, input is INVERTED or NORMAL.
         // @tags
         // <MaterialTag.mode>
         // -->
@@ -170,6 +180,9 @@ public class MaterialMode implements Property {
             }
             else if (isSculkSensor() && mechanism.requireEnum(false, SculkSensor.Phase.values())) {
                 ((SculkSensor) material.getModernData()).setPhase(SculkSensor.Phase.valueOf(mechanism.getValue().asString().toUpperCase())); // TODO 1.17
+            }
+            else if (isDaylightDetector()) {
+                getDaylightDetector().setInverted(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "inverted"));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
@@ -27,7 +27,8 @@ public class MaterialMode implements Property {
                 || data instanceof PistonHead
                 || data instanceof BubbleColumn
                 || data instanceof StructureBlock
-                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && data instanceof SculkSensor)
+                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && (data instanceof SculkSensor
+                                                                        || data instanceof BigDripleaf))
                 || data instanceof DaylightDetector
                 || data instanceof CommandBlock;
     }
@@ -67,6 +68,7 @@ public class MaterialMode implements Property {
         // For sculk-sensors, output is ACTIVE, COOLDOWN, or INACTIVE.
         // For daylight-detectors, output is INVERTED or NORMAL.
         // For command-blocks, output is CONDITIONAL or NORMAL.
+        // For big-dripleafs, output is FULL, NONE, PARTIAL, or UNSTABLE.
         // -->
         PropertyParser.<MaterialMode, ElementTag>registerStaticTag(ElementTag.class, "mode", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -101,6 +103,10 @@ public class MaterialMode implements Property {
         return material.getModernData() instanceof CommandBlock;
     }
 
+    public boolean isBigDripleaf() {
+        return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && material.getModernData() instanceof BigDripleaf;
+    }
+
     public Comparator getComparator() {
         return (Comparator) material.getModernData();
     }
@@ -127,6 +133,10 @@ public class MaterialMode implements Property {
 
     /*public SculkSensor getSculkSensor() { // TODO 1.17
         return (SculkSensor) material.getModernData();
+    }
+
+    public BigDripleaf getBigDripleaf() {
+        return (BigDripleaf) material.getModernData();
     }*/
 
     @Override
@@ -152,6 +162,9 @@ public class MaterialMode implements Property {
         else if (isCommandBlock()) {
             return getCommandBlock().isConditional() ? "CONDITIONAL" : "NORMAL";
         }
+        else if (isBigDripleaf()) {
+            return ((BigDripleaf) material.getModernData()).getTilt().name(); // TODO 1.17
+        }
         return null; //Unreachable
     }
 
@@ -176,6 +189,7 @@ public class MaterialMode implements Property {
         // For sculk-sensors, input is ACTIVE, COOLDOWN, or INACTIVE.
         // For daylight-detectors, input is INVERTED or NORMAL.
         // For command-blocks, input is CONDITIONAL or NORMAL.
+        // For big-dripleafs, input is FULL, NONE, PARTIAL, or UNSTABLE.
         // @tags
         // <MaterialTag.mode>
         // -->
@@ -200,6 +214,9 @@ public class MaterialMode implements Property {
             }
             else if (isCommandBlock()) {
                 getCommandBlock().setConditional(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "conditional"));
+            }
+            else if (isBigDripleaf() && mechanism.requireEnum(false, BigDripleaf.Tilt.values())) {
+                ((BigDripleaf) material.getModernData()).setTilt(BigDripleaf.Tilt.valueOf(mechanism.getValue().asString().toUpperCase()));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
@@ -11,6 +11,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.BubbleColumn;
 import org.bukkit.block.data.type.Comparator;
 import org.bukkit.block.data.type.PistonHead;
+import org.bukkit.block.data.type.StructureBlock;
 
 public class MaterialMode implements Property {
 
@@ -25,7 +26,8 @@ public class MaterialMode implements Property {
         BlockData data = mat.getModernData();
         return data instanceof Comparator
                 || data instanceof PistonHead
-                || data instanceof BubbleColumn;
+                || data instanceof BubbleColumn
+                || data instanceof StructureBlock;
     }
 
     public static MaterialMode getFrom(ObjectTag _material) {
@@ -59,6 +61,7 @@ public class MaterialMode implements Property {
         // For comparators, output is COMPARE or SUBTRACT.
         // For piston_heads, output is NORMAL or SHORT.
         // For bubble-columns, output is NORMAL or DRAG.
+        // For structure-blocks, output is CORNER, DATA, LOAD, or SAVE.
         // -->
         PropertyParser.<MaterialMode, ElementTag>registerStaticTag(ElementTag.class, "mode", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -77,6 +80,10 @@ public class MaterialMode implements Property {
         return material.getModernData() instanceof BubbleColumn;
     }
 
+    public boolean isStructureBlock() {
+        return material.getModernData() instanceof StructureBlock;
+    }
+
     public Comparator getComparator() {
         return (Comparator) material.getModernData();
     }
@@ -89,6 +96,10 @@ public class MaterialMode implements Property {
         return (BubbleColumn) material.getModernData();
     }
 
+    public StructureBlock getStructureBlock() {
+        return (StructureBlock) material.getModernData();
+    }
+
     @Override
     public String getPropertyString() {
         if (isComparator()) {
@@ -97,9 +108,13 @@ public class MaterialMode implements Property {
         else if (isBubbleColumn()) {
             return getBubbleColumn().isDrag() ? "DRAG" : "NORMAL";
         }
-        else {
+        else if (isPistonHead()) {
             return getPistonHead().isShort() ? "SHORT" : "NORMAL";
         }
+        else if (isStructureBlock()) {
+            return getStructureBlock().getMode().name();
+        }
+        return null; //Unreachable
     }
 
     @Override
@@ -119,6 +134,7 @@ public class MaterialMode implements Property {
         // For comparators, input is COMPARE or SUBTRACT.
         // For piston_heads, input is NORMAL or SHORT.
         // For bubble-columns, input is NORMAL or DRAG.
+        // For structure blocks, input is CORNER, DATA, LOAD, or SAVE.
         // @tags
         // <MaterialTag.mode>
         // -->
@@ -131,6 +147,9 @@ public class MaterialMode implements Property {
             }
             else if (isPistonHead()) {
                 getPistonHead().setShort(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "short"));
+            }
+            else if (isStructureBlock() && mechanism.requireEnum(false, StructureBlock.Mode.values())) {
+                getStructureBlock().setMode(StructureBlock.Mode.valueOf(mechanism.getValue().asString().toUpperCase()));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
@@ -28,7 +28,8 @@ public class MaterialMode implements Property {
                 || data instanceof BubbleColumn
                 || data instanceof StructureBlock
                 || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && data instanceof SculkSensor)
-                || data instanceof DaylightDetector;
+                || data instanceof DaylightDetector
+                || data instanceof CommandBlock;
     }
 
     public static MaterialMode getFrom(ObjectTag _material) {
@@ -65,6 +66,7 @@ public class MaterialMode implements Property {
         // For structure-blocks, output is CORNER, DATA, LOAD, or SAVE.
         // For sculk-sensors, output is ACTIVE, COOLDOWN, or INACTIVE.
         // For daylight-detectors, output is INVERTED or NORMAL.
+        // For command-blocks, output is CONDITIONAL or NORMAL.
         // -->
         PropertyParser.<MaterialMode, ElementTag>registerStaticTag(ElementTag.class, "mode", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -95,6 +97,10 @@ public class MaterialMode implements Property {
         return material.getModernData() instanceof DaylightDetector;
     }
 
+    public boolean isCommandBlock() {
+        return material.getModernData() instanceof CommandBlock;
+    }
+
     public Comparator getComparator() {
         return (Comparator) material.getModernData();
     }
@@ -113,6 +119,10 @@ public class MaterialMode implements Property {
 
     public DaylightDetector getDaylightDetector() {
         return (DaylightDetector) material.getModernData();
+    }
+
+    public CommandBlock getCommandBlock() {
+        return (CommandBlock) material.getModernData();
     }
 
     /*public SculkSensor getSculkSensor() { // TODO 1.17
@@ -139,6 +149,9 @@ public class MaterialMode implements Property {
         else if (isDaylightDetector()) {
             return getDaylightDetector().isInverted() ? "INVERTED" : "NORMAL";
         }
+        else if (isCommandBlock()) {
+            return getCommandBlock().isConditional() ? "CONDITIONAL" : "NORMAL";
+        }
         return null; //Unreachable
     }
 
@@ -162,6 +175,7 @@ public class MaterialMode implements Property {
         // For structure-blocks, input is CORNER, DATA, LOAD, or SAVE.
         // For sculk-sensors, input is ACTIVE, COOLDOWN, or INACTIVE.
         // For daylight-detectors, input is INVERTED or NORMAL.
+        // For command-blocks, input is CONDITIONAL or NORMAL.
         // @tags
         // <MaterialTag.mode>
         // -->
@@ -183,6 +197,9 @@ public class MaterialMode implements Property {
             }
             else if (isDaylightDetector()) {
                 getDaylightDetector().setInverted(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "inverted"));
+            }
+            else if (isCommandBlock()) {
+                getCommandBlock().setConditional(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "conditional"));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.objects.properties.material;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -12,6 +14,7 @@ import org.bukkit.block.data.type.BubbleColumn;
 import org.bukkit.block.data.type.Comparator;
 import org.bukkit.block.data.type.PistonHead;
 import org.bukkit.block.data.type.StructureBlock;
+import org.bukkit.block.data.type.SculkSensor;
 
 public class MaterialMode implements Property {
 
@@ -27,7 +30,8 @@ public class MaterialMode implements Property {
         return data instanceof Comparator
                 || data instanceof PistonHead
                 || data instanceof BubbleColumn
-                || data instanceof StructureBlock;
+                || data instanceof StructureBlock
+                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && data instanceof SculkSensor);
     }
 
     public static MaterialMode getFrom(ObjectTag _material) {
@@ -62,6 +66,7 @@ public class MaterialMode implements Property {
         // For piston_heads, output is NORMAL or SHORT.
         // For bubble-columns, output is NORMAL or DRAG.
         // For structure-blocks, output is CORNER, DATA, LOAD, or SAVE.
+        // For sculk-sensors, output is ACTIVE, COOLDOWN, or INACTIVE.
         // -->
         PropertyParser.<MaterialMode, ElementTag>registerStaticTag(ElementTag.class, "mode", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -84,6 +89,10 @@ public class MaterialMode implements Property {
         return material.getModernData() instanceof StructureBlock;
     }
 
+    public boolean isSculkSensor() {
+        return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && material.getModernData() instanceof SculkSensor;
+    }
+
     public Comparator getComparator() {
         return (Comparator) material.getModernData();
     }
@@ -100,6 +109,10 @@ public class MaterialMode implements Property {
         return (StructureBlock) material.getModernData();
     }
 
+    /*public SculkSensor getSculkSensor() { // TODO 1.17
+        return (SculkSensor) material.getModernData();
+    }*/
+
     @Override
     public String getPropertyString() {
         if (isComparator()) {
@@ -113,6 +126,9 @@ public class MaterialMode implements Property {
         }
         else if (isStructureBlock()) {
             return getStructureBlock().getMode().name();
+        }
+        else if (isSculkSensor()) {
+            return ((SculkSensor) material.getModernData()).getPhase().name(); // TODO 1.17
         }
         return null; //Unreachable
     }
@@ -132,9 +148,10 @@ public class MaterialMode implements Property {
         // @description
         // Set a block's mode.
         // For comparators, input is COMPARE or SUBTRACT.
-        // For piston_heads, input is NORMAL or SHORT.
+        // For piston-heads, input is NORMAL or SHORT.
         // For bubble-columns, input is NORMAL or DRAG.
-        // For structure blocks, input is CORNER, DATA, LOAD, or SAVE.
+        // For structure-blocks, input is CORNER, DATA, LOAD, or SAVE.
+        // For sculk-sensors, input is ACTIVE, COOLDOWN, or INACTIVE.
         // @tags
         // <MaterialTag.mode>
         // -->
@@ -150,6 +167,9 @@ public class MaterialMode implements Property {
             }
             else if (isStructureBlock() && mechanism.requireEnum(false, StructureBlock.Mode.values())) {
                 getStructureBlock().setMode(StructureBlock.Mode.valueOf(mechanism.getValue().asString().toUpperCase()));
+            }
+            else if (isSculkSensor() && mechanism.requireEnum(false, SculkSensor.Phase.values())) {
+                ((SculkSensor) material.getModernData()).setPhase(SculkSensor.Phase.valueOf(mechanism.getValue().asString().toUpperCase())); // TODO 1.17
             }
         }
     }


### PR DESCRIPTION
This pull request adds:
Structure block mode support in `MaterialTag.mode`
`MaterialTag.distance` tag + mech - controls scaffolding's distance from a "bottom" (on ground/stable) scaffolding
Support scaffolding's "bottom" property in `MaterialTag.type`
Support sculk sensor's "phase" property in `MaterialTag.mode`
Support inverting daylight detectors in `MaterialTag.mode`
Support command block's "conditional" property in `MaterialTag.mode`
Support big dripleaf's "tilt" property in `MaterialTag.mode`
Add `MaterialBrewingStand` property - controls the bottles on a brewing stand
Support Jigsaw's "orientation" property in `MaterialTag.direction`