### PR TITLE
Update `EntityDisabledSlots` to modern MapTag format

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
@@ -144,7 +144,6 @@ public class EntityDisabledSlots implements Property {
         // @object EntityTag
         // @name disabled_slots_raw
         // @input ElementTag(Number)
-        // @deprecated Use 'disabled_slots'
         // @description
         // Deprecated in favor of <@link mechanism EntityTag.disabled_slots>.
         // @tags

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
@@ -31,7 +32,7 @@ public class EntityDisabledSlots implements Property {
     }
 
     public static final String[] handledMechs = new String[] {
-            "disabled_slots_raw", "disabled_slots"
+            "disabled_slots"
     };
 
     private EntityDisabledSlots(EntityTag entity) {
@@ -65,9 +66,23 @@ public class EntityDisabledSlots implements Property {
         return list;
     }
 
+    private ListTag getDisabledSlotsMap() {
+        Map<EquipmentSlot, Set<Action>> map = CustomNBT.getDisabledSlots(dentity.getBukkitEntity());
+        ListTag list = new ListTag();
+        for (Map.Entry<EquipmentSlot, Set<Action>> entry : map.entrySet()) {
+            for (Action action : entry.getValue()) {
+                MapTag mapTag = new MapTag();
+                mapTag.putObject("slot", new ElementTag(CoreUtilities.toLowerCase(entry.getKey().name())));
+                mapTag.putObject("action", new ElementTag(CoreUtilities.toLowerCase(action.name())));
+                list.addObject(mapTag);
+            }
+        }
+        return list;
+    }
+
     @Override
     public String getPropertyString() {
-        ListTag list = getDisabledSlots();
+        ListTag list = getDisabledSlotsMap();
         return list.isEmpty() ? null : list.identify();
     }
 
@@ -85,18 +100,9 @@ public class EntityDisabledSlots implements Property {
         // @group properties
         // @description
         // If the entity is an armor stand, returns a list of its disabled slots in the form slot/action|...
+        // Consider instead using <@link tag EntityTag.disabled_slots_data>.
         // -->
         PropertyParser.<EntityDisabledSlots, ObjectTag>registerTag(ObjectTag.class, "disabled_slots", (attribute, object) -> {
-
-            // <--[tag]
-            // @attribute <EntityTag.disabled_slots.raw>
-            // @returns ElementTag(Number)
-            // @mechanism EntityTag.disabled_slots_raw
-            // @group properties
-            // @description
-            // If the entity is an armor stand, returns its raw disabled slots value.
-            // See <@link url https://minecraft.fandom.com/wiki/Armor_Stand/ED>
-            // -->
             if (attribute.startsWith("raw", 2)) {
                 attribute.fulfill(1);
                 return new ElementTag(CustomNBT.getCustomIntNBT(object.dentity.getBukkitEntity(), CustomNBT.KEY_DISABLED_SLOTS));
@@ -104,22 +110,23 @@ public class EntityDisabledSlots implements Property {
 
             return object.getDisabledSlots();
         });
+
+        // <--[tag]
+        // @attribute <EntityTag.disabled_slots_data>
+        // @returns ListTag
+        // @mechanism EntityTag.disabled_slots
+        // @group properties
+        // @description
+        // If the entity is an armor stand, returns it's disabled slots as a list of maps with "slot" and "action" keys.
+        // -->
+        PropertyParser.<EntityDisabledSlots, ListTag>registerTag(ListTag.class, "disabled_slots_data", (attribute, object) -> {
+            return object.getDisabledSlotsMap();
+        });
     }
 
     @Override
     public void adjust(Mechanism mechanism) {
 
-        // <--[mechanism]
-        // @object EntityTag
-        // @name disabled_slots_raw
-        // @input ElementTag(Number)
-        // @description
-        // Sets the raw disabled slots value of an armor stand.
-        // See <@link url https://minecraft.fandom.com/wiki/Armor_Stand/ED>
-        // @tags
-        // <EntityTag.disabled_slots>
-        // <EntityTag.disabled_slots.raw>
-        // -->
         if (mechanism.matches("disabled_slots_raw") && mechanism.requireInteger()) {
             CustomNBT.addCustomNBT(dentity.getBukkitEntity(), CustomNBT.KEY_DISABLED_SLOTS, mechanism.getValue().asInt());
         }
@@ -129,13 +136,13 @@ public class EntityDisabledSlots implements Property {
         // @name disabled_slots
         // @input ListTag
         // @description
-        // Sets the disabled slots of an armor stand in the form slot(/action)|...
-        // Optionally include an action to disable specific interactions (defaults to ALL).
-        // Leave empty to enable all slots.
+        // Sets the disabled slots of an armor stand.
+        // Input is a list of MapTags with a "slot" key, optionally include an "action" key to disable specific interactions (defaults to ALL).
+        // Specify no input to enable all slots.
         // Slots: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/inventory/EquipmentSlot.html>
         // Actions: ALL, REMOVE, PLACE
-        // NOTE: Minecraft contains a bug where disabling HAND/ALL still allows item removal.
-        // To fully disable hand interaction, disable HAND/ALL and HAND/REMOVE.
+        // NOTE: Minecraft contains a bug where disabling ALL for the HAND slot still allows item removal.
+        // To fully disable hand interaction, disable ALL and REMOVE.
         // @tags
         // <EntityTag.disabled_slots>
         // <EntityTag.disabled_slots.raw>
@@ -146,30 +153,61 @@ public class EntityDisabledSlots implements Property {
                 return;
             }
 
-            ListTag list = mechanism.valueAsType(ListTag.class);
+            Collection<ObjectTag> list = CoreUtilities.objectToList(mechanism.value, mechanism.context);
             Map<EquipmentSlot, Set<Action>> map = new HashMap<>();
 
-            for (String string : list) {
-                String[] split = string.toUpperCase().split("/", 2);
-
-                EquipmentSlot slot = new ElementTag(split[0]).asEnum(EquipmentSlot.class);
-                Action action = null;
-
-                if (slot == null) {
-                    mechanism.echoError("Invalid equipment slot specified: " + split[0]);
-                    continue;
-                }
-
-                if (split.length == 2) {
-                    action = new ElementTag(split[1]).asEnum(Action.class);
-                    if (action == null) {
-                        mechanism.echoError("Invalid action specified: " + split[1]);
+            for (ObjectTag object : list) {
+                EquipmentSlot slot;
+                Action action = Action.ALL;
+                if (object.canBeType(MapTag.class)) {
+                    MapTag mapTag = object.asType(MapTag.class, mechanism.context);
+                    ObjectTag slotObject = mapTag.getObject("slot");
+                    ObjectTag actionObject = mapTag.getObject("action");
+                    if (slotObject != null) {
+                        if (slotObject.asElement().matchesEnum(EquipmentSlot.class)) {
+                            slot = slotObject.asElement().asEnum(EquipmentSlot.class);
+                        }
+                        else {
+                            mechanism.echoError("Invalid equipment slot specified: " + slotObject);
+                            continue;
+                        }
+                    }
+                    else {
+                        mechanism.echoError("Invalid equipment slot specified: slot is required.");
                         continue;
                     }
+                    if (actionObject != null) {
+                        if (actionObject.asElement().matchesEnum(Action.class)) {
+                            action = actionObject.asElement().asEnum(Action.class);
+                        }
+                        else {
+                            mechanism.echoError("Invalid action specified: " + actionObject);
+                            continue;
+                        }
+                    }
                 }
+                else {
+                    String[] split = object.toString().toUpperCase().split("/", 2);
 
+                    slot = new ElementTag(split[0]).asEnum(EquipmentSlot.class);
+
+                    if (slot == null) {
+                        mechanism.echoError("Invalid equipment slot specified: " + split[0]);
+                        continue;
+                    }
+
+                    if (split.length == 2) {
+                        action = new ElementTag(split[1]).asEnum(Action.class);
+                        if (action == null) {
+                            mechanism.echoError("Invalid action specified: " + split[1]);
+                            continue;
+                        }
+                    }
+
+
+                }
                 Set<Action> set = map.computeIfAbsent(slot, k -> new HashSet<>());
-                set.add(action == null ? Action.ALL : action);
+                set.add(action);
             }
 
             CustomNBT.setDisabledSlots(dentity.getBukkitEntity(), map);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
@@ -141,7 +141,7 @@ public class EntityDisabledSlots implements Property {
         // @description
         // Sets the disabled slots of an armor stand.
         // Input is a list of MapTags with a "slot" key, optionally include an "action" key to disable specific interactions (defaults to ALL).
-        // Specify no input to enable all slots.
+        // Provide no input to enable all slots.
         // Slots: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/inventory/EquipmentSlot.html>
         // Actions: ALL, REMOVE, PLACE
         // NOTE: Minecraft contains a bug where disabling ALL for the HAND slot still allows item removal.

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
@@ -144,6 +144,7 @@ public class EntityDisabledSlots implements Property {
         // @object EntityTag
         // @name disabled_slots_raw
         // @input ElementTag(Number)
+        // @deprecated Use 'disabled_slots'
         // @description
         // Deprecated in favor of <@link mechanism EntityTag.disabled_slots>.
         // @tags

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -32,7 +33,7 @@ public class EntityDisabledSlots implements Property {
     }
 
     public static final String[] handledMechs = new String[] {
-            "disabled_slots"
+            "disabled_slots", "disabled_slots_raw"
     };
 
     private EntityDisabledSlots(EntityTag entity) {
@@ -104,6 +105,7 @@ public class EntityDisabledSlots implements Property {
         // -->
         PropertyParser.<EntityDisabledSlots, ObjectTag>registerTag(ObjectTag.class, "disabled_slots", (attribute, object) -> {
             if (attribute.startsWith("raw", 2)) {
+                BukkitImplDeprecations.armorStandRawSlot.warn(attribute.context);
                 attribute.fulfill(1);
                 return new ElementTag(CustomNBT.getCustomIntNBT(object.dentity.getBukkitEntity(), CustomNBT.KEY_DISABLED_SLOTS));
             }
@@ -128,6 +130,7 @@ public class EntityDisabledSlots implements Property {
     public void adjust(Mechanism mechanism) {
 
         if (mechanism.matches("disabled_slots_raw") && mechanism.requireInteger()) {
+            BukkitImplDeprecations.armorStandRawSlot.warn(mechanism.context);
             CustomNBT.addCustomNBT(dentity.getBukkitEntity(), CustomNBT.KEY_DISABLED_SLOTS, mechanism.getValue().asInt());
         }
 
@@ -144,8 +147,7 @@ public class EntityDisabledSlots implements Property {
         // NOTE: Minecraft contains a bug where disabling ALL for the HAND slot still allows item removal.
         // To fully disable hand interaction, disable ALL and REMOVE.
         // @tags
-        // <EntityTag.disabled_slots>
-        // <EntityTag.disabled_slots.raw>
+        // <EntityTag.disabled_slots_data>
         // -->
         if (mechanism.matches("disabled_slots")) {
             if (!mechanism.hasValue()) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisabledSlots.java
@@ -33,7 +33,7 @@ public class EntityDisabledSlots implements Property {
     }
 
     public static final String[] handledMechs = new String[] {
-            "disabled_slots", "disabled_slots_raw"
+            "disabled_slots_raw", "disabled_slots"
     };
 
     private EntityDisabledSlots(EntityTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -166,6 +166,7 @@ public class BukkitImplDeprecations {
 
     // Added 2021/05/05.
     public static Warning locationDistanceTag = new SlowWarning("locationDistanceTag", "locationtag.tree_distance is deprecated in favor of location.material.distance");
+    public static Warning armorStandRawSlot = new SlowWarning("armorStandRawSlot", "The EntityTag.disabled_slots.raw tag and EntityTag.disabled_slots_raw mechanism are deprecated, use the EntityTag.disabled_slots_data tag and EntityTag.disabled_slots mechanism instead.");
 
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -250,6 +250,10 @@ public class BukkitImplDeprecations {
     // Added 2022/02/21, deprecate officially by 2024.
     public static Warning oldPotionEffects = new FutureWarning("oldPotionEffects", "The comma-separated-list potion effect tags like 'list_effects' are deprecated in favor of MapTag based tags - 'effects_data'. Refer to meta documentation for details.");
 
+    // Added 2022/5/7, deprecate officially by 2024.
+    public static Warning armorStandDisabledSlotsOldFormat = new FutureWarning("armorStandDisabledSlotsList", "The EntityTag.disabled_slots tag and the SLOT/ACTION format in the EntityTag.disabled_slots mechanism are deprecated in favour of the EntityTag.disabled_slots_data tag and the MapTag format.");
+
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Added on 2019/10/13


### PR DESCRIPTION
## Additions

- `EntityDisabledSlots#getDisabledSlotsMap` - Returns an armor stand's disabled slots as a map of slot names to list of actions.
- `EntityTag.disabled_slots_data` - See above
- `BukkitImplDeprecations.armorStandRawSlot` - A deprecation warning for `EntityTag.disabled_slots.raw` and the `EntityTag.disabled_slots_raw` mechanism
- `EntityTag.disabled_slots` mechanism - Support for input in the MapTag format, same as `EntityTag.disabled_slots_data`
- `EntityTag.disabled_slots` tag - Recommendation to use `EntityTag.disabled_slots_data` in the meta

## Changes

- `EntityTag.disabled_slots` mechanism - Changed meta docs to only include the MapTag format, let me know if the old format should be included as well