### PR TITLE
Add `EntityTag.auto_expire` paper-only property

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -1,6 +1,8 @@
 package com.denizenscript.denizen.paper;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
@@ -52,6 +54,9 @@ public class PaperModule {
 
         // Properties
         PropertyParser.registerProperty(EntityArmsRaised.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+            PropertyParser.registerProperty(EntityAutoExpire.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityCanTick.class, EntityTag.class);
         PropertyParser.registerProperty(EntityCarryingEgg.class, EntityTag.class);
         PropertyParser.registerProperty(EntityDrinkingPotion.class, EntityTag.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityAutoExpire.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityAutoExpire.java
@@ -1,0 +1,88 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.entity.FallingBlock;
+
+public class EntityAutoExpire implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag
+                && ((EntityTag) entity).getBukkitEntity() instanceof FallingBlock;
+    }
+
+    public static EntityAutoExpire getFrom(ObjectTag _entity) {
+        if (!describes(_entity)) {
+            return null;
+        }
+        else {
+            return new EntityAutoExpire((EntityTag) _entity);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "auto_expire"
+    };
+
+    private EntityAutoExpire(EntityTag _entity) {
+        entity = _entity;
+    }
+
+    EntityTag entity;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.auto_expire>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.auto_expire
+        // @group properties
+        // @Plugin Paper
+        // @description
+        // Returns whether a falling_block will auto-expire (after 30 seconds, or 5 when outside the world).
+        PropertyParser.<EntityAutoExpire, ElementTag>registerTag(ElementTag.class, "auto_expire", (attribute, object) -> {
+            return new ElementTag(object.doesAutoExpire());
+        });
+    }
+
+    public FallingBlock getFallingBlock() {
+        return (FallingBlock) entity.getBukkitEntity();
+    }
+
+    public boolean doesAutoExpire() {
+        return getFallingBlock().doesAutoExpire();
+    }
+
+    @Override
+    public String getPropertyString() {
+        return doesAutoExpire() ? null : "false";
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "auto_expire";
+    }
+
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name auto_expire
+        // @input ElementTag(Boolean)
+        // @Plugin Paper
+        // @description
+        // Sets whether a falling_block will auto-expire (after 30 seconds, or 5 when outside the world).
+        // @tags
+        // <EntityTag.auto_expire>
+        // -->
+        if (mechanism.matches("auto_expire") && mechanism.requireBoolean()) {
+            getFallingBlock().shouldAutoExpire(mechanism.getValue().asBoolean());
+        }
+    }
+}


### PR DESCRIPTION
## Additions

- `EntityTag.auto_expire` property - Controls whether a falling_block will auto-expire (after 30 seconds, or 5 when outside the world).