### PR TITLE
Fix text_width issues, add the rest of the ascii.png chars

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/TextWidthHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/TextWidthHelper.java
@@ -7,15 +7,24 @@ import java.util.HashMap;
 
 public class TextWidthHelper {
 
+    public static int[] asciiWidthMap = new int[128];
     public static HashMap<Character, Integer> characterWidthMap = new HashMap<>();
 
     public static void setWidth(int width, String chars) {
         for (char c : chars.toCharArray()) {
-            characterWidthMap.put(c, width);
+            if (c < 128) {
+                asciiWidthMap[c] = width;
+            }
+            else {
+                characterWidthMap.put(c, width);
+            }
         }
     }
 
     static {
+        for (int i = 0; i < 128; i++) {
+            asciiWidthMap[i] = 6;
+        }
         // Covers all symbols in the default ascii.png texture file
         setWidth(2, "!,.:;|i'");
         setWidth(3, "l`");
@@ -28,6 +37,9 @@ public class TextWidthHelper {
     }
 
     public static int getWidth(char c) {
+        if (c < 128) {
+            return asciiWidthMap[c];
+        }
         return characterWidthMap.getOrDefault(c, 6);
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/TextWidthHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/TextWidthHelper.java
@@ -3,30 +3,32 @@ package com.denizenscript.denizen.utilities;
 import com.denizenscript.denizencore.utilities.AsciiMatcher;
 import org.bukkit.ChatColor;
 
+import java.util.HashMap;
+
 public class TextWidthHelper {
 
-    public static int[] characterWidthMap = new int[128];
+    public static HashMap<Character, Integer> characterWidthMap = new HashMap<>();
 
     public static void setWidth(int width, String chars) {
         for (char c : chars.toCharArray()) {
-            characterWidthMap[c] = width;
+            characterWidthMap.put(c, width);
         }
     }
 
     static {
-        for (int i = 0; i < 128; i++) {
-            characterWidthMap[i] = 6;
-        }
-        setWidth(2, "!,.:;|i`");
-        setWidth(3, "'l");
-        setWidth(4, " []tI");
-        setWidth(5, "\"()*<>fk{}");
-        // all other ASCII characters are length=6
-        setWidth(7, "@~");
+        // Covers all symbols in the default ascii.png texture file
+        setWidth(2, "!,.:;|i'");
+        setWidth(3, "l`");
+        setWidth(4, " (){}[]tI\"*");
+        setWidth(5, "<>fkªº▌⌡°ⁿ²");
+        // all other characters are length=6
+        setWidth(7, "@~«»≡≈√");
+        setWidth(8, "░╢╖╣║╗╝╜∅⌠");
+        setWidth(9, "▒▓└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┌█▄▐▀");
     }
 
     public static int getWidth(char c) {
-        return c > 127 ? 6 : characterWidthMap[c];
+        return characterWidthMap.getOrDefault(c, 6);
     }
 
     public static AsciiMatcher formatCharCodeMatcher = new AsciiMatcher("klmnoKLMNO");
@@ -59,7 +61,7 @@ public class TextWidthHelper {
                 i++;
                 continue;
             }
-            total += getWidth(c) + (bold ? 2 : 0);
+            total += getWidth(c) + (bold ? 1 : 0);
             if (c == '\n') {
                 if (total > maxWidth) {
                     maxWidth = total;


### PR DESCRIPTION
Tested all the chars I moved around, they are all accurate now. Screenshot is just one example.
![image](https://user-images.githubusercontent.com/29823405/166171621-bde3459d-a576-45b9-8610-fc6e33b92d24.png)
Even works for some of these funky symbols:
![image](https://user-images.githubusercontent.com/29823405/166172281-1048c4a1-6ec5-4ae2-b414-b4df4f732f59.png)
![image](https://user-images.githubusercontent.com/29823405/166172349-f3f2c4d7-63dc-4951-bef5-fc3d54f3cea5.png)


At some point it would be nice for this to support user-defined chars and fonts. This just solves my immediate problem of some of the widths being off or unavailable.