### PR TITLE
Entity Properties Update - Part 3

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCritical.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCritical.java
@@ -5,13 +5,14 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
-import org.bukkit.entity.Arrow;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.entity.AbstractArrow;
 
 public class EntityCritical implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Arrow;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof AbstractArrow;
     }
 
     public static EntityCritical getFrom(ObjectTag entity) {
@@ -22,10 +23,6 @@ public class EntityCritical implements Property {
             return new EntityCritical((EntityTag) entity);
         }
     }
-
-    public static final String[] handledTags = new String[] {
-            "critical"
-    };
 
     public static final String[] handledMechs = new String[] {
             "critical"
@@ -39,12 +36,7 @@ public class EntityCritical implements Property {
 
     @Override
     public String getPropertyString() {
-        if (!((Arrow) critical.getBukkitEntity()).isCritical()) {
-            return null;
-        }
-        else {
-            return "true";
-        }
+        return getAbstractArrow().isCritical() ? "true" : null;
     }
 
     @Override
@@ -52,12 +44,11 @@ public class EntityCritical implements Property {
         return "critical";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public AbstractArrow getAbstractArrow() {
+        return (AbstractArrow) critical.getBukkitEntity();
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    public void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.critical>
@@ -67,12 +58,9 @@ public class EntityCritical implements Property {
         // @description
         // If the entity is an arrow or trident, returns whether the arrow/trident is critical.
         // -->
-        if (attribute.startsWith("critical")) {
-            return new ElementTag(((Arrow) critical.getBukkitEntity()).isCritical())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityCritical, ElementTag>registerTag(ElementTag.class, "critical", (attribute, object) -> {
+            return new ElementTag(object.getAbstractArrow().isCritical());
+        });
     }
 
     @Override
@@ -88,7 +76,7 @@ public class EntityCritical implements Property {
         // <EntityTag.critical>
         // -->
         if (mechanism.matches("critical") && mechanism.requireBoolean()) {
-            ((Arrow) critical.getBukkitEntity()).setCritical(mechanism.getValue().asBoolean());
+            getAbstractArrow().setCritical(mechanism.getValue().asBoolean());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCritical.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCritical.java
@@ -48,7 +48,7 @@ public class EntityCritical implements Property {
         return (AbstractArrow) critical.getBukkitEntity();
     }
 
-    public void registerTags() {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.critical>

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomName.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomName.java
@@ -44,7 +44,7 @@ public class EntityCustomName implements Property {
         return "custom_name";
     }
 
-    public void registerTags() {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.custom_name>
@@ -55,7 +55,7 @@ public class EntityCustomName implements Property {
         // Returns the entity's custom name (as set by plugin or name tag item), if any.
         // -->
         PropertyParser.<EntityCustomName, ElementTag>registerTag(ElementTag.class, "custom_name", (attribute, object) -> {
-            String name = AdvancedTextImpl.instance.getCustomName(entity.getBukkitEntity());
+            String name = AdvancedTextImpl.instance.getCustomName(object.entity.getBukkitEntity());
             if (name == null) {
                 return null;
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomName.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomName.java
@@ -6,7 +6,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 
 public class EntityCustomName implements Property {
@@ -19,12 +19,10 @@ public class EntityCustomName implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityCustomName((EntityTag) entity);
+        else {
+            return new EntityCustomName((EntityTag) entity);
+        }
     }
-
-    public static final String[] handledTags = new String[] {
-            "custom_name"
-    };
 
     public static final String[] handledMechs = new String[] {
             "custom_name"
@@ -46,12 +44,7 @@ public class EntityCustomName implements Property {
         return "custom_name";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
+    public void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.custom_name>
@@ -61,18 +54,13 @@ public class EntityCustomName implements Property {
         // @description
         // Returns the entity's custom name (as set by plugin or name tag item), if any.
         // -->
-        else if (attribute.startsWith("custom_name")) {
+        PropertyParser.<EntityCustomName, ElementTag>registerTag(ElementTag.class, "custom_name", (attribute, object) -> {
             String name = AdvancedTextImpl.instance.getCustomName(entity.getBukkitEntity());
             if (name == null) {
                 return null;
             }
-            else {
-                return new ElementTag(name, true).getObjectAttribute(attribute.fulfill(1));
-            }
-        }
-        else {
-            return null;
-        }
+            return new ElementTag(name, true);
+        });
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomNameVisible.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomNameVisible.java
@@ -5,7 +5,7 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 public class EntityCustomNameVisible implements Property {
 
@@ -17,12 +17,10 @@ public class EntityCustomNameVisible implements Property {
         if (!describes(entity)) {
             return null;
         }
-        return new EntityCustomNameVisible((EntityTag) entity);
+        else {
+            return new EntityCustomNameVisible((EntityTag) entity);
+        }
     }
-
-    public static final String[] handledTags = new String[] {
-            "custom_name_visible"
-    };
 
     public static final String[] handledMechs = new String[] {
             "custom_name_visibility", "custom_name_visible"
@@ -44,12 +42,7 @@ public class EntityCustomNameVisible implements Property {
         return "custom_name_visible";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
+    public void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.custom_name_visible>
@@ -59,11 +52,9 @@ public class EntityCustomNameVisible implements Property {
         // @description
         // Returns true if the entity's custom name is visible.
         // -->
-        if (attribute.startsWith("custom_name_visible")) {
-            return new ElementTag(entity.getBukkitEntity().isCustomNameVisible()).getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityCustomNameVisible, ElementTag>registerTag(ElementTag.class, "custom_name_visible", (attribute, object) -> {
+            return new ElementTag(object.entity.getBukkitEntity().isCustomNameVisible());
+        });
     }
 
     @Override
@@ -74,7 +65,7 @@ public class EntityCustomNameVisible implements Property {
         // @name custom_name_visible
         // @input ElementTag(Boolean)
         // @description
-        // Sets whether the custom name is visible.
+        // Sets whether the entity's custom name is visible.
         // @tags
         // <EntityTag.custom_name_visible>
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomNameVisible.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomNameVisible.java
@@ -50,7 +50,7 @@ public class EntityCustomNameVisible implements Property {
         // @mechanism EntityTag.custom_name_visible
         // @group attributes
         // @description
-        // Returns true if the entity's custom name is visible.
+        // Returns whether the entity's custom name is visible.
         // -->
         PropertyParser.<EntityCustomNameVisible, ElementTag>registerTag(ElementTag.class, "custom_name_visible", (attribute, object) -> {
             return new ElementTag(object.entity.getBukkitEntity().isCustomNameVisible());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomNameVisible.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCustomNameVisible.java
@@ -42,7 +42,7 @@ public class EntityCustomNameVisible implements Property {
         return "custom_name_visible";
     }
 
-    public void registerTags() {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.custom_name_visible>


### PR DESCRIPTION
## Properties Updated
`EntityCritical`
`EntityCustomName`
`EntityCustomNameVisible`

## Changes

- All above properties were updated to new tag registration, and had `get*Thing*()` methods added for cleaner-looking code where necessary.
- `EntityCritical` changed to use `AbstractArrow` instead of `Arrow` (as `Trident` is no longer a subinterface of `Arrow` )
- Small meta fix to `EntityCustomNameVisible`