### PR TITLE
Kill command

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -100,6 +100,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         registerCommand(HealthCommand.class);
         registerCommand(HurtCommand.class);
         registerCommand(InvisibleCommand.class);
+        registerCommand(KillCommand.class);
         registerCommand(LeashCommand.class);
         registerCommand(LookCommand.class);
         registerCommand(MountCommand.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/KillCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/KillCommand.java
@@ -8,7 +8,6 @@ import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import org.bukkit.entity.LivingEntity;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/KillCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/KillCommand.java
@@ -8,8 +8,8 @@ import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import org.bukkit.entity.LivingEntity;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class KillCommand extends AbstractCommand {
@@ -47,7 +47,7 @@ public class KillCommand extends AbstractCommand {
     // - kill <npc>
     //
     // @Usage
-    // Use to kill all monsters within 10 blocks of the player
+    // Use to kill all monsters within 10 blocks of the linked player
     // - kill <player.location.find_entities[monster].within[10]>
     // -->
 
@@ -62,20 +62,7 @@ public class KillCommand extends AbstractCommand {
                 arg.reportUnhandled();
             }
         }
-        if (!scriptEntry.hasObject("entities")) {
-            List<EntityTag> entities = new ArrayList<>();
-            if (Utilities.entryHasPlayer(scriptEntry)) {
-                entities.add(Utilities.getEntryPlayer(scriptEntry).getDenizenEntity());
-            }
-            else if (Utilities.entryHasNPC(scriptEntry)) {
-                entities.add(Utilities.getEntryNPC(scriptEntry).getDenizenEntity());
-            }
-            else {
-                throw new InvalidArgumentsException("No valid target entities found.");
-            }
-            scriptEntry.addObject("entities", entities);
-        }
-
+        scriptEntry.defaultObject("entities", Utilities.entryDefaultEntityList(scriptEntry, true));
     }
 
     @Override
@@ -89,7 +76,11 @@ public class KillCommand extends AbstractCommand {
                 Debug.echoError(scriptEntry.getResidingQueue(), entity + " is not a living entity!");
                 continue;
             }
-            entity.getLivingEntity().setHealth(0);
+            LivingEntity livingEntity = entity.getLivingEntity();
+            livingEntity.damage(livingEntity.getHealth());
+            if (livingEntity.getHealth() > 0) {
+                livingEntity.setHealth(0);
+            }
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/KillCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/KillCommand.java
@@ -1,0 +1,96 @@
+package com.denizenscript.denizen.scripts.commands.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
+import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KillCommand extends AbstractCommand {
+
+    public KillCommand() {
+        setName("kill");
+        setSyntax("kill ({player}/<entity>|...)");
+        setRequiredArguments(0, 1);
+        isProcedural = false;
+    }
+
+    // <--[command]
+    // @Name Kill
+    // @Syntax kill ({player}/<entity>|...)
+    // @Required 0
+    // @Maximum 1
+    // @Short Kills the player or a list of entities.
+    // @Group entity
+    //
+    // @Description
+    // Kills a list of entities, or a single entity.
+    //
+    // If no entities are specified, the command targets the linked player. If there is no linked
+    // player, the command targets the linked NPC. If neither is available, the command errors.
+    //
+    // @Tags
+    // <EntityTag.is_spawned>
+    //
+    // @Usage
+    // Use to kill the linked player
+    // - kill
+    //
+    // @Usage
+    // Use to kill the linked NPC
+    // - kill <npc>
+    //
+    // @Usage
+    // Use to kill all monsters within 10 blocks of the player
+    // - kill <player.location.find_entities[monster].within[10]>
+    // -->
+
+    @Override
+    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
+        for (Argument arg : scriptEntry) {
+            if (!scriptEntry.hasObject("entities")
+                    && arg.matchesArgumentList(EntityTag.class)) {
+                scriptEntry.addObject("entities", arg.asType(ListTag.class).filter(EntityTag.class, scriptEntry));
+            }
+            else {
+                arg.reportUnhandled();
+            }
+        }
+        if (!scriptEntry.hasObject("entities")) {
+            List<EntityTag> entities = new ArrayList<>();
+            if (Utilities.entryHasPlayer(scriptEntry)) {
+                entities.add(Utilities.getEntryPlayer(scriptEntry).getDenizenEntity());
+            }
+            else if (Utilities.entryHasNPC(scriptEntry)) {
+                entities.add(Utilities.getEntryNPC(scriptEntry).getDenizenEntity());
+            }
+            else {
+                throw new InvalidArgumentsException("No valid target entities found.");
+            }
+            scriptEntry.addObject("entities", entities);
+        }
+
+    }
+
+    @Override
+    public void execute(ScriptEntry scriptEntry) {
+        List<EntityTag> entities = (List<EntityTag>) scriptEntry.getObject("entities");
+        if (scriptEntry.dbCallShouldDebug()) {
+            Debug.report(scriptEntry, getName(), db("entities", entities));
+        }
+        for (EntityTag entity : entities) {
+            if (!entity.isLivingEntity()) {
+                Debug.echoError(scriptEntry.getResidingQueue(), entity + " is not a living entity!");
+                continue;
+            }
+            entity.getLivingEntity().setHealth(0);
+        }
+    }
+}


### PR DESCRIPTION
## Additions
`- kill` command, takes a list of entities and kills them
If no entities were specified, defaults to the linked player, if there isn't one, defaults to the linked NPC, if neither are available, the command errors.