### PR TITLE
`EntityTag.item` ender signal support + add `EntityTag.material`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -106,6 +106,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityJumpStrength.class, EntityTag.class);
         PropertyParser.registerProperty(EntityKnockback.class, EntityTag.class);
         PropertyParser.registerProperty(EntityMarker.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityMaterial.class, EntityTag.class);
         PropertyParser.registerProperty(EntityMaxFuseTicks.class, EntityTag.class);
         PropertyParser.registerProperty(EntityPainting.class, EntityTag.class);
         PropertyParser.registerProperty(EntityPatrolLeader.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
@@ -56,22 +56,22 @@ public class EntityItem implements Property {
         if (isDroppedItem()) {
             return new ItemTag(getDroppedItem().getItemStack());
         }
-        else if (isThrowableProjectile()) {
-            return new ItemTag(((ThrowableProjectile) item.getBukkitEntity()).getItem()); // TODO: 1.15
-        }
-        else if (isTrident()) {
-            // TODO: 1.15: supported by ThrowableProjectile now, remove this part when 1.14 is dropped
-            return new ItemTag(NMSHandler.getEntityHelper().getItemFromTrident(item.getBukkitEntity()));
-        }
-        else if (isEnderSignal()) {
-            return new ItemTag(getEnderSignal().getItem());
-        }
         else if (isEnderman()) {
             BlockData data = getEnderman().getCarriedBlock();
             if (data == null) {
                 return new ItemTag(Material.AIR);
             }
             return new ItemTag(data.getMaterial());
+        }
+        else if (isTrident()) {
+            // TODO: 1.15: supported by ThrowableProjectile now, remove this part when 1.14 is dropped
+            return new ItemTag(NMSHandler.getEntityHelper().getItemFromTrident(item.getBukkitEntity()));
+        }
+        else if (isThrowableProjectile()) {
+            return new ItemTag(((ThrowableProjectile) item.getBukkitEntity()).getItem()); // TODO: 1.15
+        }
+        else if (isEnderSignal()) {
+            return new ItemTag(getEnderSignal().getItem());
         }
         return null; // Unreachable
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
@@ -171,18 +171,18 @@ public class EntityItem implements Property {
             if (isDroppedItem()) {
                 getDroppedItem().setItemStack(itemStack);
             }
-            else if (isThrowableProjectile()) {
-                ((ThrowableProjectile) item.getBukkitEntity()).setItem(itemStack); // TODO: 1.15
+            else if (isEnderman()) {
+                getEnderman().setCarriedBlock(itemStack.getType().createBlockData());
             }
             else if (isTrident()) {
                 // TODO: 1.15: supported by ThrowableProjectile now, remove this part when 1.14 is dropped
                 NMSHandler.getEntityHelper().setItemForTrident(item.getBukkitEntity(), itemStack);
             }
+            else if (isThrowableProjectile()) {
+                ((ThrowableProjectile) item.getBukkitEntity()).setItem(itemStack); // TODO: 1.15
+            }
             else if (isEnderSignal()) {
                 getEnderSignal().setItem(itemStack);
-            }
-            else if (isEnderman()) {
-                getEnderman().setCarriedBlock(itemStack.getType().createBlockData());
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityMaterial.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityMaterial.java
@@ -1,0 +1,131 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Enderman;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Minecart;
+
+public class EntityMaterial implements Property {
+
+    public static boolean describes(ObjectTag object) {
+        if (!(object instanceof EntityTag)) {
+            return false;
+        }
+        Entity entity = ((EntityTag) object).getBukkitEntity();
+        return entity instanceof Enderman
+                || entity instanceof Minecart;
+    }
+
+    public static EntityMaterial getFrom(ObjectTag _entity) {
+        if (!describes(_entity)) {
+            return null;
+        }
+        else {
+            return new EntityMaterial((EntityTag) _entity);
+        }
+    }
+
+    public static final String[] handledMechs = new String[]{
+            "material"
+    };
+
+    private EntityMaterial(EntityTag _entity) {
+        entity = _entity;
+    }
+
+    EntityTag entity;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.material>
+        // @returns MaterialTag
+        // @mechanism EntityTag.material
+        // @group properties
+        // @description
+        // Returns the material associated with the entity.
+        // For enderman, returns the material the enderman is holding.
+        // For minecarts, returns the material the minecart is carrying.
+        // -->
+        PropertyParser.<EntityMaterial, MaterialTag>registerTag(MaterialTag.class, "material", (attribute, object) -> {
+            return object.getMaterial();
+        });
+    }
+
+    public boolean isEnderman() {
+        return entity.getBukkitEntity() instanceof Enderman;
+    }
+
+    public boolean isMinecart() {
+        return entity.getBukkitEntity() instanceof Minecart;
+    }
+
+    public Enderman getEnderman() {
+        return (Enderman) entity.getBukkitEntity();
+    }
+
+    public Minecart getMinecart() {
+        return (Minecart) entity.getBukkitEntity();
+    }
+
+    public MaterialTag getMaterial() {
+        BlockData data = null;
+        if (isEnderman()) {
+            data = getEnderman().getCarriedBlock();
+        }
+        else if (isMinecart()) {
+            data = getMinecart().getDisplayBlockData();
+        }
+        if (data == null) {
+            return new MaterialTag(Material.AIR);
+        }
+        return new MaterialTag(data);
+    }
+
+    @Override
+    public String getPropertyString() {
+        MaterialTag material = getMaterial();
+        if (material.getMaterial() != Material.AIR) {
+            return material.identify();
+        }
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "material";
+    }
+
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name material
+        // @input MaterialTag
+        // @description
+        // Sets the material associated with the entity.
+        // For enderman, sets the material the enderman is holding.
+        // For minecarts, sets the material the minecart is carrying.
+        // @tags
+        // <EntityTag.material>
+        // -->
+        if (mechanism.matches("material") && mechanism.requireObject(MaterialTag.class)) {
+            BlockData data = mechanism.valueAsType(MaterialTag.class).getModernData();
+            if (isEnderman()) {
+                getEnderman().setCarriedBlock(data);
+            }
+            else if (isMinecart()) {
+                getMinecart().setDisplayBlockData(data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Additions

- `EntityTag.material` controls the material enderman are holding / minecarts are carrying, replaces enderman support in `EntityTag.item` (may need a deprecation added in DenizenCore)
- `EntityTag.item` ender signal support

## Changes
`EntityTag.item`

- remove documentation for Enderman (replaced with `EntityTag.material`)
- update tag registration to new tag registration method (`PropertyParser#registerTag`)
- attempt at cleaner code
- todo comments

##
Note: the `EnderSignal` interface exists in 1.14, but the methods to set the item were only added on 1.16, hence the version check.