### PR TITLE
Entity Properties Update - Part 1

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -56,10 +56,6 @@ public abstract class EntityHelper {
         ((LivingEntity) entity).setArrowsInBody(numArrows);
     }
 
-    public abstract double getArrowDamage(Entity arrow);
-
-    public abstract void setArrowDamage(Entity arrow, double damage);
-
     public abstract String getArrowPickupStatus(Entity entity);
 
     public abstract void setArrowPickupStatus(Entity entity, String status);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAI.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAI.java
@@ -5,7 +5,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 public class EntityAI implements Property {
 
@@ -47,13 +47,7 @@ public class EntityAI implements Property {
         return "has_ai";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
-
+    public static void registerTags() {
         // <--[tag]
         // @attribute <EntityTag.has_ai>
         // @returns ElementTag(Boolean)
@@ -65,12 +59,9 @@ public class EntityAI implements Property {
         // This generally shouldn't be used with NPCs. NPCs do not have vanilla AI, regardless of what this tag returns.
         // Other programmatic methods of blocking AI might also not be accounted for by this tag.
         // -->
-        if (attribute.startsWith("has_ai")) {
-            return new ElementTag(entity.getLivingEntity().hasAI())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityAI, ElementTag>registerTag(ElementTag.class, "has_ai", (attribute, object) -> {
+            return new ElementTag(object.entity.getLivingEntity().hasAI());
+        });
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAI.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAI.java
@@ -23,10 +23,6 @@ public class EntityAI implements Property {
         }
     }
 
-    public static final String[] handledTags = new String[] {
-            "has_ai"
-    };
-
     public static final String[] handledMechs = new String[] {
             "has_ai", "toggle_ai"
     };

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAI.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAI.java
@@ -44,6 +44,7 @@ public class EntityAI implements Property {
     }
 
     public static void registerTags() {
+
         // <--[tag]
         // @attribute <EntityTag.has_ai>
         // @returns ElementTag(Boolean)

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.Attribute;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.Age;
@@ -119,13 +120,7 @@ public class EntityAge implements Property {
         return "age";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
-
+    public static void registerTags() {
         // <--[tag]
         // @attribute <EntityTag.age>
         // @returns ElementTag(Number)
@@ -138,10 +133,9 @@ public class EntityAge implements Property {
         // A standard adult is 0.
         // An adult that just bred is 6000.
         // -->
-        if (attribute.startsWith("age")) {
-            return new ElementTag(getAge())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
+        PropertyParser.<EntityAge, ElementTag>registerTag(ElementTag.class, "age", (attribute, object) -> {
+            return new ElementTag(object.getAge());
+        });
 
         // <--[tag]
         // @attribute <EntityTag.is_age_locked>
@@ -151,10 +145,9 @@ public class EntityAge implements Property {
         // @description
         // If the entity is ageable, returns whether the entity is age locked.
         // -->
-        if (attribute.startsWith("is_age_locked")) {
-            return new ElementTag(getLock())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
+        PropertyParser.<EntityAge, ElementTag>registerTag(ElementTag.class, "is_age_locked", (attribute, object) -> {
+            return new ElementTag(object.getLock());
+        });
 
         // <--[tag]
         // @attribute <EntityTag.is_baby>
@@ -164,12 +157,9 @@ public class EntityAge implements Property {
         // @description
         // If the entity is ageable, returns whether the entity is a baby.
         // -->
-        if (attribute.startsWith("is_baby")) {
-            return new ElementTag(isBaby())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityAge, ElementTag>registerTag(ElementTag.class, "is_baby", (attribute, object) -> {
+            return new ElementTag(object.isBaby());
+        });
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
@@ -7,7 +7,6 @@ import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
-import com.denizenscript.denizencore.tags.Attribute;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.Age;
 import org.bukkit.entity.Ageable;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
@@ -116,6 +116,7 @@ public class EntityAge implements Property {
     }
 
     public static void registerTags() {
+
         // <--[tag]
         // @attribute <EntityTag.age>
         // @returns ElementTag(Number)

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
@@ -33,10 +33,6 @@ public class EntityAge implements Property {
         }
     }
 
-    public static final String[] handledTags = new String[] {
-            "age", "is_age_locked", "is_baby"
-    };
-
     public static final String[] handledMechs = new String[] {
             "age_lock", "age"
     };

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
@@ -5,7 +5,7 @@ import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.Bee;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.PigZombie;
@@ -28,10 +28,6 @@ public class EntityAnger implements Property {
             return new EntityAnger((EntityTag) entity);
         }
     }
-
-    public static final String[] handledTags = new String[] {
-            "anger"
-    };
 
     public static final String[] handledMechs = new String[] {
             "anger"
@@ -62,13 +58,7 @@ public class EntityAnger implements Property {
         }
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
-
+    public static void registerTags() {
         // <--[tag]
         // @attribute <EntityTag.anger>
         // @returns DurationTag
@@ -77,12 +67,9 @@ public class EntityAnger implements Property {
         // @description
         // Returns the remaining anger time of a PigZombie or Bee.
         // -->
-        if (attribute.startsWith("anger")) {
-            return new DurationTag((long) getAnger())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityAnger, DurationTag>registerTag(DurationTag.class, "anger", (attribute, object) -> {
+            return new DurationTag((long) object.getAnger());
+        });
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
@@ -17,7 +17,8 @@ public class EntityAnger implements Property {
             return false;
         }
         Entity bukkitEntity = ((EntityTag) entity).getBukkitEntity();
-        return bukkitEntity instanceof PigZombie || bukkitEntity instanceof Bee;
+        return bukkitEntity instanceof PigZombie
+                || bukkitEntity instanceof Bee;
     }
 
     public static EntityAnger getFrom(ObjectTag entity) {
@@ -50,15 +51,28 @@ public class EntityAnger implements Property {
     }
 
     public int getAnger() {
-        if (entity.getBukkitEntity() instanceof PigZombie) {
-            return ((PigZombie) entity.getBukkitEntity()).getAnger();
+        if (isPigZombie()) {
+            return getPigZombie().getAnger();
         }
         else {
-            return ((Bee) entity.getBukkitEntity()).getAnger();
+            return getBee().getAnger();
         }
     }
 
+    public boolean isPigZombie() {
+        return entity.getBukkitEntity() instanceof PigZombie;
+    }
+
+    public PigZombie getPigZombie() {
+        return (PigZombie) entity.getBukkitEntity();
+    }
+
+    public Bee getBee() {
+        return (Bee) entity.getBukkitEntity();
+    }
+
     public static void registerTags() {
+
         // <--[tag]
         // @attribute <EntityTag.anger>
         // @returns DurationTag
@@ -84,7 +98,7 @@ public class EntityAnger implements Property {
         // @tags
         // <EntityTag.anger>
         // -->
-        if (mechanism.matches("anger")) {
+        if (mechanism.matches("anger") && mechanism.requireObject(DurationTag.class)) {
             DurationTag duration;
             if (mechanism.getValue().isInt()) {
                 duration = new DurationTag(mechanism.getValue().asLong());
@@ -92,11 +106,11 @@ public class EntityAnger implements Property {
             else {
                 duration = mechanism.valueAsType(DurationTag.class);
             }
-            if (entity.getBukkitEntity() instanceof PigZombie) {
-                ((PigZombie) entity.getBukkitEntity()).setAnger(duration.getTicksAsInt());
+            if (isPigZombie()) {
+                getPigZombie().setAnger(duration.getTicksAsInt());
             }
             else {
-                ((Bee) entity.getBukkitEntity()).setAnger(duration.getTicksAsInt());
+                getBee().setAnger(duration.getTicksAsInt());
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
@@ -7,7 +7,7 @@ import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.Bee;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.PigZombie;
@@ -31,10 +31,6 @@ public class EntityAnger implements Property {
             return new EntityAnger((EntityTag) entity);
         }
     }
-
-    public static final String[] handledTags = new String[] {
-            "anger"
-    };
 
     public static final String[] handledMechs = new String[] {
             "anger"
@@ -65,13 +61,7 @@ public class EntityAnger implements Property {
         }
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
-
+    public static void registerTags() {
         // <--[tag]
         // @attribute <EntityTag.anger>
         // @returns DurationTag
@@ -80,12 +70,9 @@ public class EntityAnger implements Property {
         // @description
         // Returns the remaining anger time of a PigZombie or Bee.
         // -->
-        if (attribute.startsWith("anger")) {
-            return new DurationTag((long) getAnger())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityAnger, DurationTag>registerTag(DurationTag.class, "anger", (attribute, object) -> {
+            return new DurationTag((long) object.getAnger());
+        });
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArmorBonus.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArmorBonus.java
@@ -20,7 +20,9 @@ public class EntityArmorBonus implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityArmorBonus((EntityTag) entity);
+        else {
+            return new EntityArmorBonus((EntityTag) entity);
+        }
     }
 
     public static final String[] handledMechs = new String[] {
@@ -35,19 +37,13 @@ public class EntityArmorBonus implements Property {
 
     @Override
     public String getPropertyString() {
-        if (getAttribute().getValue() > 0.0) {
-            return getArmorBonus().asString();
-        }
-        return null;
+        double value = getAttribute().getValue();
+        return value > 0 ? String.valueOf(value) : null;
     }
 
     @Override
     public String getPropertyId() {
         return "armor_bonus";
-    }
-
-    public ElementTag getArmorBonus() {
-        return new ElementTag(getAttribute().getValue());
     }
 
     public AttributeInstance getAttribute() {
@@ -65,7 +61,7 @@ public class EntityArmorBonus implements Property {
         // Returns the entity's base armor bonus.
         // -->
         PropertyParser.<EntityArmorBonus, ElementTag>registerTag(ElementTag.class, "armor_bonus", (attribute, object) -> {
-            return object.getArmorBonus();
+            return new ElementTag(object.getAttribute().getValue());
         });
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArmorBonus.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArmorBonus.java
@@ -5,15 +5,15 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 
 public class EntityArmorBonus implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        if (!(entity instanceof EntityTag)) {
-            return false;
-        }
-        return ((EntityTag) entity).isLivingEntity();
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).isLivingEntity();
     }
 
     public static EntityArmorBonus getFrom(ObjectTag entity) {
@@ -22,10 +22,6 @@ public class EntityArmorBonus implements Property {
         }
         return new EntityArmorBonus((EntityTag) entity);
     }
-
-    public static final String[] handledTags = new String[] {
-            "armor_bonus"
-    };
 
     public static final String[] handledMechs = new String[] {
             "armor_bonus"
@@ -39,7 +35,7 @@ public class EntityArmorBonus implements Property {
 
     @Override
     public String getPropertyString() {
-        if (entity.getLivingEntity().getAttribute(org.bukkit.attribute.Attribute.GENERIC_ARMOR).getValue() > 0.0) {
+        if (getAttribute().getValue() > 0.0) {
             return getArmorBonus().asString();
         }
         return null;
@@ -51,15 +47,14 @@ public class EntityArmorBonus implements Property {
     }
 
     public ElementTag getArmorBonus() {
-        return new ElementTag(entity.getLivingEntity().getAttribute(org.bukkit.attribute.Attribute.GENERIC_ARMOR).getValue());
+        return new ElementTag(getAttribute().getValue());
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public AttributeInstance getAttribute() {
+        return entity.getLivingEntity().getAttribute(Attribute.GENERIC_ARMOR);
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.armor_bonus>
@@ -69,11 +64,9 @@ public class EntityArmorBonus implements Property {
         // @description
         // Returns the entity's base armor bonus.
         // -->
-        if (attribute.startsWith("armor_bonus")) {
-            return getArmorBonus().getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityArmorBonus, ElementTag>registerTag(ElementTag.class, "armor_bonus", (attribute, object) -> {
+            return object.getArmorBonus();
+        });
     }
 
     @Override
@@ -89,8 +82,7 @@ public class EntityArmorBonus implements Property {
         // <EntityTag.armor_bonus>
         // -->
         if (mechanism.matches("armor_bonus") && mechanism.requireDouble()) {
-            entity.getLivingEntity().getAttribute(org.bukkit.attribute.Attribute.GENERIC_ARMOR)
-                    .setBaseValue(mechanism.getValue().asDouble());
+            getAttribute().setBaseValue(mechanism.getValue().asDouble());
         }
 
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArmorPose.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArmorPose.java
@@ -22,7 +22,7 @@ public class EntityArmorPose implements Property {
 
     public static boolean describes(ObjectTag entity) {
         return entity instanceof EntityTag
-                && ((EntityTag) entity).getBukkitEntityType() == EntityType.ARMOR_STAND;
+                && ((EntityTag) entity).getBukkitEntity() instanceof ArmorStand;
     }
 
     public static EntityArmorPose getFrom(ObjectTag entity) {
@@ -147,7 +147,7 @@ public class EntityArmorPose implements Property {
         // -->
         if (mechanism.matches("armor_pose")) {
             ArmorStand armorStand = (ArmorStand) entity.getBukkitEntity();
-            if (mechanism.getValue().asString().contains("=")) {
+            if (mechanism.value.canBeType(MapTag.class)) {
                 MapTag map = mechanism.valueAsType(MapTag.class);
                 for (Map.Entry<StringHolder, ObjectTag> entry : map.map.entrySet()) {
                     PosePart posePart = PosePart.fromName(entry.getKey().str);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArms.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArms.java
@@ -37,10 +37,7 @@ public class EntityArms implements Property {
 
     @Override
     public String getPropertyString() {
-        if (!getStand().hasArms()) {
-            return null;
-        }
-        return "true";
+        return getStand().hasArms() ? "true" : null;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArms.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArms.java
@@ -5,14 +5,15 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.EntityType;
+
 
 public class EntityArms implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.ARMOR_STAND;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof ArmorStand;
     }
 
     public static EntityArms getFrom(ObjectTag entity) {
@@ -23,10 +24,6 @@ public class EntityArms implements Property {
             return new EntityArms((EntityTag) entity);
         }
     }
-
-    public static final String[] handledTags = new String[] {
-            "arms"
-    };
 
     public static final String[] handledMechs = new String[] {
             "arms"
@@ -40,12 +37,10 @@ public class EntityArms implements Property {
 
     @Override
     public String getPropertyString() {
-        if (!((ArmorStand) dentity.getBukkitEntity()).hasArms()) {
+        if (!getStand().hasArms()) {
             return null;
         }
-        else {
-            return "true";
-        }
+        return "true";
     }
 
     @Override
@@ -53,12 +48,11 @@ public class EntityArms implements Property {
         return "arms";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public ArmorStand getStand() {
+        return (ArmorStand) dentity.getBukkitEntity();
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.arms>
@@ -68,12 +62,9 @@ public class EntityArms implements Property {
         // @description
         // If the entity is an armor stand, returns whether the armor stand has arms.
         // -->
-        if (attribute.startsWith("arms")) {
-            return new ElementTag(((ArmorStand) dentity.getBukkitEntity()).hasArms())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityArms, ElementTag>registerTag(ElementTag.class, "arms", (attribute, object) -> {
+            return new ElementTag(object.getStand().hasArms());
+        });
     }
 
     @Override
@@ -89,7 +80,7 @@ public class EntityArms implements Property {
         // <EntityTag.arms>
         // -->
         if (mechanism.matches("arms") && mechanism.requireBoolean()) {
-            ((ArmorStand) dentity.getBukkitEntity()).setArms(mechanism.getValue().asBoolean());
+            getStand().setArms(mechanism.getValue().asBoolean());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowDamage.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowDamage.java
@@ -19,7 +19,9 @@ public class EntityArrowDamage implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityArrowDamage((EntityTag) entity);
+        else {
+            return new EntityArrowDamage((EntityTag) entity);
+        }
     }
 
     public static final String[] handledMechs = {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowDamage.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowDamage.java
@@ -1,18 +1,18 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
-import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.Arrow;
 
 public class EntityArrowDamage implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Arrow;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof Arrow;
     }
 
     public static EntityArrowDamage getFrom(ObjectTag entity) {
@@ -21,10 +21,6 @@ public class EntityArrowDamage implements Property {
         }
         return new EntityArrowDamage((EntityTag) entity);
     }
-
-    public static final String[] handledTags = {
-            "damage"
-    };
 
     public static final String[] handledMechs = {
             "damage"
@@ -38,7 +34,7 @@ public class EntityArrowDamage implements Property {
 
     @Override
     public String getPropertyString() {
-        return String.valueOf(NMSHandler.getEntityHelper().getArrowDamage(dentity.getBukkitEntity()));
+        return String.valueOf(getArrow().getDamage());
     }
 
     @Override
@@ -46,12 +42,11 @@ public class EntityArrowDamage implements Property {
         return "damage";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public Arrow getArrow() {
+        return (Arrow) dentity.getBukkitEntity();
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.damage>
@@ -62,12 +57,9 @@ public class EntityArrowDamage implements Property {
         // Returns the damage that the arrow/trident will inflict.
         // NOTE: The actual damage dealt by the arrow/trident may be different depending on the projectile's flight speed.
         // -->
-        if (attribute.startsWith("damage")) {
-            return new ElementTag(NMSHandler.getEntityHelper().getArrowDamage(dentity.getBukkitEntity()))
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityArrowDamage, ElementTag>registerTag(ElementTag.class, "damage", (attribute, object) -> {
+            return new ElementTag(object.getArrow().getDamage());
+        });
     }
 
     @Override
@@ -83,7 +75,7 @@ public class EntityArrowDamage implements Property {
         // <EntityTag.damage>
         // -->
         if (mechanism.matches("damage") && mechanism.requireDouble()) {
-            NMSHandler.getEntityHelper().setArrowDamage(dentity.getBukkitEntity(), mechanism.getValue().asDouble());
+            getArrow().setDamage(mechanism.getValue().asDouble());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeBaseValues.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeBaseValues.java
@@ -25,7 +25,9 @@ public class EntityAttributeBaseValues implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityAttributeBaseValues((EntityTag) entity);
+        else {
+            return new EntityAttributeBaseValues((EntityTag) entity);
+        }
     }
 
     public static final String[] handledMechs = new String[] {
@@ -57,10 +59,7 @@ public class EntityAttributeBaseValues implements Property {
     @Override
     public String getPropertyString() {
         MapTag map = attributeBaseValues();
-        if (map.map.isEmpty()) {
-            return null;
-        }
-        return map.savable();
+        return map.map.isEmpty() ? null : map.savable();
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeBaseValues.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeBaseValues.java
@@ -6,9 +6,10 @@ import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
 import org.bukkit.attribute.Attributable;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 
 import java.util.Map;
@@ -16,21 +17,16 @@ import java.util.Map;
 public class EntityAttributeBaseValues implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Attributable;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof Attributable;
     }
 
     public static EntityAttributeBaseValues getFrom(ObjectTag entity) {
         if (!describes(entity)) {
             return null;
         }
-        else {
-            return new EntityAttributeBaseValues((EntityTag) entity);
-        }
+        return new EntityAttributeBaseValues((EntityTag) entity);
     }
-
-    public static final String[] handledTags = new String[] {
-            "has_attribute", "attribute_value", "attribute_base_value", "attribute_default_value"
-    };
 
     public static final String[] handledMechs = new String[] {
             "attribute_base_values"
@@ -44,14 +40,18 @@ public class EntityAttributeBaseValues implements Property {
 
     public MapTag attributeBaseValues() {
         MapTag result = new MapTag();
-        Attributable ent = (Attributable) entity.getBukkitEntity();
-        for (org.bukkit.attribute.Attribute attr : org.bukkit.attribute.Attribute.values()) {
+        Attributable ent = getAttributable();
+        for (Attribute attr : Attribute.values()) {
             AttributeInstance instance = ent.getAttribute(attr);
             if (instance != null) {
                 result.putObject(attr.name(), new ElementTag(instance.getBaseValue()));
             }
         }
         return result;
+    }
+
+    public Attributable getAttributable() {
+        return (Attributable) entity.getBukkitEntity();
     }
 
     @Override
@@ -68,12 +68,7 @@ public class EntityAttributeBaseValues implements Property {
         return "attribute_base_values";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.has_attribute[<attribute>]>
@@ -84,11 +79,14 @@ public class EntityAttributeBaseValues implements Property {
         // Valid attribute names are listed at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html>
         // See also <@link language attribute modifiers>.
         // -->
-        if (attribute.startsWith("has_attribute") && attribute.hasParam()) {
-            AttributeInstance instance = ((Attributable) entity.getBukkitEntity()).getAttribute(
-                    org.bukkit.attribute.Attribute.valueOf(attribute.getParam().toUpperCase()));
-            return new ElementTag(instance != null).getObjectAttribute(attribute.fulfill(1));
-        }
+        PropertyParser.<EntityAttributeBaseValues, ElementTag>registerTag(ElementTag.class, "has_attribute", (attribute, object) -> {
+            if (!(attribute.hasParam() && attribute.getParamElement().matchesEnum(Attribute.values()))) {
+                attribute.echoError("Invalid entity.has_attribute[...] input: must be a valid attribute name.");
+                return null;
+            }
+            Attribute attr = Attribute.valueOf(attribute.getParam().toUpperCase());
+            return new ElementTag(object.getAttributable().getAttribute(attr) != null);
+        });
 
         // <--[tag]
         // @attribute <EntityTag.attribute_value[<attribute>]>
@@ -101,15 +99,19 @@ public class EntityAttributeBaseValues implements Property {
         // Valid attribute names are listed at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html>
         // See also <@link language attribute modifiers>.
         // -->
-        if (attribute.startsWith("attribute_value") && attribute.hasParam()) {
-            org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(attribute.getParam().toUpperCase());
-            AttributeInstance instance = ((Attributable) entity.getBukkitEntity()).getAttribute(attr);
-            if (instance == null) {
-                attribute.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+        PropertyParser.<EntityAttributeBaseValues, ElementTag>registerTag(ElementTag.class, "attribute_value", (attribute, object) -> {
+            if (!(attribute.hasParam() && attribute.getParamElement().matchesEnum(Attribute.values()))) {
+                attribute.echoError("Invalid entity.attribute_value[...] input: must be a valid attribute name.");
                 return null;
             }
-            return new ElementTag(instance.getValue()).getObjectAttribute(attribute.fulfill(1));
-        }
+            Attribute attr = Attribute.valueOf(attribute.getParam().toUpperCase());
+            AttributeInstance instance = object.getAttributable().getAttribute(attr);
+            if (instance == null) {
+                attribute.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + object.entity.getBukkitEntityType().name());
+                return null;
+            }
+            return new ElementTag(instance.getValue());
+        });
 
         // <--[tag]
         // @attribute <EntityTag.attribute_base_value[<attribute>]>
@@ -122,15 +124,19 @@ public class EntityAttributeBaseValues implements Property {
         // Valid attribute names are listed at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html>
         // See also <@link language attribute modifiers>.
         // -->
-        if (attribute.startsWith("attribute_base_value") && attribute.hasParam()) {
-            org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(attribute.getParam().toUpperCase());
-            AttributeInstance instance = ((Attributable) entity.getBukkitEntity()).getAttribute(attr);
-            if (instance == null) {
-                attribute.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+        PropertyParser.<EntityAttributeBaseValues, ElementTag>registerTag(ElementTag.class, "attribute_base_value", (attribute, object) -> {
+            if (!(attribute.hasParam() && attribute.getParamElement().matchesEnum(Attribute.values()))) {
+                attribute.echoError("Invalid entity.attribute_base_value[...] input: must be a valid attribute name.");
                 return null;
             }
-            return new ElementTag(instance.getBaseValue()).getObjectAttribute(attribute.fulfill(1));
-        }
+            Attribute attr = Attribute.valueOf(attribute.getParam().toUpperCase());
+            AttributeInstance instance = object.getAttributable().getAttribute(attr);
+            if (instance == null) {
+                attribute.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + object.entity.getBukkitEntityType().name());
+                return null;
+            }
+            return new ElementTag(instance.getBaseValue());
+        });
 
         // <--[tag]
         // @attribute <EntityTag.attribute_default_value[<attribute>]>
@@ -143,17 +149,19 @@ public class EntityAttributeBaseValues implements Property {
         // Valid attribute names are listed at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html>
         // See also <@link language attribute modifiers>.
         // -->
-        if (attribute.startsWith("attribute_default_value") && attribute.hasParam()) {
-            org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(attribute.getParam().toUpperCase());
-            AttributeInstance instance = ((Attributable) entity.getBukkitEntity()).getAttribute(attr);
-            if (instance == null) {
-                attribute.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+        PropertyParser.<EntityAttributeBaseValues, ElementTag>registerTag(ElementTag.class, "attribute_default_value", (attribute, object) -> {
+            if (!(attribute.hasParam() && attribute.getParamElement().matchesEnum(Attribute.values()))) {
+                attribute.echoError("Invalid entity.attribute_default_value[...] input: must be a valid attribute name.");
                 return null;
             }
-            return new ElementTag(instance.getDefaultValue()).getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+            Attribute attr = Attribute.valueOf(attribute.getParam().toUpperCase());
+            AttributeInstance instance = object.getAttributable().getAttribute(attr);
+            if (instance == null) {
+                attribute.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + object.entity.getBukkitEntityType().name());
+                return null;
+            }
+            return new ElementTag(instance.getDefaultValue());
+        });
     }
 
     @Override
@@ -176,15 +184,20 @@ public class EntityAttributeBaseValues implements Property {
         // -->
         if (mechanism.matches("attribute_base_values") && mechanism.requireObject(MapTag.class)) {
             MapTag input = mechanism.valueAsType(MapTag.class);
-            Attributable ent = (Attributable) entity.getBukkitEntity();
+            Attributable ent = getAttributable();
             for (Map.Entry<StringHolder, ObjectTag> subValue : input.map.entrySet()) {
-                org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(subValue.getKey().str.toUpperCase());
+                Attribute attr = Attribute.valueOf(subValue.getKey().str.toUpperCase());
                 AttributeInstance instance = ent.getAttribute(attr);
                 if (instance == null) {
-                    mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+                    mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntityType().name());
                     continue;
                 }
-                instance.setBaseValue(Double.parseDouble(subValue.getValue().toString()));
+                ElementTag value = subValue.getValue().asElement();
+                if (!value.isDouble()) {
+                    mechanism.echoError("Invalid input '" + value + "': must be a decimal number.");
+                    continue;
+                }
+                instance.setBaseValue(value.asDouble());
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
@@ -35,7 +35,9 @@ public class EntityAttributeModifiers implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityAttributeModifiers((EntityTag) entity);
+        else {
+            return new EntityAttributeModifiers((EntityTag) entity);
+        }
     }
 
     public static final String[] handledMechs = new String[] {
@@ -154,10 +156,7 @@ public class EntityAttributeModifiers implements Property {
     @Override
     public String getPropertyString() {
         MapTag map = getAttributeModifiers();
-        if (map.map.isEmpty()) {
-            return null;
-        }
-        return map.savable();
+        return map.map.isEmpty() ? null : map.savable();
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
@@ -8,12 +8,13 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.core.EscapeTagBase;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.Deprecations;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
 import org.bukkit.attribute.Attributable;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.EquipmentSlot;
@@ -26,21 +27,16 @@ import java.util.UUID;
 public class EntityAttributeModifiers implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Attributable;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof Attributable;
     }
 
     public static EntityAttributeModifiers getFrom(ObjectTag entity) {
         if (!describes(entity)) {
             return null;
         }
-        else {
-            return new EntityAttributeModifiers((EntityTag) entity);
-        }
+        return new EntityAttributeModifiers((EntityTag) entity);
     }
-
-    public static final String[] handledTags = new String[] {
-            "attributes", "attribute_modifiers"
-    };
 
     public static final String[] handledMechs = new String[] {
             "attributes", "attribute_modifiers", "add_attribute_modifiers", "remove_attribute_modifiers"
@@ -61,8 +57,8 @@ public class EntityAttributeModifiers implements Property {
     @Deprecated
     public ListTag getAttributes() {
         ListTag list = new ListTag();
-        for (org.bukkit.attribute.Attribute attribute : org.bukkit.attribute.Attribute.values()) {
-            AttributeInstance instance = ((Attributable) entity.getBukkitEntity()).getAttribute(attribute);
+        for (Attribute attribute : Attribute.values()) {
+            AttributeInstance instance = getAttributable().getAttribute(attribute);
             if (instance == null) {
                 continue;
             }
@@ -85,7 +81,7 @@ public class EntityAttributeModifiers implements Property {
         return result;
     }
 
-    public static AttributeModifier modiferForMap(org.bukkit.attribute.Attribute attr, MapTag map) {
+    public static AttributeModifier modiferForMap(Attribute attr, MapTag map) {
         ObjectTag name = map.getObject("name");
         ObjectTag amount = map.getObject("amount");
         ObjectTag operation = map.getObject("operation");
@@ -99,28 +95,28 @@ public class EntityAttributeModifiers implements Property {
             operationValue = AttributeModifier.Operation.valueOf(operation.toString().toUpperCase());
         }
         catch (IllegalArgumentException ex) {
-            Debug.echoError("Attribute modifier operation '" + operation.toString() + "' does not exist.");
+            Debug.echoError("Attribute modifier operation '" + operation + "' does not exist.");
             return null;
         }
         try {
             idValue = id == null ? UUID.randomUUID() : UUID.fromString(id.toString());
         }
         catch (IllegalArgumentException ex) {
-            Debug.echoError("Attribute modifier ID '" + id.toString() + "' is not a valid UUID.");
+            Debug.echoError("Attribute modifier ID '" + id + "' is not a valid UUID.");
             return null;
         }
         try {
             slotValue = slot == null || CoreUtilities.equalsIgnoreCase(slot.toString(), "any") ? null : EquipmentSlot.valueOf(slot.toString().toUpperCase());
         }
         catch (IllegalArgumentException ex) {
-            Debug.echoError("Attribute modifier slot '" + slot.toString() + "' is not a valid slot.");
+            Debug.echoError("Attribute modifier slot '" + slot + "' is not a valid slot.");
             return null;
         }
         try {
             amountValue = Double.parseDouble(amount.toString());
         }
         catch (NumberFormatException ex) {
-            Debug.echoError("Attribute modifier amount '" + amount.toString() + "' is not a valid decimal number.");
+            Debug.echoError("Attribute modifier amount '" + amount + "' is not a valid decimal number.");
             return null;
         }
         return new AttributeModifier(idValue, name == null ? attr.name() : name.toString(), amountValue, operationValue, slotValue);
@@ -142,13 +138,17 @@ public class EntityAttributeModifiers implements Property {
 
     public MapTag getAttributeModifiers() {
         MapTag map = new MapTag();
-        for (org.bukkit.attribute.Attribute attribute : org.bukkit.attribute.Attribute.values()) {
-            ListTag list = getAttributeModifierList(((Attributable) entity.getBukkitEntity()).getAttribute(attribute));
+        for (Attribute attribute : Attribute.values()) {
+            ListTag list = getAttributeModifierList(getAttributable().getAttribute(attribute));
             if (list != null) {
                 map.putObject(attribute.name(), list);
             }
         }
         return map;
+    }
+    
+    public Attributable getAttributable() {
+        return (Attributable) entity.getBukkitEntity();
     }
 
     @Override
@@ -225,12 +225,7 @@ public class EntityAttributeModifiers implements Property {
     //
     // -->
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.attribute_modifiers>
@@ -243,16 +238,14 @@ public class EntityAttributeModifiers implements Property {
         // This is formatted in a way that can be sent back into the 'attribute_modifiers' mechanism.
         // See also <@link language attribute modifiers>.
         // -->
-        if (attribute.startsWith("attribute_modifiers")) {
-            return getAttributeModifiers().getObjectAttribute(attribute.fulfill(1));
-        }
+        PropertyParser.<EntityAttributeModifiers, MapTag>registerTag(MapTag.class, "attribute_modifiers", (attribute, object) -> {
+            return object.getAttributeModifiers();
+        });
 
-        if (attribute.startsWith("attributes")) {
+        PropertyParser.<EntityAttributeModifiers, ListTag>registerTag(ListTag.class, "attributes", (attribute, object) -> {
             Deprecations.legacyAttributeProperties.warn(attribute.context);
-            return getAttributes().getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+            return object.getAttributes();
+        });
     }
 
     @Override
@@ -276,19 +269,19 @@ public class EntityAttributeModifiers implements Property {
         if (mechanism.matches("attribute_modifiers") && mechanism.requireObject(MapTag.class)) {
             try {
                 MapTag input = mechanism.valueAsType(MapTag.class);
-                Attributable ent = (Attributable) entity.getBukkitEntity();
+                Attributable ent = getAttributable();
                 for (Map.Entry<StringHolder, ObjectTag> subValue : input.map.entrySet()) {
-                    org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(subValue.getKey().str.toUpperCase());
+                    Attribute attr = Attribute.valueOf(subValue.getKey().str.toUpperCase());
                     AttributeInstance instance = ent.getAttribute(attr);
                     if (instance == null) {
-                        mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+                        mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntityType().name());
                         continue;
                     }
                     for (AttributeModifier modifier : instance.getModifiers()) {
                         instance.removeModifier(modifier);
                     }
                     for (ObjectTag listValue : CoreUtilities.objectToList(subValue.getValue(), mechanism.context)) {
-                        instance.addModifier(modiferForMap(attr, (MapTag) listValue));
+                        instance.addModifier(modiferForMap(attr, listValue.asType(MapTag.class, mechanism.context)));
                     }
                 }
             }
@@ -314,16 +307,16 @@ public class EntityAttributeModifiers implements Property {
         if (mechanism.matches("add_attribute_modifiers") && mechanism.requireObject(MapTag.class)) {
             try {
                 MapTag input = mechanism.valueAsType(MapTag.class);
-                Attributable ent = (Attributable) entity.getBukkitEntity();
+                Attributable ent = getAttributable();
                 for (Map.Entry<StringHolder, ObjectTag> subValue : input.map.entrySet()) {
-                    org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(subValue.getKey().str.toUpperCase());
+                    Attribute attr = Attribute.valueOf(subValue.getKey().str.toUpperCase());
                     AttributeInstance instance = ent.getAttribute(attr);
                     if (instance == null) {
-                        mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+                        mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntityType().name());
                         continue;
                     }
                     for (ObjectTag listValue : CoreUtilities.objectToList(subValue.getValue(), mechanism.context)) {
-                        instance.addModifier(modiferForMap(attr, (MapTag) listValue));
+                        instance.addModifier(modiferForMap(attr, listValue.asType(MapTag.class, mechanism.context)));
                     }
                 }
             }
@@ -348,14 +341,14 @@ public class EntityAttributeModifiers implements Property {
         // -->
         if (mechanism.matches("remove_attribute_modifiers") && mechanism.requireObject(ListTag.class)) {
             ArrayList<String> inputList = new ArrayList<>(mechanism.valueAsType(ListTag.class));
-            Attributable ent = (Attributable) entity.getBukkitEntity();
+            Attributable ent = getAttributable();
             for (String toRemove : new ArrayList<>(inputList)) {
-                if (new ElementTag(toRemove).matchesEnum(org.bukkit.attribute.Attribute.values())) {
+                if (new ElementTag(toRemove).matchesEnum(Attribute.values())) {
                     inputList.remove(toRemove);
-                    org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(toRemove.toUpperCase());
+                    Attribute attr = Attribute.valueOf(toRemove.toUpperCase());
                     AttributeInstance instance = ent.getAttribute(attr);
                     if (instance == null) {
-                        mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+                        mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntityType().name());
                         continue;
                     }
                     for (AttributeModifier modifier : instance.getModifiers()) {
@@ -365,7 +358,7 @@ public class EntityAttributeModifiers implements Property {
             }
             for (String toRemove : inputList) {
                 UUID id = UUID.fromString(toRemove);
-                for (org.bukkit.attribute.Attribute attr : org.bukkit.attribute.Attribute.values()) {
+                for (Attribute attr : Attribute.values()) {
                     AttributeInstance instance = ent.getAttribute(attr);
                     if (instance == null) {
                         continue;
@@ -382,14 +375,14 @@ public class EntityAttributeModifiers implements Property {
 
         if (mechanism.matches("attributes") && mechanism.hasValue()) {
             Deprecations.legacyAttributeProperties.warn(mechanism.context);
-            Attributable ent = (Attributable) entity.getBukkitEntity();
+            Attributable ent = getAttributable();
             ListTag list = mechanism.valueAsType(ListTag.class);
             for (String str : list) {
                 List<String> subList = CoreUtilities.split(str, '/');
-                org.bukkit.attribute.Attribute attr = org.bukkit.attribute.Attribute.valueOf(EscapeTagBase.unEscape(subList.get(0)).toUpperCase());
+                Attribute attr = Attribute.valueOf(EscapeTagBase.unEscape(subList.get(0)).toUpperCase());
                 AttributeInstance instance = ent.getAttribute(attr);
                 if (instance == null) {
-                    mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntity().getType().name());
+                    mechanism.echoError("Attribute " + attr.name() + " is not applicable to entity of type " + entity.getBukkitEntityType().name());
                     continue;
                 }
                 instance.setBaseValue(Double.parseDouble(subList.get(1)));

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAware.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAware.java
@@ -11,14 +11,17 @@ import org.bukkit.entity.Mob;
 public class EntityAware implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Mob;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).isMobType();
     }
 
     public static EntityAware getFrom(ObjectTag entity) {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityAware((EntityTag) entity);
+        else {
+            return new EntityAware((EntityTag) entity);
+        }
     }
 
     public static final String[] handledMechs = new String[] {
@@ -33,12 +36,16 @@ public class EntityAware implements Property {
 
     @Override
     public String getPropertyString() {
-        return String.valueOf(((Mob) entity.getBukkitEntity()).isAware());
+        return String.valueOf(getMob().isAware());
     }
 
     @Override
     public String getPropertyId() {
         return "is_aware";
+    }
+
+    public Mob getMob() {
+        return (Mob) entity.getBukkitEntity();
     }
 
     public static void registerTags() {
@@ -54,7 +61,7 @@ public class EntityAware implements Property {
         // Similar to <@link tag EntityTag.has_ai>, except allows the entity to be moved by gravity, being pushed or attacked, etc.
         // -->
         PropertyParser.<EntityAware, ElementTag>registerTag(ElementTag.class, "is_aware", (attribute, entity) -> {
-            return new ElementTag(((Mob) entity.entity.getBukkitEntity()).isAware());
+            return new ElementTag(entity.getMob().isAware());
         });
     }
 
@@ -73,7 +80,7 @@ public class EntityAware implements Property {
         // <EntityTag.is_aware>
         // -->
         if (mechanism.matches("is_aware") && mechanism.requireBoolean()) {
-            ((Mob) entity.getBukkitEntity()).setAware(mechanism.getValue().asBoolean());
+            getMob().setAware(mechanism.getValue().asBoolean());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBasePlate.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBasePlate.java
@@ -19,7 +19,9 @@ public class EntityBasePlate implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityBasePlate((EntityTag) entity);
+        else {
+            return new EntityBasePlate((EntityTag) entity);
+        }
     }
 
     public static final String[] handledMechs = new String[] {
@@ -38,10 +40,7 @@ public class EntityBasePlate implements Property {
 
     @Override
     public String getPropertyString() {
-        if (getStand().hasBasePlate()) {
-            return null;
-        }
-        return "false";
+        return getStand().hasBasePlate() ? null : "false";
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBasePlate.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBasePlate.java
@@ -5,28 +5,22 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.EntityType;
 
 public class EntityBasePlate implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.ARMOR_STAND;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof ArmorStand;
     }
 
     public static EntityBasePlate getFrom(ObjectTag entity) {
         if (!describes(entity)) {
             return null;
         }
-        else {
-            return new EntityBasePlate((EntityTag) entity);
-        }
+        return new EntityBasePlate((EntityTag) entity);
     }
-
-    public static final String[] handledTags = new String[] {
-            "base_plate"
-    };
 
     public static final String[] handledMechs = new String[] {
             "base_plate"
@@ -38,14 +32,16 @@ public class EntityBasePlate implements Property {
 
     EntityTag dentity;
 
+    public ArmorStand getStand() {
+        return (ArmorStand) dentity.getBukkitEntity();
+    }
+
     @Override
     public String getPropertyString() {
-        if (((ArmorStand) dentity.getBukkitEntity()).hasBasePlate()) {
+        if (getStand().hasBasePlate()) {
             return null;
         }
-        else {
-            return "false";
-        }
+        return "false";
     }
 
     @Override
@@ -53,12 +49,7 @@ public class EntityBasePlate implements Property {
         return "base_plate";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.base_plate>
@@ -68,12 +59,9 @@ public class EntityBasePlate implements Property {
         // @description
         // If the entity is an armor stand, returns whether the armor stand has a base plate.
         // -->
-        if (attribute.startsWith("base_plate")) {
-            return new ElementTag(((ArmorStand) dentity.getBukkitEntity()).hasBasePlate())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityBasePlate, ElementTag>registerTag(ElementTag.class, "base_plate", (attribute, object) -> {
+            return new ElementTag(object.getStand().hasBasePlate());
+        });
     }
 
     @Override
@@ -89,7 +77,7 @@ public class EntityBasePlate implements Property {
         // <EntityTag.base_plate>
         // -->
         if (mechanism.matches("base_plate") && mechanism.requireBoolean()) {
-            ((ArmorStand) dentity.getBukkitEntity()).setBasePlate(mechanism.getValue().asBoolean());
+            getStand().setBasePlate(mechanism.getValue().asBoolean());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBeamTarget.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBeamTarget.java
@@ -20,7 +20,9 @@ public class EntityBeamTarget implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityBeamTarget((EntityTag) entity);
+        else {
+            return new EntityBeamTarget((EntityTag) entity);
+        }
     }
 
     public static final String[] handledMechs = new String[] {
@@ -36,10 +38,7 @@ public class EntityBeamTarget implements Property {
     @Override
     public String getPropertyString() {
         Location beamTarget = getCrystal().getBeamTarget();
-        if (beamTarget != null) {
-            return new LocationTag(beamTarget).identify();
-        }
-        return null;
+        return beamTarget != null ? new LocationTag(beamTarget).identify() : null;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoatType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoatType.java
@@ -20,7 +20,9 @@ public class EntityBoatType implements Property {
         if (!describes(object)) {
             return null;
         }
-        return new EntityBoatType((EntityTag) object);
+        else {
+            return new EntityBoatType((EntityTag) object);
+        }
     }
 
     public static final String[] handledMechs = new String[] {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBodyArrows.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBodyArrows.java
@@ -19,7 +19,9 @@ public class EntityBodyArrows implements Property {
         if (!describes(object)) {
             return null;
         }
-        return new EntityBodyArrows((EntityTag) object);
+        else {
+            return new EntityBodyArrows((EntityTag) object);
+        }
     }
 
     public static final String[] handledMechs = new String[] {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBodyArrows.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBodyArrows.java
@@ -6,25 +6,21 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 public class EntityBodyArrows implements Property {
+
     public static boolean describes(ObjectTag object) {
-        return object instanceof EntityTag && ((EntityTag) object).isLivingEntity();
+        return object instanceof EntityTag
+                && ((EntityTag) object).isLivingEntity();
     }
 
     public static EntityBodyArrows getFrom(ObjectTag object) {
         if (!describes(object)) {
             return null;
         }
-        else {
-            return new EntityBodyArrows((EntityTag) object);
-        }
+        return new EntityBodyArrows((EntityTag) object);
     }
-
-    public static final String[] handledTags = new String[] {
-            "body_arrows"
-    };
 
     public static final String[] handledMechs = new String[] {
             "body_arrows", "clear_body_arrows"
@@ -55,12 +51,7 @@ public class EntityBodyArrows implements Property {
         return "body_arrows";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.body_arrows>
@@ -71,12 +62,9 @@ public class EntityBodyArrows implements Property {
         // Returns the number of arrows stuck in the entity's body.
         // Note: Body arrows will only be visible for players or player-type npcs.
         // -->
-        if (attribute.startsWith("body_arrows")) {
-            return new ElementTag(getBodyArrows())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityBodyArrows, ElementTag>registerTag(ElementTag.class, "body_arrows", (attribute, object) -> {
+            return new ElementTag(object.getBodyArrows());
+        });
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoundingBox.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoundingBox.java
@@ -8,7 +8,7 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 import java.util.HashSet;
 import java.util.List;
@@ -25,14 +25,8 @@ public class EntityBoundingBox implements Property {
         if (!describes(object)) {
             return null;
         }
-        else {
-            return new EntityBoundingBox((EntityTag) object);
-        }
+        return new EntityBoundingBox((EntityTag) object);
     }
-
-    public static final String[] handledTags = new String[] {
-            "bounding_box"
-    };
 
     public static final String[] handledMechs = new String[] {
             "bounding_box"
@@ -74,11 +68,7 @@ public class EntityBoundingBox implements Property {
         return "bounding_box";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.bounding_box>
@@ -88,11 +78,9 @@ public class EntityBoundingBox implements Property {
         // @description
         // Returns the collision bounding box of the entity in the format "<low>|<high>", essentially a cuboid with decimals.
         // -->
-        if (attribute.startsWith("bounding_box")) {
-            return getBoundingBox().getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityBoundingBox, ListTag>registerTag(ListTag.class, "bounding_box", (attribute, object) -> {
+            return object.getBoundingBox();
+        });
     }
 
     @Override
@@ -107,7 +95,7 @@ public class EntityBoundingBox implements Property {
         // @tags
         // <EntityTag.bounding_box>
         // -->
-        if (mechanism.matches("bounding_box")) {
+        if (mechanism.matches("bounding_box") && mechanism.requireObject(ListTag.class)) {
             if (entity.isCitizensNPC()) {
                 // TODO: Allow editing NPC boxes properly?
                 return;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoundingBox.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoundingBox.java
@@ -25,7 +25,9 @@ public class EntityBoundingBox implements Property {
         if (!describes(object)) {
             return null;
         }
-        return new EntityBoundingBox((EntityTag) object);
+        else {
+            return new EntityBoundingBox((EntityTag) object);
+        }
     }
 
     public static final String[] handledMechs = new String[] {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AgeCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AgeCommand.java
@@ -103,10 +103,10 @@ public class AgeCommand extends AbstractCommand {
                     EntityAge property = EntityAge.getFrom(entity);
                     if (ageType != null) {
                         if (ageType.equals(AgeType.BABY)) {
-                            property.setBaby(true);
+                            property.setAge(-24000);
                         }
                         else {
-                            property.setBaby(false);
+                            property.setAge(0);
                         }
                     }
                     else {

--- a/v1_14/src/main/java/com/denizenscript/denizen/nms/v1_14/helpers/EntityHelperImpl.java
+++ b/v1_14/src/main/java/com/denizenscript/denizen/nms/v1_14/helpers/EntityHelperImpl.java
@@ -150,16 +150,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public double getArrowDamage(Entity arrow) {
-        return ((Arrow) arrow).getDamage();
-    }
-
-    @Override
-    public void setArrowDamage(Entity arrow, double damage) {
-        ((Arrow) arrow).setDamage(damage);
-    }
-
-    @Override
     public void setRiptide(Entity entity, boolean state) {
         ((CraftLivingEntity) entity).getHandle().q(state ? 0 : 1);
     }

--- a/v1_15/src/main/java/com/denizenscript/denizen/nms/v1_15/helpers/EntityHelperImpl.java
+++ b/v1_15/src/main/java/com/denizenscript/denizen/nms/v1_15/helpers/EntityHelperImpl.java
@@ -149,16 +149,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public double getArrowDamage(Entity arrow) {
-        return ((Arrow) arrow).getDamage();
-    }
-
-    @Override
-    public void setArrowDamage(Entity arrow, double damage) {
-        ((Arrow) arrow).setDamage(damage);
-    }
-
-    @Override
     public void setRiptide(Entity entity, boolean state) {
         ((CraftLivingEntity) entity).getHandle().r(state ? 0 : 1);
     }

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
@@ -149,16 +149,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public double getArrowDamage(Entity arrow) {
-        return ((Arrow) arrow).getDamage();
-    }
-
-    @Override
-    public void setArrowDamage(Entity arrow, double damage) {
-        ((Arrow) arrow).setDamage(damage);
-    }
-
-    @Override
     public void setRiptide(Entity entity, boolean state) {
         ((CraftLivingEntity) entity).getHandle().r(state ? 0 : 1);
     }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -187,16 +187,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public double getArrowDamage(Entity arrow) {
-        return ((Arrow) arrow).getDamage();
-    }
-
-    @Override
-    public void setArrowDamage(Entity arrow, double damage) {
-        ((Arrow) arrow).setDamage(damage);
-    }
-
-    @Override
     public void setRiptide(Entity entity, boolean state) {
         ((CraftLivingEntity) entity).getHandle().startAutoSpinAttack(state ? 0 : 1);
     }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -187,16 +187,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public double getArrowDamage(Entity arrow) {
-        return ((Arrow) arrow).getDamage();
-    }
-
-    @Override
-    public void setArrowDamage(Entity arrow, double damage) {
-        ((Arrow) arrow).setDamage(damage);
-    }
-
-    @Override
     public void setRiptide(Entity entity, boolean state) {
         ((CraftLivingEntity) entity).getHandle().startAutoSpinAttack(state ? 0 : 1);
     }


### PR DESCRIPTION
## Properties Updated

- `EntityAge`
- `EntityAI`
- `EntityAnger`
- `EntityArrowDamage`
- `EntityAttributeBaseValues`
- `EntitityAttributeModifiers`
- `EntityBasePlate`
- `EntityBeamTarget`
- `EntityBoatType`
- `EntityBodyArrows`
- `EntityBoundingBox`
- `EntityEquipment`

## Changes

- All above properties were updated to new tag registration, had require checks added to mechanisms where necessary, and `get*Thing*()` / `is*Thing*()` methods for cleaner-looking code (I.e. `getCreeper()` instead of `((Creeper) entity.getBukkitEntity())`).
- Arrow Damage controls moved from `EntityHelper` into the property, due to being the same on all supported versions.
- `setBaby()` removed from `EntityAge`, due to zombies supporting `setAge()` now.
- Adds extra checks / error messages to a few mechanisms/tags
- Several other minor changes and code updates 