### PR TITLE
Entity changes food level event - item support

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
@@ -25,7 +25,7 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
     //
     // @Cancellable true
     //
-    // @Switch item:<item> To only process the event if it was triggered by an item that matches the specified item.
+    // @Switch item:<item> to only process the event if it was triggered by an item that matches the specified item.
     //
     // @Triggers when an entity's food level changes.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.events.entity;
 
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -17,8 +18,6 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
     // entity changes food level
     // <entity> changes food level
     //
-    // @Regex ^on [^\s]+ changes food level$
-    //
     // @Synonyms player hunger depletes
     //
     // @Group Entity
@@ -32,6 +31,7 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
     // @Context
     // <context.entity> returns the EntityTag.
     // <context.food> returns an ElementTag(Number) of the entity's new food level.
+    // <context.item> returns an ItemTag of the item eaten, if any.
     //
     // @Determine
     // ElementTag(Number) to set the entity's new food level.
@@ -44,35 +44,27 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
 
     public EntityFoodLevelChangeScriptEvent() {
         instance = this;
+        registerCouldMatcher("<entity> changes food level");
+        registerSwitches("item");
     }
 
     public static EntityFoodLevelChangeScriptEvent instance;
     public EntityTag entity;
+    public ItemTag item;
     public FoodLevelChangeEvent event;
-
-    @Override
-    public boolean couldMatch(ScriptPath path) {
-        if (!path.eventLower.contains("changes food level")) {
-            return false;
-        }
-        if (!couldMatchEntity(path.eventArgLowerAt(0))) {
-            return false;
-        }
-        return true;
-    }
 
     @Override
     public boolean matches(ScriptPath path) {
         String target = path.eventArgLowerAt(0);
-
         if (!tryEntity(entity, target)) {
             return false;
         }
-
+        if (path.switches.containsKey("item") && !tryItem(item, path.switches.get("item"))) {
+            return false;
+        }
         if (!runInCheck(path, entity.getLocation())) {
             return false;
         }
-
         return super.matches(path);
     }
 
@@ -83,8 +75,8 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
 
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag && ((ElementTag) determinationObj).isInt()) {
-            event.setFoodLevel(((ElementTag) determinationObj).asInt());
+        if (determinationObj instanceof ElementTag && determinationObj.asElement().isInt()) {
+            event.setFoodLevel(determinationObj.asElement().asInt());
             return true;
         }
         return super.applyDetermination(path, determinationObj);
@@ -97,11 +89,10 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("entity")) {
-            return entity.getDenizenObject();
-        }
-        else if (name.equals("food")) {
-            return new ElementTag(event.getFoodLevel());
+        switch (name) {
+            case "entity": return entity.getDenizenObject();
+            case "food": return new ElementTag(event.getFoodLevel());
+            case "item": return item;
         }
         return super.getContext(name);
     }
@@ -109,6 +100,7 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
     @EventHandler
     public void onEntityFoodLevelChanged(FoodLevelChangeEvent event) {
         entity = new EntityTag(event.getEntity());
+        item = event.getItem() != null ? new ItemTag(event.getItem()) : null;
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
@@ -25,12 +25,14 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
     //
     // @Cancellable true
     //
+    // @Switch item:<item> To only process the event if it was triggered by an item that matches the specified item.
+    //
     // @Triggers when an entity's food level changes.
     //
     // @Context
     // <context.entity> returns the EntityTag.
     // <context.food> returns an ElementTag(Number) of the entity's new food level.
-    // <context.item> returns an ItemTag of the item eaten, if any.
+    // <context.item> returns an ItemTag of the item that triggered the event, if any.
     //
     // @Determine
     // ElementTag(Number) to set the entity's new food level.

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityFoodLevelChangeScriptEvent.java
@@ -15,7 +15,6 @@ public class EntityFoodLevelChangeScriptEvent extends BukkitScriptEvent implemen
 
     // <--[event]
     // @Events
-    // entity changes food level
     // <entity> changes food level
     //
     // @Synonyms player hunger depletes


### PR DESCRIPTION
## Additions
`<context.item>` - returns an ItemTag of the item that triggered the event, if any
`item:<item>` - to only process the event if it was triggered by an item that matches the specified item

## Changes
Replace `couldMatch()` with modern `registerCouldMatcher()`
Replace casting to ElementTag with `ObjectTag#asElement()`
Replace `if/else` with `switch/case` in `getContext()`