### PR TITLE
Entity Properties Update - Part 4

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDarkDuration.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDarkDuration.java
@@ -5,13 +5,14 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.GlowSquid;
 
 public class EntityDarkDuration implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof GlowSquid;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof GlowSquid;
     }
 
     public static EntityDarkDuration getFrom(ObjectTag entity) {
@@ -22,10 +23,6 @@ public class EntityDarkDuration implements Property {
             return new EntityDarkDuration((EntityTag) entity);
         }
     }
-
-    public static final String[] handledTags = new String[] {
-            "dark_duration"
-    };
 
     public static final String[] handledMechs = new String[] {
             "dark_duration"
@@ -39,7 +36,7 @@ public class EntityDarkDuration implements Property {
 
     @Override
     public String getPropertyString() {
-        return new DurationTag((long) ((GlowSquid) entity.getBukkitEntity()).getDarkTicksRemaining()).identify();
+        return new DurationTag((long) getGlowSquid().getDarkTicksRemaining()).identify();
     }
 
     @Override
@@ -47,12 +44,11 @@ public class EntityDarkDuration implements Property {
         return "dark_duration";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public GlowSquid getGlowSquid() {
+        return (GlowSquid) entity.getBukkitEntity();
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    public void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.dark_duration>
@@ -62,12 +58,9 @@ public class EntityDarkDuration implements Property {
         // @description
         // Returns the duration remaining before a glow squid starts glowing.
         // -->
-        if (attribute.startsWith("dark_duration")) {
-            return new DurationTag((long) ((GlowSquid) entity.getBukkitEntity()).getDarkTicksRemaining())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityDarkDuration, DurationTag>registerTag(DurationTag.class, "dark_duration", (attribute, object) -> {
+            return new DurationTag((long) object.getGlowSquid().getDarkTicksRemaining());
+        });
     }
 
     @Override
@@ -83,7 +76,7 @@ public class EntityDarkDuration implements Property {
         // <EntityTag.dark_duration>
         // -->
         if (mechanism.matches("dark_duration") && mechanism.requireObject(DurationTag.class)) {
-            ((GlowSquid) entity.getBukkitEntity()).setDarkTicksRemaining(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
+            getGlowSquid().setDarkTicksRemaining(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDarkDuration.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDarkDuration.java
@@ -48,7 +48,7 @@ public class EntityDarkDuration implements Property {
         return (GlowSquid) entity.getBukkitEntity();
     }
 
-    public void registerTags() {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.dark_duration>

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDirection.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDirection.java
@@ -48,7 +48,7 @@ public class EntityDirection implements Property {
         return (Fireball) entity.getBukkitEntity();
     }
 
-    public void registerTags() {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.direction>

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDirection.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDirection.java
@@ -5,13 +5,14 @@ import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.Fireball;
 
 public class EntityDirection implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntity() instanceof Fireball;
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof Fireball;
     }
 
     public static EntityDirection getFrom(ObjectTag entity) {
@@ -22,10 +23,6 @@ public class EntityDirection implements Property {
             return new EntityDirection((EntityTag) entity);
         }
     }
-
-    public static final String[] handledTags = new String[] {
-            "direction"
-    };
 
     public static final String[] handledMechs = new String[] {
             "direction"
@@ -39,7 +36,7 @@ public class EntityDirection implements Property {
 
     @Override
     public String getPropertyString() {
-        return new LocationTag(((Fireball) entity.getBukkitEntity()).getDirection()).identify();
+        return new LocationTag(getFireball().getDirection()).identify();
     }
 
     @Override
@@ -47,12 +44,11 @@ public class EntityDirection implements Property {
         return "direction";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public Fireball getFireball() {
+        return (Fireball) entity.getBukkitEntity();
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    public void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.direction>
@@ -62,12 +58,9 @@ public class EntityDirection implements Property {
         // @description
         // Returns the movement/acceleration direction of a fireball entity, as a LocationTag vector.
         // -->
-        if (attribute.startsWith("direction")) {
-            return new LocationTag(((Fireball) entity.getBukkitEntity()).getDirection())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<EntityDirection, LocationTag>registerTag(LocationTag.class, "direction", (attribute, object) -> {
+            return new LocationTag(object.getFireball().getDirection());
+        });
     }
 
     @Override
@@ -83,7 +76,7 @@ public class EntityDirection implements Property {
         // <EntityTag.direction>
         // -->
         if (mechanism.matches("direction") && mechanism.requireObject(LocationTag.class)) {
-            ((Fireball) entity.getBukkitEntity()).setDirection(mechanism.valueAsType(LocationTag.class).toVector());
+            getFireball().setDirection(mechanism.valueAsType(LocationTag.class).toVector());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
@@ -76,7 +76,7 @@ public class EntityDisabledSlots implements Property {
         return "disabled_slots";
     }
 
-    public void registerTags() {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <EntityTag.disabled_slots>
@@ -98,10 +98,11 @@ public class EntityDisabledSlots implements Property {
             // See <@link url https://minecraft.fandom.com/wiki/Armor_Stand/ED>
             // -->
             if (attribute.startsWith("raw", 2)) {
-                return new ElementTag(CustomNBT.getCustomIntNBT(dentity.getBukkitEntity(), CustomNBT.KEY_DISABLED_SLOTS));
+                attribute.fulfill(1);
+                return new ElementTag(CustomNBT.getCustomIntNBT(object.dentity.getBukkitEntity(), CustomNBT.KEY_DISABLED_SLOTS));
             }
 
-            return getDisabledSlots();
+            return object.getDisabledSlots();
         });
     }
 


### PR DESCRIPTION
## Properties Updated
`EntityDarkDuration`
`EntityDirection`
`EntityDisabledSlots`

## Changes

- All above properties were updated to new tag registration, and had `get*Thing*()` methods added for cleaner-looking code where necessary.
- `EntityDisabledSlots` - `describes` changed to use `instanceof` check instead of `== EntityType`
- `EntityDisabledSlots` - `disabled_slots` mechanism changed to use `ElementTag#asEnum` and `!= null` checks instead of `try/catch` for cleaner-looking/shorter code.