### PR TITLE
Add `LocationTag.map_color`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.nms.interfaces;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
+import org.bukkit.Color;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -97,4 +98,9 @@ public interface BlockHelper {
     default void setSpawnerSpawnedType(CreatureSpawner spawner, EntityTag entity) {
         spawner.setSpawnedType(entity.getBukkitEntityType());
     }
+
+    default Color getMapColor(Block block) {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4186,6 +4186,21 @@ public class LocationTag extends org.bukkit.Location implements ObjectTag, Notab
             }
             return new ElementTag(((Sign) state).getColor().name());
         });
+
+        // <--[tag]
+        // @attribute <LocationTag.map_color>
+        // @returns ColorTag
+        // @group world
+        // @description
+        // Returns the color of the block at the location, as seen in a map.
+        // -->
+        tagProcessor.registerTag(ColorTag.class, "map_color", (attribute, object) -> {
+            Block block = object.getBlockForTag(attribute);
+            if (block == null) {
+                return null;
+            }
+            return new ColorTag(NMSHandler.blockHelper.getMapColor(block));
+        });
     }
 
     public static ObjectTagProcessor<LocationTag> tagProcessor = new ObjectTagProcessor<>();

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/BlockHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/BlockHelperImpl.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.material.PushReaction;
+import org.bukkit.Color;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -298,4 +299,11 @@ public class BlockHelperImpl implements BlockHelper {
         return blockType.getExpDrop(((CraftBlock) block).getNMS(), ((CraftBlock) block).getCraftWorld().getHandle(), ((CraftBlock) block).getPosition(),
                 item == null ? null : CraftItemStack.asNMSCopy(item));
     }
+
+    @Override
+    public Color getMapColor(Block block) {
+        CraftBlock craftBlock = (CraftBlock) block;
+        return Color.fromRGB(craftBlock.getNMS().getMapColor(craftBlock.getHandle(), craftBlock.getPosition()).col);
+    }
+
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.material.PushReaction;
+import org.bukkit.Color;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -347,4 +348,11 @@ public class BlockHelperImpl implements BlockHelper {
             Debug.echoError(ex);
         }
     }
+
+    @Override
+    public Color getMapColor(Block block) {
+        CraftBlock craftBlock = (CraftBlock) block;
+        return Color.fromRGB(craftBlock.getNMS().getMapColor(craftBlock.getHandle(), craftBlock.getPosition()).col);
+    }
+
 }


### PR DESCRIPTION
## Additions

- `LocationTag.map_color` - Returns the color of the block at the location, as seen in a map.
- `BlockHelper#getMapColor(org.bukkit.block.Block block)`  - Returns the map color of the block as a `org.bukkit.Color`, Implemented in `1.17` and `1.18`.