### PR TITLE
Add `EntityTag.arms_raised/invulnerable_duration/held_potion/goat_ram`

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -1,6 +1,8 @@
 package com.denizenscript.denizen.paper;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
@@ -50,7 +52,12 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(UnknownCommandScriptEvent.class);
 
         // Properties
+        PropertyParser.registerProperty(EntityArmsRaised.class, EntityTag.class);
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_16)) {
+            PropertyParser.registerProperty(EntityWitch.class, EntityTag.class);
+            PropertyParser.registerProperty(EntityWitherInvulnerable.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(ItemArmorStand.class, ItemTag.class);
 
         // Paper extension properties

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityArmsRaised.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityArmsRaised.java
@@ -1,0 +1,85 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.destroystokyo.paper.entity.RangedEntity;
+
+public class EntityArmsRaised implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof RangedEntity;
+    }
+
+    public static EntityArmsRaised getFrom(ObjectTag _entity) {
+        if (!describes(_entity)) {
+            return null;
+        }
+        else {
+            return new EntityArmsRaised((EntityTag) _entity);
+        }
+    }
+
+    public static final String[] handledMechs = new String[]{
+            "arms_raised"
+    };
+
+    private EntityArmsRaised(EntityTag _entity) {
+        entity = _entity;
+    }
+
+    EntityTag entity;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.arms_raised>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.arms_raised
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns whether a skeleton, stray, wither skeleton, drowned, illusioner, or piglin is "charging" up an attack (its arms are raised).
+        // -->
+        PropertyParser.<EntityArmsRaised, ElementTag>registerTag(ElementTag.class, "arms_raised", (attribute, object) -> {
+            return new ElementTag(object.getRanged().isChargingAttack());
+        });
+    }
+
+    public RangedEntity getRanged() {
+        return (RangedEntity) entity.getBukkitEntity();
+    }
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(getRanged().isChargingAttack());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "arms_raised";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name arms_raised
+        // @input ElementTag(Boolean)
+        // @Plugin Paper
+        // @description
+        // Sets whether a skeleton, stray, wither skeleton, drowned, illusioner, or piglin is "charging" up an attack (its arms are raised).
+        // Some entities may require <@link mechanism EntityTag.is_aware> to be set to false.
+        // @tags
+        // <EntityTag.arms_raised>
+        // -->
+        if (mechanism.matches("arms_raised") && mechanism.requireBoolean()) {
+            getRanged().setChargingAttack(mechanism.getValue().asBoolean());
+        }
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityWitch.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityWitch.java
@@ -1,0 +1,124 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.Material;
+import org.bukkit.entity.Witch;
+import org.bukkit.inventory.ItemStack;
+
+public class EntityWitch implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof Witch;
+    }
+
+    public static EntityWitch getFrom(ObjectTag _entity) {
+        if (!describes(_entity)) {
+            return null;
+        }
+        else {
+            return new EntityWitch((EntityTag) _entity);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "held_potion", "potion_drink_duration"
+    };
+
+    private EntityWitch(EntityTag _entity) {
+        entity = _entity;
+    }
+
+    EntityTag entity;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.held_potion>
+        // @returns ItemTag
+        // @mechanism EntityTag.held_potion
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns the potion item a witch is holding, or air if none.
+        // -->
+        PropertyParser.<EntityWitch, ItemTag>registerTag(ItemTag.class, "held_potion", (attribute, object) -> {
+            ItemStack potion = object.getWitch().getDrinkingPotion();
+            if (potion == null) {
+                return new ItemTag(Material.AIR);
+            }
+            return new ItemTag(object.getWitch().getDrinkingPotion());
+        });
+
+        // <--[tag]
+        // @attribute <EntityTag.potion_drink_duration>
+        // @returns DurationTag
+        // @mechanism EntityTag.potion_drink_duration
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns the duration remaining until a witch is done drinking a potion.
+        // -->
+        PropertyParser.<EntityWitch, DurationTag>registerTag(DurationTag.class, "potion_drink_duration", (attribute, object) -> {
+            return new DurationTag((long) object.getWitch().getPotionUseTimeLeft());
+        });
+    }
+
+    public Witch getWitch() {
+        return (Witch) entity.getBukkitEntity();
+    }
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "held_potion";
+    }
+
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name held_potion
+        // @input ItemTag
+        // @Plugin Paper
+        // @description
+        // Sets the potion item a witch is holding.
+        // @tags
+        // <EntityTag.held_potion>
+        // -->
+        if (mechanism.matches("held_potion") && mechanism.requireObject(ItemTag.class)) {
+            ItemTag potion = mechanism.valueAsType(ItemTag.class);
+            if (potion.getBukkitMaterial() != Material.POTION) {
+                mechanism.echoError("Invalid item input '" + potion + "': item must be a potion");
+                return;
+            }
+            getWitch().setDrinkingPotion(potion.getItemStack());
+        }
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name potion_drink_duration
+        // @input DurationTag
+        // @Plugin Paper
+        // @description
+        // Sets the duration remaining until a witch is done drinking a potion.
+        // @tags
+        // <EntityTag.potion_drink_duration>
+        // -->
+        if (mechanism.matches("potion_drink_duration") && mechanism.requireObject(DurationTag.class)) {
+            getWitch().setPotionUseTimeLeft(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
+        }
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityWitherInvulnerable.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityWitherInvulnerable.java
@@ -1,0 +1,88 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.entity.Wither;
+
+public class EntityWitherInvulnerable implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof Wither;
+    }
+
+    public static EntityWitherInvulnerable getFrom(ObjectTag _entity) {
+        if (!describes(_entity)) {
+            return null;
+        }
+        else {
+            return new EntityWitherInvulnerable((EntityTag) _entity);
+        }
+    }
+
+    public static final String[] handledMechs = new String[]{
+            "invulnerable_duration"
+    };
+
+    private EntityWitherInvulnerable(EntityTag _entity) {
+        entity = _entity;
+    }
+
+    EntityTag entity;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.invulnerable_duration>
+        // @returns DurationTag
+        // @mechanism EntityTag.invulnerable_duration
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns the duration remaining until the wither becomes vulnerable.
+        // -->
+        PropertyParser.<EntityWitherInvulnerable, DurationTag>registerTag(DurationTag.class, "invulnerable_duration", (attribute, object) -> {
+            return new DurationTag((long) object.getWither().getInvulnerableTicks());
+        });
+    }
+
+    public Wither getWither() {
+        return (Wither) entity.getBukkitEntity();
+    }
+
+    @Override
+    public String getPropertyString() {
+        int ticks = getWither().getInvulnerableTicks();
+        if (ticks == 0) {
+            return null;
+        }
+        return new DurationTag((long) ticks).identify();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "invulnerable_duration";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name invulnerable_duration
+        // @input DurationTag
+        // @Plugin Paper
+        // @description
+        // Sets the duration remaining until the wither becomes vulnerable.
+        // @tags
+        // <EntityTag.invulnerable_duration>
+        // -->
+        if (mechanism.matches("invulnerable_duration") && mechanism.requireObject(DurationTag.class)) {
+            getWither().setInvulnerableTicks(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
+        }
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperEntityProperties.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperEntityProperties.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.paper.properties;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.objects.Mechanism;
@@ -10,6 +12,7 @@ import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Goat;
 
 import java.util.UUID;
 
@@ -20,7 +23,8 @@ public class PaperEntityProperties implements Property {
     }
 
     public static final String[] handledMechs = new String[] {
-    }; // None
+            "goat_ram"
+    };
 
     public static PaperEntityProperties getFrom(ObjectTag entity) {
         if (!describes(entity)) {
@@ -155,5 +159,19 @@ public class PaperEntityProperties implements Property {
 
     @Override
     public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name goat_ram
+        // @input EntityTag
+        // @Plugin Paper
+        // @description
+        // Causes a goat to ram the specified entity.
+        // -->
+        if (mechanism.matches("goat_ram") && mechanism.requireObject(EntityTag.class)
+                && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17)
+                && entity.getBukkitEntity() instanceof Goat) {
+            ((Goat) entity.getBukkitEntity()).ram(mechanism.valueAsType(EntityTag.class).getLivingEntity());
+        }
     }
 }


### PR DESCRIPTION
## Additions

- `EntityTag.invulnerable_duration` - controls the invulnerability duration of a wither
- `EntityTag.arms_raised` - controls whether a ranged entity's arms are raised
- `EntityTag.goat_ram` - causes a goat to ram the specified entity
- `EntityWitch` property, controls the potion a witch is currently drinking, and the duration it will take to do so.

All are paper-only.