### PR TITLE
`player uses portal` - Update + extra features

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerUsesPortalScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerUsesPortalScriptEvent.java
@@ -5,7 +5,9 @@ import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerPortalEvent;
@@ -16,43 +18,55 @@ public class PlayerUsesPortalScriptEvent extends BukkitScriptEvent implements Li
     // @Events
     // player uses portal
     //
-    // @Regex ^on player uses portal$
-    //
     // @Group Player
     //
     // @Location true
+    //
+    // @Switch from:<block> to only process the event if the block the player teleported from matches the LocationTag matcher provided.
+    // @Switch to:<block> to only process the event if the block the player teleported to matches the LocationTag matcher provided.
+    //
+    // @Cancellable true
     //
     // @Triggers when a player enters a portal.
     //
     // @Context
     // <context.from> returns the location teleported from.
     // <context.to> returns the location teleported to.
+    // <context.can_create> returns whether the server will attempt to create a destination portal.
+    // <context.creation_radius> returns the radius that will be checked for a free space to create the portal in.
+    // <context.search_radius> returns the radius that will be checked for an existing portal to teleport to.
     //
     // @Determine
     // LocationTag to change the destination.
+    // "CAN_CREATE:" + ElementTag(Boolean) to set whether the server will attempt to create a destination portal.
+    // "CREATION_RADIUS:" + ElementTag(Number) to set the radius that will be checked for a free space to create the portal in.
+    // "SEARCH_RADIUS:" + ElementTag(Number) to set the radius that will be checked for an existing portal to teleport to.
     //
     // @Player Always.
     //
     // -->
 
     public PlayerUsesPortalScriptEvent() {
+        registerCouldMatcher("player uses portal");
+        registerSwitches("from", "to");
         instance = this;
     }
 
     public static PlayerUsesPortalScriptEvent instance;
-    public EntityTag entity;
     public LocationTag to;
     public LocationTag from;
     public PlayerPortalEvent event;
 
-    @Override
-    public boolean couldMatch(ScriptPath path) {
-        return path.eventLower.startsWith("player uses portal");
-    }
 
     @Override
     public boolean matches(ScriptPath path) {
         if (!runInCheck(path, to) && !runInCheck(path, from)) {
+            return false;
+        }
+        if (path.switches.containsKey("from") && !from.tryAdvancedMatcher(path.switches.get("from"))) {
+            return false;
+        }
+        if (to != null && path.switches.containsKey("to") && !to.tryAdvancedMatcher(path.switches.get("to"))) {
             return false;
         }
         return super.matches(path);
@@ -65,9 +79,23 @@ public class PlayerUsesPortalScriptEvent extends BukkitScriptEvent implements Li
 
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        String determination = determinationObj.toString();
-        if (LocationTag.matches(determination)) {
-            to = LocationTag.valueOf(determination, getTagContext(path));
+        if (determinationObj instanceof ElementTag) {
+            String determination = CoreUtilities.toLowerCase(determinationObj.toString());
+            if (determination.startsWith("can_create:")) {
+                event.setCanCreatePortal(new ElementTag(determination.substring("can_create:".length())).asBoolean());
+                return true;
+            }
+            else if (determination.startsWith("creation_radius:")) {
+                event.setCreationRadius(new ElementTag(determination.substring("creation_radius:".length())).asInt());
+                return true;
+            }
+            else if (determination.startsWith("search_radius:")) {
+                event.setSearchRadius(new ElementTag(determination.substring("search_radius:".length())).asInt());
+                return true;
+            }
+        }
+        if (determinationObj.canBeType(LocationTag.class)) {
+            to = determinationObj.asType(LocationTag.class, getTagContext(path));
             event.setTo(to);
             return true;
         }
@@ -76,18 +104,17 @@ public class PlayerUsesPortalScriptEvent extends BukkitScriptEvent implements Li
 
     @Override
     public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(entity);
+        return new BukkitScriptEntryData(event.getPlayer());
     }
 
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "entity":
-                return entity;
-            case "to":
-                return to;
-            case "from":
-                return from;
+            case "to": return to;
+            case "from": return from;
+            case "can_create": return new ElementTag(event.getCanCreatePortal());
+            case "creation_radius": return new ElementTag(event.getCreationRadius());
+            case "search_radius": return new ElementTag(event.getSearchRadius());
         }
         return super.getContext(name);
     }
@@ -97,7 +124,6 @@ public class PlayerUsesPortalScriptEvent extends BukkitScriptEvent implements Li
         if (EntityTag.isNPC(event.getPlayer())) {
             return;
         }
-        entity = new EntityTag(event.getPlayer());
         to = event.getTo() == null ? null : new LocationTag(event.getTo());
         from = new LocationTag(event.getFrom());
         this.event = event;


### PR DESCRIPTION
## Additions

- `from:<block>` switch - to only process the event if the block the player teleported from matches the LocationTag matcher provided.
- `to:<block>` switch - to only process the event if the block the player teleported to matches the LocationTag matcher provided.
- `<context.can_create>` - returns whether the server will attempt to create a destination portal.
- `<context.creation_radius>` - returns the radius that will be checked for a free space to create the portal in.
- `<context.search_radius>` - returns the radius that will be checked for an existing portal to teleport to.
- `"CAN_CREATE:" + ElementTag(Boolean)` determination - to set whether the server will attempt to create a destination portal.
- `"CREATION_RADIUS:" + ElementTag(Number)` determination -  to set the radius that will be checked for a free space to create the portal in.
- `"SEARCH_RADIUS:" + ElementTag(Number)` determination - to set the radius that will be checked for an existing portal to teleport to.
- Added missing `Cancellable` doc

## Changes

- Event was updated to use the modern couldMatching system (`registerCouldMatcher`)
- Removed undocumented `entity` context

## Note
While the locations can already be matched using the `in:<area>` and `location_flagged:<flag>` switches, the `from:` and `to:` switches allows matching them separately, and also allows things like `from:nether_portal` to match specific portal types