### PR TITLE
`MaterialAttached` - Hangable (mangrove_propagule) support

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -175,7 +175,7 @@ public class PropertyRegistry {
 
         // register core MaterialTag properties
         PropertyParser.registerProperty(MaterialAge.class, MaterialTag.class);
-        PropertyParser.registerProperty(MaterialAttachedToWall.class, MaterialTag.class);
+        PropertyParser.registerProperty(MaterialAttached.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialBlockType.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialBrewingStand.class, MaterialTag.class);
         PropertyParser.registerProperty(MaterialCampfire.class, MaterialTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialAttached.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialAttached.java
@@ -1,37 +1,41 @@
 package com.denizenscript.denizen.objects.properties.material;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.block.data.Hangable;
 import org.bukkit.block.data.type.Gate;
 import org.bukkit.block.data.type.Lantern;
 
-public class MaterialAttachedToWall implements Property {
+public class MaterialAttached implements Property {
 
     public static boolean describes(ObjectTag material) {
         return material instanceof MaterialTag
                 && ((MaterialTag) material).hasModernData()
                 && (((MaterialTag) material).getModernData() instanceof Gate
-                || ((MaterialTag) material).getModernData() instanceof Lantern);
+                || ((MaterialTag) material).getModernData() instanceof Lantern
+                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && ((MaterialTag) material).getModernData() instanceof Hangable));
     }
 
-    public static MaterialAttachedToWall getFrom(ObjectTag _material){
+    public static MaterialAttached getFrom(ObjectTag _material){
         if (!describes(_material)) {
             return null;
         }
         else {
-            return new MaterialAttachedToWall((MaterialTag) _material);
+            return new MaterialAttached((MaterialTag) _material);
         }
     }
 
     public static final String[] handledMechs = new String[] {
-            "attached_to_wall"
+            "attached", "attached_to_wall"
     };
 
-    private MaterialAttachedToWall(MaterialTag _material) {
+    private MaterialAttached(MaterialTag _material) {
         material = _material;
     }
 
@@ -40,62 +44,77 @@ public class MaterialAttachedToWall implements Property {
     public static void registerTags() {
 
         // <--[tag]
-        // @attribute <MaterialTag.attached_to_wall>
+        // @attribute <MaterialTag.attached>
         // @returns ElementTag(Boolean)
-        // @mechanism MaterialTag.attached_to_wall
+        // @mechanism MaterialTag.attached
         // @group properties
         // @description
-        // Returns whether this material is attached to a wall.
-        // For a lantern, this returns true if it is hanging from the ceiling.
+        // Returns whether a material is attached.
+        // For a lantern, this returns whether it is hanging from the ceiling.
         // For a gate, this returns whether it is lowered to attach to a wall block.
+        // For a mangrove_propagule, this returns whether it is hanging from the block above it.
         // -->
-        PropertyParser.<MaterialAttachedToWall, ElementTag>registerStaticTag(ElementTag.class, "attached_to_wall", (attribute, material) -> {
+        PropertyParser.<MaterialAttached, ElementTag>registerStaticTag(ElementTag.class, "attached", (attribute, material) -> {
             if (material.isGate()) {
                 return new ElementTag(material.getGate().isInWall());
             }
             else if (material.isLantern()) {
                 return new ElementTag(material.getLantern().isHanging());
             }
+            else if (material.isHangable()) {
+                return new ElementTag(((Hangable) material.material.getModernData()).isHanging());
+            }
             else { // Unreachable
                 return null;
             }
-        });
+        }, "attached_to_wall");
     }
 
     public boolean isGate() {
         return material.getModernData() instanceof Gate;
     }
 
-    public boolean isLantern() {
+    public boolean isLantern() { // TODO: 1.19 - Lantern extends Hangable
         return material.getModernData() instanceof Lantern;
+    }
+
+    public boolean isHangable() {
+        return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && material.getModernData() instanceof Hangable;
     }
 
     public Gate getGate() {
         return (Gate) material.getModernData();
     }
 
-    public Lantern getLantern() {
+    public Lantern getLantern() { // TODO: 1.19 - Lantern extends Hangable
         return (Lantern) material.getModernData();
     }
 
-    public boolean getAttachment() {
+    /*public Hangable getHangable() { // TODO: 1.19
+        return (Hangable) material.getModernData();
+    }*/
+
+    public boolean isAttached() {
         if (isGate()) {
             return getGate().isInWall();
         }
         else if (isLantern()) {
             return getLantern().isHanging();
         }
+        else if (isHangable()) {
+            return ((Hangable) material.getModernData()).isHanging(); // TODO: 1.19
+        }
         return false; // Unreachable
     }
 
     @Override
     public String getPropertyString() {
-        return String.valueOf(getAttachment());
+        return String.valueOf(isAttached());
     }
 
     @Override
     public String getPropertyId() {
-        return "attached_to_wall";
+        return "attached";
     }
 
     @Override
@@ -103,20 +122,25 @@ public class MaterialAttachedToWall implements Property {
 
         // <--[mechanism]
         // @object MaterialTag
-        // @name attached_to_wall
+        // @name attached
         // @input ElementTag(Boolean)
         // @description
-        // Sets whether a material is 'attached to a wall', which has a different meaning depending on the material type.
-        // Refer to <@link tag MaterialTag.attached_to_wall> for specifics.
+        // Sets whether a material is attached.
+        // For a lantern, this sets whether it is hanging from the ceiling.
+        // For a gate, this sets whether it is lowered to attach to a wall block.
+        // For a mangrove_propagule, this sets whether it is hanging from the block above it.
         // @tags
-        // <MaterialTag.attached_to_wall>
+        // <MaterialTag.attached>
         // -->
-        if (mechanism.matches("attached_to_wall") && mechanism.requireBoolean()) {
+        if ((mechanism.matches("attached") || mechanism.matches("attached_to_wall")) && mechanism.requireBoolean()) {
             if (isGate()) {
                 getGate().setInWall(mechanism.getValue().asBoolean());
             }
             else if (isLantern()) {
                 getLantern().setHanging(mechanism.getValue().asBoolean());
+            }
+            else if (isHangable()) {
+                ((Hangable) material.getModernData()).setHanging(mechanism.getValue().asBoolean()); // TODO: 1.19
             }
         }
     }


### PR DESCRIPTION
## Additions

- Added support for the 1.19 `Hangable` interface in the `MaterialAttached` property, which `Lantern` and `MangrovePropagule` extend

## Changes

- Renamed `MaterialAttachedToWall` to a more generic `MaterialAttached` - let me know if that should be reverted, the `attached_to_wall` name just didn't really make sense anymore
- Renamed `MaterialAttached#getAttachment()` to `MaterialAttached#isAttached()`
- Added meta to the Mechanism instead of just linking the tag

## Notes

- The `Lantern` code is still there for back-support, can be removed once support for `1.18` is dropped
- `attached_to_wall` naming still available for back-support