### PR TITLE
Set dimension based on environment instead of world name

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/WorldHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/WorldHelper.java
@@ -10,6 +10,10 @@ public interface WorldHelper {
 
     void setStatic(World world, boolean isStatic);
 
+    default void setDimension(World world, World.Environment environment) {
+        // Pre-1.17 do nothing
+    }
+
     float getLocalDifficulty(Location location);
 
     default Location getNearestBiomeLocation(Location start, BiomeTag biome) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.scripts.commands.world;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.utilities.Settings;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.debugging.Debug;
@@ -224,6 +225,7 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
                 Debug.echoError("World is null, something went wrong in creation!");
             }
             else {
+                NMSHandler.getWorldHelper().setDimension(world, World.Environment.valueOf(environment.asString().toUpperCase()));
                 Debug.echoDebug(scriptEntry, "Created new world " + world.getName());
             }
             scriptEntry.setFinished(true);

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/ReflectionMappingsInfo.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/ReflectionMappingsInfo.java
@@ -30,6 +30,7 @@ public class ReflectionMappingsInfo {
     public static String Item_maxStackSize = "c";
 
     public static String Level_isClientSide = "y";
+    public static String Level_dimension = "G";
 
     public static String ThreadedLevelLightEngine_addTask = "a";
 

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/WorldHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/WorldHelperImpl.java
@@ -24,7 +24,7 @@ public class WorldHelperImpl implements WorldHelper {
     @Override
     public void setStatic(World world, boolean isStatic) {
         ServerLevel worldServer = ((CraftWorld) world).getHandle();
-        ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_isClientSide, worldServer, isStatic);
+        ReflectionHelper.setFieldValue(Level.class, ReflectionMappingsInfo.Level_isClientSide, worldServer, isStatic);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class WorldHelperImpl implements WorldHelper {
         }
         if (dimension != null) {
             ServerLevel worldServer = ((CraftWorld) world).getHandle();
-            ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_dimension, worldServer, dimension);
+            ReflectionHelper.setFieldValue(Level.class, ReflectionMappingsInfo.Level_dimension, worldServer, dimension);
         }
     }
 

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/WorldHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/WorldHelperImpl.java
@@ -6,8 +6,10 @@ import com.denizenscript.denizen.nms.v1_17.impl.BiomeNMSImpl;
 import com.denizenscript.denizen.objects.BiomeTag;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.level.Level;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
@@ -23,6 +25,26 @@ public class WorldHelperImpl implements WorldHelper {
     public void setStatic(World world, boolean isStatic) {
         ServerLevel worldServer = ((CraftWorld) world).getHandle();
         ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_isClientSide, worldServer, isStatic);
+    }
+
+    @Override
+    public void setDimension(World world, World.Environment environment) {
+        ResourceKey<Level> dimension = null;
+        switch (environment) {
+            case NORMAL:
+                dimension = Level.OVERWORLD;
+                break;
+            case NETHER:
+                dimension = Level.NETHER;
+                break;
+            case THE_END:
+                dimension = Level.END;
+                break;
+        }
+        if (dimension != null) {
+            ServerLevel worldServer = ((CraftWorld) world).getHandle();
+            ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_dimension, worldServer, dimension);
+        }
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/ReflectionMappingsInfo.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/ReflectionMappingsInfo.java
@@ -44,6 +44,7 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.world.level.Level
     public static String Level_isClientSide = "y";
+    public static String Level_dimension = "G";
 
     // net.minecraft.server.level.ThreadedLevelLightEngine
     public static String ThreadedLevelLightEngine_addTask = "a";

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/WorldHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/WorldHelperImpl.java
@@ -24,7 +24,7 @@ public class WorldHelperImpl implements WorldHelper {
     @Override
     public void setStatic(World world, boolean isStatic) {
         ServerLevel worldServer = ((CraftWorld) world).getHandle();
-        ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_isClientSide, worldServer, isStatic);
+        ReflectionHelper.setFieldValue(Level.class, ReflectionMappingsInfo.Level_isClientSide, worldServer, isStatic);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class WorldHelperImpl implements WorldHelper {
         }
         if (dimension != null) {
             ServerLevel worldServer = ((CraftWorld) world).getHandle();
-            ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_dimension, worldServer, dimension);
+            ReflectionHelper.setFieldValue(Level.class, ReflectionMappingsInfo.Level_dimension, worldServer, dimension);
         }
     }
 

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/WorldHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/WorldHelperImpl.java
@@ -6,8 +6,10 @@ import com.denizenscript.denizen.nms.v1_18.impl.BiomeNMSImpl;
 import com.denizenscript.denizen.objects.BiomeTag;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.level.Level;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_18_R1.CraftWorld;
@@ -23,6 +25,26 @@ public class WorldHelperImpl implements WorldHelper {
     public void setStatic(World world, boolean isStatic) {
         ServerLevel worldServer = ((CraftWorld) world).getHandle();
         ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_isClientSide, worldServer, isStatic);
+    }
+
+    @Override
+    public void setDimension(World world, World.Environment environment) {
+        ResourceKey<Level> dimension = null;
+        switch (environment) {
+            case NORMAL:
+                dimension = Level.OVERWORLD;
+                break;
+            case NETHER:
+                dimension = Level.NETHER;
+                break;
+            case THE_END:
+                dimension = Level.END;
+                break;
+        }
+        if (dimension != null) {
+            ServerLevel worldServer = ((CraftWorld) world).getHandle();
+            ReflectionHelper.setFieldValue(net.minecraft.world.level.Level.class, ReflectionMappingsInfo.Level_dimension, worldServer, dimension);
+        }
     }
 
     @Override


### PR DESCRIPTION
Spigot (or vanilla?) sets this based off the world name. It's totally fine in vanilla, but any shaders that hook into this dimension field will display stuff incorrectly. I went through 3 popular shader packs and none of them could properly display extra non-default end/nether skyboxes.

This should fix it for worlds created via `createworld`. Screenshots of the fix:

Before:
![nether_before](https://user-images.githubusercontent.com/29823405/151091140-dca0a822-1929-4bfa-94df-abf750124b46.PNG)
![end_before](https://user-images.githubusercontent.com/29823405/151091145-e6390e57-f970-49ec-8dde-5abc1ccd2bf2.PNG)

After:
![nether_after](https://user-images.githubusercontent.com/29823405/151091158-3d9ee8ad-3966-49bf-a423-a5bd3f7e9dce.PNG)
![end_after](https://user-images.githubusercontent.com/29823405/151091162-3636b4cf-a51e-4d27-834e-1c07ca82fe91.PNG)

Tested on 1.17.1 and 1.18.1