### PR TITLE
Entity Properties Update - Part 2

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -302,12 +302,6 @@ public abstract class EntityHelper {
 
     public abstract void setBoundingBox(Entity entity, BoundingBox boundingBox);
 
-    public abstract boolean isChestedHorse(Entity horse);
-
-    public abstract boolean isCarryingChest(Entity horse);
-
-    public abstract void setCarryingChest(Entity horse, boolean carrying);
-
     public List<Player> getPlayersThatSee(Entity entity) {
         throw new UnsupportedOperationException();
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArms.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArms.java
@@ -8,7 +8,6 @@ import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.ArmorStand;
 
-
 public class EntityArms implements Property {
 
     public static boolean describes(ObjectTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCanJoinRaid.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCanJoinRaid.java
@@ -11,7 +11,8 @@ import org.bukkit.entity.Raider;
 public class EntityCanJoinRaid implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Raider;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof Raider;
     }
 
     public static EntityCanJoinRaid getFrom(ObjectTag entity) {
@@ -35,12 +36,16 @@ public class EntityCanJoinRaid implements Property {
 
     @Override
     public String getPropertyString() {
-        return ((Raider) entity.getBukkitEntity()).isCanJoinRaid() ? "true" : "false";
+        return String.valueOf(getRaider().isCanJoinRaid());
     }
 
     @Override
     public String getPropertyId() {
         return "can_join_raid";
+    }
+    
+    public Raider getRaider() {
+        return (Raider) entity.getBukkitEntity();
     }
 
     public static void registerTags() {
@@ -54,7 +59,7 @@ public class EntityCanJoinRaid implements Property {
         // If the entity is raider mob (like a pillager), returns whether the entity is allowed to join active raids.
         // -->
         PropertyParser.<EntityCanJoinRaid, ElementTag>registerTag(ElementTag.class, "can_join_raid", (attribute, object) -> {
-            return new ElementTag(((Raider) object.entity.getBukkitEntity()).isCanJoinRaid());
+            return new ElementTag(object.getRaider().isCanJoinRaid());
         });
     }
 
@@ -71,7 +76,7 @@ public class EntityCanJoinRaid implements Property {
         // <EntityTag.can_join_raid>
         // -->
         if (mechanism.matches("can_join_raid") && mechanism.requireBoolean()) {
-            ((Raider) entity.getBukkitEntity()).setCanJoinRaid(mechanism.getValue().asBoolean());
+            getRaider().setCanJoinRaid(mechanism.getValue().asBoolean());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCanJoinRaid.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCanJoinRaid.java
@@ -36,7 +36,7 @@ public class EntityCanJoinRaid implements Property {
 
     @Override
     public String getPropertyString() {
-        return String.valueOf(getRaider().isCanJoinRaid());
+        return getRaider().isCanJoinRaid() ? "true" : "false";
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityChestCarrier.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityChestCarrier.java
@@ -1,18 +1,18 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
-import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.entity.ChestedHorse;
 
 public class EntityChestCarrier implements Property {
 
     public static boolean describes(ObjectTag entity) {
         return entity instanceof EntityTag
-                && NMSHandler.getEntityHelper().isChestedHorse(((EntityTag) entity).getBukkitEntity());
+                && ((EntityTag) entity).getBukkitEntity() instanceof ChestedHorse;
     }
 
     public static EntityChestCarrier getFrom(ObjectTag entity) {
@@ -23,10 +23,6 @@ public class EntityChestCarrier implements Property {
             return new EntityChestCarrier((EntityTag) entity);
         }
     }
-
-    public static final String[] handledTags = new String[] {
-            "carries_chest"
-    };
 
     public static final String[] handledMechs = new String[] {
             "carries_chest"
@@ -40,7 +36,7 @@ public class EntityChestCarrier implements Property {
 
     @Override
     public String getPropertyString() {
-        return NMSHandler.getEntityHelper().isCarryingChest(entity.getBukkitEntity()) ? "true" : "false";
+        return String.valueOf(getChestedHorse().isCarryingChest());
     }
 
     @Override
@@ -48,12 +44,11 @@ public class EntityChestCarrier implements Property {
         return "carries_chest";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public ChestedHorse getChestedHorse() {
+        return (ChestedHorse) entity.getBukkitEntity();
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.carries_chest>
@@ -61,14 +56,11 @@ public class EntityChestCarrier implements Property {
         // @mechanism EntityTag.carries_chest
         // @group properties
         // @description
-        // If the entity is a horse, returns whether it is carrying a chest.
+        // Returns whether a horse-like entity is carrying a chest.
         // -->
-        if (attribute.startsWith("carries_chest")) {
-            return new ElementTag(NMSHandler.getEntityHelper().isCarryingChest(entity.getBukkitEntity()))
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityChestCarrier, ElementTag>registerTag(ElementTag.class, "carries_chest", (attribute, object) -> {
+            return new ElementTag(object.getChestedHorse().isCarryingChest());
+        });
     }
 
     @Override
@@ -79,12 +71,12 @@ public class EntityChestCarrier implements Property {
         // @name carries_chest
         // @input ElementTag(Boolean)
         // @description
-        // Changes whether a Horse carries a chest.
+        // Sets whether a horse-like entity is carrying a chest.
         // @tags
         // <EntityTag.carries_chest>
         // -->
         if (mechanism.matches("carries_chest") && mechanism.requireBoolean()) {
-            NMSHandler.getEntityHelper().setCarryingChest(entity.getBukkitEntity(), mechanism.getValue().asBoolean());
+            getChestedHorse().setCarryingChest(mechanism.getValue().asBoolean());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -19,11 +19,11 @@ import java.util.Arrays;
 
 public class EntityColor implements Property {
 
-    public static boolean describes(ObjectTag object) {
-        if (!(object instanceof EntityTag)) {
+    public static boolean describes(ObjectTag entity) {
+        if (!(entity instanceof EntityTag)) {
             return false;
         }
-        EntityType type = ((EntityTag) object).getBukkitEntityType();
+        EntityType type = ((EntityTag) entity).getBukkitEntityType();
         return type == EntityType.SHEEP ||
                 type == EntityType.HORSE ||
                 type == EntityType.WOLF ||

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -381,11 +381,9 @@ public class EntityColor implements Property {
             else if (type == EntityType.ARROW && mechanism.requireObject(ColorTag.class)) {
                 ((Arrow) colored.getBukkitEntity()).setColor(mechanism.valueAsType(ColorTag.class).getColor());
             }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17) && MultiVersionHelper1_17.colorIsApplicable(type)) {
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17)
+                    && MultiVersionHelper1_17.colorIsApplicable(type)) {
                 MultiVersionHelper1_17.setColor(colored.getBukkitEntity(), mechanism);
-            }
-            else { // Should never happen
-                mechanism.echoError("Could not apply color '" + mechanism.getValue().toString() + "' to entity of type " + type.name() + ".");
             }
         }
     }

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
@@ -10,7 +10,6 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import net.minecraft.server.v1_16_R3.*;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
@@ -601,23 +600,6 @@ public class EntityHelperImpl extends EntityHelper {
         Vector low = boundingBox.getLow();
         Vector high = boundingBox.getHigh();
         ((CraftEntity) entity).getHandle().a(new AxisAlignedBB(low.getX(), low.getY(), low.getZ(), high.getX(), high.getY(), high.getZ()));
-    }
-
-    @Override
-    public boolean isChestedHorse(Entity horse) {
-        return horse instanceof ChestedHorse;
-    }
-
-    @Override
-    public boolean isCarryingChest(Entity horse) {
-        return horse instanceof ChestedHorse && ((ChestedHorse) horse).isCarryingChest();
-    }
-
-    @Override
-    public void setCarryingChest(Entity horse, boolean carrying) {
-        if (horse instanceof ChestedHorse) {
-            ((ChestedHorse) horse).setCarryingChest(carrying);
-        }
     }
 
     @Override

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -42,7 +42,6 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
@@ -637,23 +636,6 @@ public class EntityHelperImpl extends EntityHelper {
         Vector low = boundingBox.getLow();
         Vector high = boundingBox.getHigh();
         ((CraftEntity) entity).getHandle().setBoundingBox(new AABB(low.getX(), low.getY(), low.getZ(), high.getX(), high.getY(), high.getZ()));
-    }
-
-    @Override
-    public boolean isChestedHorse(Entity horse) {
-        return horse instanceof ChestedHorse;
-    }
-
-    @Override
-    public boolean isCarryingChest(Entity horse) {
-        return horse instanceof ChestedHorse && ((ChestedHorse) horse).isCarryingChest();
-    }
-
-    @Override
-    public void setCarryingChest(Entity horse, boolean carrying) {
-        if (horse instanceof ChestedHorse) {
-            ((ChestedHorse) horse).setCarryingChest(carrying);
-        }
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -42,7 +42,6 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
@@ -637,23 +636,6 @@ public class EntityHelperImpl extends EntityHelper {
         Vector low = boundingBox.getLow();
         Vector high = boundingBox.getHigh();
         ((CraftEntity) entity).getHandle().setBoundingBox(new AABB(low.getX(), low.getY(), low.getZ(), high.getX(), high.getY(), high.getZ()));
-    }
-
-    @Override
-    public boolean isChestedHorse(Entity horse) {
-        return horse instanceof ChestedHorse;
-    }
-
-    @Override
-    public boolean isCarryingChest(Entity horse) {
-        return horse instanceof ChestedHorse && ((ChestedHorse) horse).isCarryingChest();
-    }
-
-    @Override
-    public void setCarryingChest(Entity horse, boolean carrying) {
-        if (horse instanceof ChestedHorse) {
-            ((ChestedHorse) horse).setCarryingChest(carrying);
-        }
     }
 
     @Override


### PR DESCRIPTION
## Properties Updated
`EntityColor`
`EntityCanJoinRaid`
`EntityChestCarrier`

## Changes

- All above properties were updated to new tag registration, had require checks added to mechanisms where necessary, and `get*Thing*()` methods for cleaner-looking code (I.e. `getCreeper()` instead of `((Creeper) entity.getBukkitEntity())`).
`EntityColor` does not have `get/is*Thing*` methods due to the large amount of applicable entity types.
- Chested Horse controls moved from EntityHelper into the property, due to being the same on all supported versions.
- Adds extra checks / error messages to a few mechanisms/tags.
- `EntityColor` changed to use `switch/case` instead of an `if/else` chain