### PR TITLE
Add player receives actionbar event

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -193,6 +193,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerPreparesAnvilCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesEnchantScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerQuitsScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerReceivesActionbarScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerReceivesCommandsScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerReceivesMessageScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerRespawnsScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerReceivesActionbarScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerReceivesActionbarScriptEvent.java
@@ -1,0 +1,46 @@
+package com.denizenscript.denizen.events.player;
+
+public class PlayerReceivesActionbarScriptEvent extends PlayerReceivesMessageScriptEvent {
+
+    // <--[event]
+    // @Events
+    // player receives actionbar
+    //
+    // @Regex ^on player receives actionbar$
+    //
+    // @Group Player
+    //
+    // @Cancellable true
+    //
+    // @Warning Triggering new actionbar messages in this event will cause it to re-fire.
+    //
+    // @Triggers when a player receives any actionbar from the server.
+    //
+    // @Context
+    // <context.message> returns an ElementTag of the actionbar.
+    // <context.raw_json> returns an ElementTag of the raw JSON used for the actionbar.
+    //
+    // @Determine
+    // "MESSAGE:" + ElementTag to change the actionbar.
+    // "RAW_JSON:" + ElementTag to change the JSON used for the actionbar.
+    //
+    // @Player Always.
+    //
+    // -->
+
+    public PlayerReceivesActionbarScriptEvent() {
+        instance = this;
+    }
+
+    public static PlayerReceivesActionbarScriptEvent instance;
+
+    @Override
+    public boolean couldMatch(ScriptPath path) {
+        return path.eventLower.startsWith("player receives actionbar");
+    }
+
+    @Override
+    public String getName() {
+        return "PlayerReceivesActionbar";
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerReceivesActionbarScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerReceivesActionbarScriptEvent.java
@@ -33,6 +33,7 @@ public class PlayerReceivesActionbarScriptEvent extends PlayerReceivesMessageScr
     }
 
     public static PlayerReceivesActionbarScriptEvent instance;
+    public boolean modified;
 
     @Override
     public boolean couldMatch(ScriptPath path) {

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/packets/PacketOutChat.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/packets/PacketOutChat.java
@@ -2,6 +2,10 @@ package com.denizenscript.denizen.nms.interfaces.packets;
 
 public interface PacketOutChat {
 
+    boolean isSystem();
+
+    boolean isActionbar();
+
     int getPosition();
 
     String getMessage();

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/impl/network/packets/PacketOutChatImpl.java
@@ -45,6 +45,16 @@ public class PacketOutChatImpl implements PacketOutChat {
     }
 
     @Override
+    public boolean isSystem() {
+        return position == ChatMessageType.SYSTEM;
+    }
+
+    @Override
+    public boolean isActionbar() {
+        return position == ChatMessageType.GAME_INFO;
+    }
+
+    @Override
     public int getPosition() {
         return position.ordinal();
     }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.nms.v1_17.impl.network.handlers;
 
 import com.denizenscript.denizen.events.player.PlayerHearsSoundScriptEvent;
+import com.denizenscript.denizen.events.player.PlayerReceivesActionbarScriptEvent;
 import com.denizenscript.denizen.nms.abstracts.BlockLight;
 import com.denizenscript.denizen.nms.v1_17.Handler;
 import com.denizenscript.denizen.nms.v1_17.ReflectionMappingsInfo;
@@ -22,6 +23,7 @@ import com.denizenscript.denizen.utilities.entity.EntityAttachmentHelper;
 import com.denizenscript.denizen.utilities.entity.HideEntitiesHelper;
 import com.denizenscript.denizen.utilities.packets.DenizenPacketHandler;
 import com.denizenscript.denizen.utilities.packets.HideParticles;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.mojang.datafixers.util.Pair;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -31,6 +33,7 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.SectionPos;
@@ -248,6 +251,7 @@ public class DenizenNetworkManagerImpl extends Connection {
             || processMirrorForPacket(packet)
             || processParticlesForPacket(packet)
             || processSoundPacket(packet)
+            || processActionbarPacket(packet, genericfuturelistener)
             || processDisguiseForPacket(packet, genericfuturelistener)
             || processMetadataChangesForPacket(packet, genericfuturelistener)
             || processEquipmentForPacket(packet, genericfuturelistener)
@@ -256,6 +260,33 @@ public class DenizenNetworkManagerImpl extends Connection {
         }
         processBlockLightForPacket(packet);
         oldManager.send(packet, genericfuturelistener);
+    }
+
+    public boolean processActionbarPacket(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
+        if (!PlayerReceivesActionbarScriptEvent.instance.loaded) {
+            return false;
+        }
+        if (packet instanceof ClientboundSetActionBarTextPacket) {
+            ClientboundSetActionBarTextPacket actionbarPacket = (ClientboundSetActionBarTextPacket) packet;
+            PlayerReceivesActionbarScriptEvent event = PlayerReceivesActionbarScriptEvent.instance;
+            Component baseComponent = actionbarPacket.getText();
+            event.message = new ElementTag(FormattedTextHelper.stringify(Handler.componentToSpigot(baseComponent), ChatColor.WHITE));
+            event.rawJson = new ElementTag(Component.Serializer.toJson(baseComponent));
+            event.system = new ElementTag(false);
+            event.player = PlayerTag.mirrorBukkitPlayer(player.getBukkitEntity());
+            event.modifyMessage = (msg) -> event.message = new ElementTag(msg);
+            event.modifyRawJson = (json) -> event.message = new ElementTag(FormattedTextHelper.stringify(ComponentSerializer.parse(json), ChatColor.WHITE));
+            event.modifyCancellation = (c) -> event.cancelled = c;
+            event.cancelled = false;
+            event.fire();
+            if (!event.cancelled) {
+                Component component = Handler.componentToNMS(FormattedTextHelper.parse(event.message.asString(), ChatColor.WHITE));
+                ClientboundSetActionBarTextPacket newPacket = new ClientboundSetActionBarTextPacket(component);
+                oldManager.send(newPacket, genericfuturelistener);
+            }
+            return true;
+        }
+        return false;
     }
 
     public boolean processSoundPacket(Packet<?> packet) {

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/network/packets/PacketOutChatImpl.java
@@ -44,6 +44,16 @@ public class PacketOutChatImpl implements PacketOutChat {
     }
 
     @Override
+    public boolean isSystem() {
+        return position == ChatType.SYSTEM;
+    }
+
+    @Override
+    public boolean isActionbar() {
+        return position == ChatType.GAME_INFO;
+    }
+
+    @Override
     public int getPosition() {
         return position.ordinal();
     }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -319,17 +319,27 @@ public class DenizenNetworkManagerImpl extends Connection {
             event.rawJson = new ElementTag(Component.Serializer.toJson(baseComponent));
             event.system = new ElementTag(false);
             event.player = PlayerTag.mirrorBukkitPlayer(player.getBukkitEntity());
-            event.modifyMessage = (msg) -> event.message = new ElementTag(msg);
-            event.modifyRawJson = (json) -> event.message = new ElementTag(FormattedTextHelper.stringify(ComponentSerializer.parse(json), ChatColor.WHITE));
+            event.modifyMessage = (msg) -> {
+                event.message = new ElementTag(msg);
+                event.modified = true;
+            };
+            event.modifyRawJson = (json) -> {
+                event.message = new ElementTag(FormattedTextHelper.stringify(ComponentSerializer.parse(json), ChatColor.WHITE));
+                event.modified = true;
+            };
             event.modifyCancellation = (c) -> event.cancelled = c;
             event.cancelled = false;
+            event.modified = false;
             event.fire();
-            if (!event.cancelled) {
+            if (event.cancelled) {
+                return true;
+            }
+            if (event.modified) {
                 Component component = Handler.componentToNMS(FormattedTextHelper.parse(event.message.asString(), ChatColor.WHITE));
                 ClientboundSetActionBarTextPacket newPacket = new ClientboundSetActionBarTextPacket(component);
                 oldManager.send(newPacket, genericfuturelistener);
+                return true;
             }
-            return true;
         }
         return false;
     }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/network/packets/PacketOutChatImpl.java
@@ -44,6 +44,16 @@ public class PacketOutChatImpl implements PacketOutChat {
     }
 
     @Override
+    public boolean isSystem() {
+        return position == ChatType.SYSTEM;
+    }
+
+    @Override
+    public boolean isActionbar() {
+        return position == ChatType.GAME_INFO;
+    }
+
+    @Override
     public int getPosition() {
         return position.ordinal();
     }


### PR DESCRIPTION
Tested via:
```denizenscript
my_events:
  type: world
  events:
    on player receives actionbar:
      - announce to_console "Player <player.name> received actionbar: <context.message>"
      - announce to_console "Raw json: <context.raw_json>"
      #- determine cancelled
      #- determine 'raw_json:{"text":"determined raw json","color":"#61C2FF"}'
      - determine "message:<&color[#ffa3e2]><&l>[MY_PREFIX] <&r><context.message>"
```
with commands:
```
/ex actionbar "<&color[#61C2FF]>this is a test"
/ex actionbar "<&color[#61C2FF]><element[this is a test].font[illageralt]>"
/title @a actionbar {"text":"this is a test","color":"#61C2FF"}
```
everything works as expected and also handles custom fonts and rgb colors. some output: https://paste.denizenscript.com/View/93878