### PR TITLE
Add `PlayerTag.send_climbable_materials` mechanism

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -113,4 +113,8 @@ public abstract class PlayerHelper {
     public void sendPlayerRemovePacket(Player player, UUID id) {
         throw new UnsupportedOperationException();
     }
+
+    public void sendClimbableMaterials(Player player, List<Material> materials) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2504,6 +2504,37 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
 
         // <--[mechanism]
         // @object PlayerTag
+        // @name send_climbable_materials
+        // @input ListTag(MaterialTag)
+        // @description
+        // Sends the player a list of climbable materials.
+        // To climb a block, the player has to stand in it, which means only non-full blocks can be climbed.
+        // Note that this gets reset once the player rejoins or once server resources are reloaded (which happens when the vanilla /reload command is used, or when a data pack gets enabled).
+        // @tags
+        // <server.vanilla_tagged_materials[<tag>]>
+        // @example
+        // # Lets the linked player climb iron_bars, while keeping other climbable materials climbable
+        // - adjust <player> send_climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars]>
+        // @example
+        // # Lets the linked player climb only acacia_buttons, making all other materials non-climbable.
+        // - adjust <player> send_climbable_materials:acacia_button
+        // -->
+        if (mechanism.matches("send_climbable_materials") && mechanism.requireObject(ListTag.class)) {
+            List<MaterialTag> materialTags = mechanism.valueAsType(ListTag.class).filter(MaterialTag.class, mechanism.context);
+            List<Material> materials = new ArrayList<>();
+            for (MaterialTag materialTag : materialTags) {
+                Material material = materialTag.getMaterial();
+                if (!material.isBlock()) {
+                    mechanism.echoError("Invalid material specified '" + material.name() + "': must be a block material.");
+                    continue;
+                }
+                materials.add(material);
+            }
+            NMSHandler.playerHelper.sendClimbableMaterials(getPlayerEntity(), materials);
+        }
+
+        // <--[mechanism]
+        // @object PlayerTag
         // @name noclip
         // @input ElementTag(Boolean)
         // @description

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/ReflectionMappingsInfo.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/ReflectionMappingsInfo.java
@@ -119,4 +119,7 @@ public class ReflectionMappingsInfo {
     public static String FluidState_isEmpty = "c";
     public static String FluidState_createLegacyBlock = "g";
     public static String FluidState_animateTick = "a";
+
+    // net.minecraft.tags.TagNetworkSerialization$NetworkPayload
+    public static String TagNetworkSerialization_NetworkPayload_tags = "a";
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
@@ -25,9 +25,12 @@ import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.mojang.authlib.properties.Property;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.md_5.bungee.api.ChatColor;
+import net.minecraft.core.Registry;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerEntity;
@@ -38,6 +41,8 @@ import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.server.players.ServerOpList;
 import net.minecraft.server.players.ServerOpListEntry;
 import net.minecraft.stats.ServerRecipeBook;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagNetworkSerialization;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.ChunkPos;
@@ -46,6 +51,7 @@ import org.bukkit.*;
 import org.bukkit.boss.BossBar;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_18_R2.boss.CraftBossBar;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
@@ -422,5 +428,18 @@ public class PlayerHelperImpl extends PlayerHelper {
         GameProfile profile = new GameProfile(id, "name");
         packet.getEntries().add(new ClientboundPlayerInfoPacket.PlayerUpdate(profile, 0, null, null));
         PacketHelperImpl.send(player, packet);
+    }
+
+    @Override
+    public void sendClimbableMaterials(Player player, List<Material> materials) {
+        Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> packetInput = TagNetworkSerialization.serializeTagsToNetwork(((CraftServer) Bukkit.getServer()).getServer().registryAccess());
+        TagNetworkSerialization.NetworkPayload payload = packetInput.get(Registry.BLOCK_REGISTRY);
+        Map<ResourceLocation, IntList> tags = ReflectionHelper.getFieldValue(TagNetworkSerialization.NetworkPayload.class, ReflectionMappingsInfo.TagNetworkSerialization_NetworkPayload_tags, payload);
+        IntList intList = tags.get(BlockTags.CLIMBABLE.location());
+        intList.clear();
+        for (Material material : materials) {
+            intList.add(Registry.BLOCK.getId(((CraftBlockData) material.createBlockData()).getState().getBlock()));
+        }
+        PacketHelperImpl.send(player, new ClientboundUpdateTagsPacket(packetInput));
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
@@ -119,4 +119,7 @@ public class ReflectionMappingsInfo {
     public static String FluidState_isEmpty = "c";
     public static String FluidState_createLegacyBlock = "g";
     public static String FluidState_animateTick = "a";
+
+    // net.minecraft.tags.TagNetworkSerialization$NetworkPayload
+    public static String TagNetworkSerialization_NetworkPayload_tags = "a";
 }


### PR DESCRIPTION
## Additions

- `PlayerTag.send_climbable_materials` mechanism - Sends the player a list of climbable materials.
- `PlayerHelper#sendClimbableMaterials(Player player, List<Material> materials)` - used by above mech.