### PR TITLE
`MaterialTag.mode` support for a few materials

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.objects.properties.material;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.MultiVersionHelper1_17;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -50,7 +51,7 @@ public class MaterialMode implements Property {
         material = _material;
     }
 
-    MaterialTag material;
+    public MaterialTag material;
 
     public static void registerTags() {
 
@@ -63,12 +64,12 @@ public class MaterialMode implements Property {
         // Returns a block's mode.
         // For comparators, output is COMPARE or SUBTRACT.
         // For piston_heads, output is NORMAL or SHORT.
-        // For bubble-columns, output is NORMAL or DRAG.
-        // For structure-blocks, output is CORNER, DATA, LOAD, or SAVE.
-        // For sculk-sensors, output is ACTIVE, COOLDOWN, or INACTIVE.
-        // For daylight-detectors, output is INVERTED or NORMAL.
-        // For command-blocks, output is CONDITIONAL or NORMAL.
-        // For big-dripleafs, output is FULL, NONE, PARTIAL, or UNSTABLE.
+        // For bubble_columns, output is NORMAL or DRAG.
+        // For structure_blocks, output is CORNER, DATA, LOAD, or SAVE.
+        // For sculk_sensors, output is ACTIVE, COOLDOWN, or INACTIVE.
+        // For daylight_detectors, output is INVERTED or NORMAL.
+        // For command_blocks, output is CONDITIONAL or NORMAL.
+        // For big_dripleafs, output is FULL, NONE, PARTIAL, or UNSTABLE.
         // -->
         PropertyParser.<MaterialMode, ElementTag>registerStaticTag(ElementTag.class, "mode", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -183,13 +184,13 @@ public class MaterialMode implements Property {
         // @description
         // Set a block's mode.
         // For comparators, input is COMPARE or SUBTRACT.
-        // For piston-heads, input is NORMAL or SHORT.
-        // For bubble-columns, input is NORMAL or DRAG.
-        // For structure-blocks, input is CORNER, DATA, LOAD, or SAVE.
-        // For sculk-sensors, input is ACTIVE, COOLDOWN, or INACTIVE.
-        // For daylight-detectors, input is INVERTED or NORMAL.
-        // For command-blocks, input is CONDITIONAL or NORMAL.
-        // For big-dripleafs, input is FULL, NONE, PARTIAL, or UNSTABLE.
+        // For piston_heads, input is NORMAL or SHORT.
+        // For bubble_columns, input is NORMAL or DRAG.
+        // For structure_blocks, input is CORNER, DATA, LOAD, or SAVE.
+        // For sculk_sensors, input is ACTIVE, COOLDOWN, or INACTIVE.
+        // For daylight_detectors, input is INVERTED or NORMAL.
+        // For command_blocks, input is CONDITIONAL or NORMAL.
+        // For big_dripleafs, input is FULL, NONE, PARTIAL, or UNSTABLE.
         // @tags
         // <MaterialTag.mode>
         // -->
@@ -206,17 +207,14 @@ public class MaterialMode implements Property {
             else if (isStructureBlock() && mechanism.requireEnum(false, StructureBlock.Mode.values())) {
                 getStructureBlock().setMode(StructureBlock.Mode.valueOf(mechanism.getValue().asString().toUpperCase()));
             }
-            else if (isSculkSensor() && mechanism.requireEnum(false, SculkSensor.Phase.values())) {
-                ((SculkSensor) material.getModernData()).setPhase(SculkSensor.Phase.valueOf(mechanism.getValue().asString().toUpperCase())); // TODO: 1.17
+            else if (isSculkSensor() || isBigDripleaf()) {
+                MultiVersionHelper1_17.materialModeRunMech(mechanism, this);
             }
             else if (isDaylightDetector()) {
                 getDaylightDetector().setInverted(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "inverted"));
             }
             else if (isCommandBlock()) {
                 getCommandBlock().setConditional(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "conditional"));
-            }
-            else if (isBigDripleaf() && mechanism.requireEnum(false, BigDripleaf.Tilt.values())) {
-                ((BigDripleaf) material.getModernData()).setTilt(BigDripleaf.Tilt.valueOf(mechanism.getValue().asString().toUpperCase()));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialMode.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.objects.properties.material;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -8,9 +10,7 @@ import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.type.BubbleColumn;
-import org.bukkit.block.data.type.Comparator;
-import org.bukkit.block.data.type.PistonHead;
+import org.bukkit.block.data.type.*;
 
 public class MaterialMode implements Property {
 
@@ -25,7 +25,12 @@ public class MaterialMode implements Property {
         BlockData data = mat.getModernData();
         return data instanceof Comparator
                 || data instanceof PistonHead
-                || data instanceof BubbleColumn;
+                || data instanceof BubbleColumn
+                || data instanceof StructureBlock
+                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && (data instanceof SculkSensor
+                                                                        || data instanceof BigDripleaf))
+                || data instanceof DaylightDetector
+                || data instanceof CommandBlock;
     }
 
     public static MaterialMode getFrom(ObjectTag _material) {
@@ -59,6 +64,11 @@ public class MaterialMode implements Property {
         // For comparators, output is COMPARE or SUBTRACT.
         // For piston_heads, output is NORMAL or SHORT.
         // For bubble-columns, output is NORMAL or DRAG.
+        // For structure-blocks, output is CORNER, DATA, LOAD, or SAVE.
+        // For sculk-sensors, output is ACTIVE, COOLDOWN, or INACTIVE.
+        // For daylight-detectors, output is INVERTED or NORMAL.
+        // For command-blocks, output is CONDITIONAL or NORMAL.
+        // For big-dripleafs, output is FULL, NONE, PARTIAL, or UNSTABLE.
         // -->
         PropertyParser.<MaterialMode, ElementTag>registerStaticTag(ElementTag.class, "mode", (attribute, material) -> {
             return new ElementTag(material.getPropertyString());
@@ -77,6 +87,26 @@ public class MaterialMode implements Property {
         return material.getModernData() instanceof BubbleColumn;
     }
 
+    public boolean isStructureBlock() {
+        return material.getModernData() instanceof StructureBlock;
+    }
+
+    public boolean isSculkSensor() {
+        return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && material.getModernData() instanceof SculkSensor;
+    }
+
+    public boolean isDaylightDetector() {
+        return material.getModernData() instanceof DaylightDetector;
+    }
+
+    public boolean isCommandBlock() {
+        return material.getModernData() instanceof CommandBlock;
+    }
+
+    public boolean isBigDripleaf() {
+        return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && material.getModernData() instanceof BigDripleaf;
+    }
+
     public Comparator getComparator() {
         return (Comparator) material.getModernData();
     }
@@ -89,6 +119,26 @@ public class MaterialMode implements Property {
         return (BubbleColumn) material.getModernData();
     }
 
+    public StructureBlock getStructureBlock() {
+        return (StructureBlock) material.getModernData();
+    }
+
+    public DaylightDetector getDaylightDetector() {
+        return (DaylightDetector) material.getModernData();
+    }
+
+    public CommandBlock getCommandBlock() {
+        return (CommandBlock) material.getModernData();
+    }
+
+    /*public SculkSensor getSculkSensor() { // TODO: 1.17
+        return (SculkSensor) material.getModernData();
+    }
+
+    public BigDripleaf getBigDripleaf() {
+        return (BigDripleaf) material.getModernData();
+    }*/
+
     @Override
     public String getPropertyString() {
         if (isComparator()) {
@@ -97,9 +147,25 @@ public class MaterialMode implements Property {
         else if (isBubbleColumn()) {
             return getBubbleColumn().isDrag() ? "DRAG" : "NORMAL";
         }
-        else {
+        else if (isPistonHead()) {
             return getPistonHead().isShort() ? "SHORT" : "NORMAL";
         }
+        else if (isStructureBlock()) {
+            return getStructureBlock().getMode().name();
+        }
+        else if (isSculkSensor()) {
+            return ((SculkSensor) material.getModernData()).getPhase().name(); // TODO: 1.17
+        }
+        else if (isDaylightDetector()) {
+            return getDaylightDetector().isInverted() ? "INVERTED" : "NORMAL";
+        }
+        else if (isCommandBlock()) {
+            return getCommandBlock().isConditional() ? "CONDITIONAL" : "NORMAL";
+        }
+        else if (isBigDripleaf()) {
+            return ((BigDripleaf) material.getModernData()).getTilt().name(); // TODO: 1.17
+        }
+        return null; //Unreachable
     }
 
     @Override
@@ -117,8 +183,13 @@ public class MaterialMode implements Property {
         // @description
         // Set a block's mode.
         // For comparators, input is COMPARE or SUBTRACT.
-        // For piston_heads, input is NORMAL or SHORT.
+        // For piston-heads, input is NORMAL or SHORT.
         // For bubble-columns, input is NORMAL or DRAG.
+        // For structure-blocks, input is CORNER, DATA, LOAD, or SAVE.
+        // For sculk-sensors, input is ACTIVE, COOLDOWN, or INACTIVE.
+        // For daylight-detectors, input is INVERTED or NORMAL.
+        // For command-blocks, input is CONDITIONAL or NORMAL.
+        // For big-dripleafs, input is FULL, NONE, PARTIAL, or UNSTABLE.
         // @tags
         // <MaterialTag.mode>
         // -->
@@ -131,6 +202,21 @@ public class MaterialMode implements Property {
             }
             else if (isPistonHead()) {
                 getPistonHead().setShort(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "short"));
+            }
+            else if (isStructureBlock() && mechanism.requireEnum(false, StructureBlock.Mode.values())) {
+                getStructureBlock().setMode(StructureBlock.Mode.valueOf(mechanism.getValue().asString().toUpperCase()));
+            }
+            else if (isSculkSensor() && mechanism.requireEnum(false, SculkSensor.Phase.values())) {
+                ((SculkSensor) material.getModernData()).setPhase(SculkSensor.Phase.valueOf(mechanism.getValue().asString().toUpperCase())); // TODO: 1.17
+            }
+            else if (isDaylightDetector()) {
+                getDaylightDetector().setInverted(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "inverted"));
+            }
+            else if (isCommandBlock()) {
+                getCommandBlock().setConditional(CoreUtilities.equalsIgnoreCase(mechanism.getValue().asString(), "conditional"));
+            }
+            else if (isBigDripleaf() && mechanism.requireEnum(false, BigDripleaf.Tilt.values())) {
+                ((BigDripleaf) material.getModernData()).setTilt(BigDripleaf.Tilt.valueOf(mechanism.getValue().asString().toUpperCase()));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_17.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_17.java
@@ -2,10 +2,13 @@ package com.denizenscript.denizen.utilities;
 
 import com.denizenscript.denizen.objects.properties.entity.EntityColor;
 import com.denizenscript.denizen.objects.properties.material.MaterialBlockType;
+import com.denizenscript.denizen.objects.properties.material.MaterialMode;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.block.data.type.BigDripleaf;
 import org.bukkit.block.data.type.PointedDripstone;
+import org.bukkit.block.data.type.SculkSensor;
 import org.bukkit.entity.Axolotl;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -52,6 +55,15 @@ public class MultiVersionHelper1_17 { // TODO: 1.17
     public static void materialBlockTypeRunMech(Mechanism mechanism, MaterialBlockType object) {
         if (object.isDripstone() && mechanism.requireEnum(false, PointedDripstone.Thickness.values())) {
             ((PointedDripstone) object.material.getModernData()).setThickness(PointedDripstone.Thickness.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+    }
+
+    public static void materialModeRunMech(Mechanism mechanism, MaterialMode object) {
+        if (object.isSculkSensor() && mechanism.requireEnum(false, SculkSensor.Phase.values())) {
+            ((SculkSensor) object.material.getModernData()).setPhase(SculkSensor.Phase.valueOf(mechanism.getValue().asString().toUpperCase()));
+        }
+        else if (object.isBigDripleaf() && mechanism.requireEnum(false, BigDripleaf.Tilt.values())) {
+            ((BigDripleaf) object.material.getModernData()).setTilt(BigDripleaf.Tilt.valueOf(mechanism.getValue().asString().toUpperCase()));
         }
     }
 }


### PR DESCRIPTION
This pull request adds:
- Structure block "mode" support
- Support sculk sensor's "phase" property
- Support inverting daylight detectors
- Support command block's "conditional" property
- Support big dripleaf's "tilt" property

To `MaterialTag.mode`