### PR TITLE
Furnace smelts event - support for all blocks

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -48,6 +48,7 @@ public class ScriptEventRegistry {
         // Block events
         ScriptEvent.registerScriptEvent(BlockBuiltScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockBurnsScriptEvent.class);
+        ScriptEvent.registerScriptEvent(BlockCooksSmeltsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockDestroyedByExplosionEvent.class);
         ScriptEvent.registerScriptEvent(BlockDispensesScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockExplodesScriptEvent.class);
@@ -62,7 +63,6 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(BrewsScriptEvent.class);
         ScriptEvent.registerScriptEvent(CauldronLevelChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(FurnaceBurnsItemScriptEvent.class);
-        ScriptEvent.registerScriptEvent(BlockCooksSmeltsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(LeafDecaysScriptEvent.class);
         ScriptEvent.registerScriptEvent(LiquidLevelChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(LiquidSpreadScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -13,8 +13,6 @@ import com.denizenscript.denizen.events.server.*;
 import com.denizenscript.denizen.events.vehicle.*;
 import com.denizenscript.denizen.events.world.*;
 import com.denizenscript.denizen.utilities.depends.Depends;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.events.ScriptEventCouldMatcher;
 
@@ -64,7 +62,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(BrewsScriptEvent.class);
         ScriptEvent.registerScriptEvent(CauldronLevelChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(FurnaceBurnsItemScriptEvent.class);
-        ScriptEvent.registerScriptEvent(FurnaceSmeltsItemScriptEvent.class);
+        ScriptEvent.registerScriptEvent(BlockCooksSmeltsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(LeafDecaysScriptEvent.class);
         ScriptEvent.registerScriptEvent(LiquidLevelChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(LiquidSpreadScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockCooksSmeltsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockCooksSmeltsItemScriptEvent.java
@@ -13,8 +13,7 @@ public class BlockCooksSmeltsItemScriptEvent extends BukkitScriptEvent implement
 
     // <--[event]
     // @Events
-    // <block> smelts <item> (into <item>)
-    // <block> cooks <item> (into <item>)
+    // <block> cooks|smelts <item> (into <item>)
     //
     // @Cancellable true
     //


### PR DESCRIPTION
## Changes

- Uses `org.bukkit.event.block.BlockCookEvent` instead of `org.bukkit.event.inventory.FurnaceSmeltEvent`, to support all smelting/cooking.
- Changes the event line to `<block> smelts <item> (into <item>)`.
- Adds an alternate event line with `cooks` instead of `smelts`, as `on campfire smelts beef` doesn't really make sense.

## Notes
Not sure if they way I listed the alternate event line was correct, should it be something like `<block> smelts|cooks <item> (into <item>)`?