### PR TITLE
`MaterialTag.vanilla_tags` mechanism

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -13,6 +13,7 @@ import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
+import java.util.Set;
 
 public interface BlockHelper {
 
@@ -100,6 +101,10 @@ public interface BlockHelper {
     }
 
     default Color getMapColor(Block block) {
+        throw new UnsupportedOperationException();
+    }
+
+    default void setVanillaTags(Material material, Set<String> tags) {
         throw new UnsupportedOperationException();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -617,6 +617,30 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
 
         // <--[mechanism]
         // @object MaterialTag
+        // @name vanilla_tags
+        // @input ListTag
+        // @description
+        // Sets the material's vanilla tags.
+        // Any tag name will be accepted. as in, any tag name inputted will be added to the material, regardless of whether it previously existed or not.
+        // Note that this gets reset once server resources are reloaded (which happens when the vanilla /reload command is used, or when a data pack gets enabled).
+        // @tags
+        // <MaterialTag.vanilla_tags>
+        // @example
+        // # Adds the guarded_by_piglins tag to <[material]>, without removing it's other tags.
+        // - adjust <[material]> vanilla_tags:<[material].vanilla_tags.include[guarded_by_piglins]>
+        // @example
+        // # Removes the dead_bush_may_place_on tag from <[material]>, while keeping it's other tags.
+        // - adjust <[material]> vanilla_tags:<[material].vanilla_tags.exclude[dead_bush_may_place_on]>
+        // @example
+        // # Removes all vanilla tags from <[material]>, leaving it with only the wither_summon_base_blocks tag.
+        // - adjust <[material]> vanilla_tags:wither_summon_base_blocks
+        // -->
+        if (!mechanism.isProperty && mechanism.matches("vanilla_tags") && mechanism.requireObject(ListTag.class)) {
+            NMSHandler.blockHelper.setVanillaTags(material, new HashSet<>(mechanism.valueAsType(ListTag.class)));
+        }
+
+        // <--[mechanism]
+        // @object MaterialTag
         // @name max_stack_size
         // @input ElementTag(Number)
         // @description

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -621,7 +621,7 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // @name vanilla_tags
         // @input ListTag
         // @description
-        // Sets the material's vanilla tags.
+        // Sets a material's vanilla tags.
         // Any tag name will be accepted. as in, any tag name inputted will be added to the material, regardless of whether it previously existed or not.
         // Note that this gets reset once server resources are reloaded (which happens when the vanilla /reload command is used, or when a data pack gets enabled).
         // @tags

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -25,6 +25,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 
 import java.util.HashSet;
+import java.util.Set;
 
 public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
 
@@ -636,7 +637,16 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // - adjust <[material]> vanilla_tags:wither_summon_base_blocks
         // -->
         if (!mechanism.isProperty && mechanism.matches("vanilla_tags") && mechanism.requireObject(ListTag.class)) {
-            NMSHandler.blockHelper.setVanillaTags(material, new HashSet<>(mechanism.valueAsType(ListTag.class)));
+            ListTag input = mechanism.valueAsType(ListTag.class);
+            Set<String> tags = new HashSet<>();
+            for (String tag : input) {
+                if (!VanillaTagHelper.isValidTagName(tag)) {
+                    mechanism.echoError("Invalid tag name '" + tag + "' inputted.");
+                    continue;
+                }
+                tags.add(tag);
+            }
+            NMSHandler.blockHelper.setVanillaTags(material, tags);
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
@@ -105,4 +105,8 @@ public class VanillaTagHelper {
         NamespacedKey key = tag.getKey();
         return key.getNamespace().equals("minecraft") ? key.getKey() : key.toString();
     }
+
+    public static boolean isValidTagName(String name) {
+        return name != null && !name.isEmpty() && NamespacedKey.fromString(name) != null;
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
@@ -2,10 +2,7 @@ package com.denizenscript.denizen.utilities;
 
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
-import org.bukkit.Bukkit;
-import org.bukkit.Keyed;
-import org.bukkit.Material;
-import org.bukkit.Tag;
+import org.bukkit.*;
 import org.bukkit.entity.EntityType;
 
 import java.util.HashMap;
@@ -41,8 +38,8 @@ public class VanillaTagHelper {
     }
 
     static <T extends Keyed> void update(Tag<T> tag, HashMap<T, HashSet<String>> tagByObj, HashMap<String, HashSet<T>> objByTag) {
-        String tagStr = tag.getKey().getKey();
-        Set<T> objs = objByTag.get(tagStr);
+        String tagName = getTagName(tag);
+        Set<T> objs = objByTag.get(tagName);
         if (objs == null) {
             return;
         }
@@ -52,12 +49,12 @@ public class VanillaTagHelper {
                 tagByObj.remove(obj);
             }
             else {
-                tags.remove(tagStr);
+                tags.remove(tagName);
             }
         }
         Set<T> newObjs = tag.getValues();
         for (T obj : newObjs) {
-            tagByObj.computeIfAbsent(obj, k -> new HashSet<>()).add(tagStr);
+            tagByObj.computeIfAbsent(obj, k -> new HashSet<>()).add(tagName);
         }
         objs.clear();
         objs.addAll(newObjs);
@@ -72,9 +69,10 @@ public class VanillaTagHelper {
     }
 
     static <T extends Keyed> void add(Tag<T> tag, HashMap<T, HashSet<String>> tagByObj, HashMap<String, HashSet<T>> objByTag) {
-        objByTag.computeIfAbsent(tag.getKey().getKey(), (k) -> new HashSet<>()).addAll(tag.getValues());
+        String tagName = getTagName(tag);
+        objByTag.computeIfAbsent(tagName, (k) -> new HashSet<>()).addAll(tag.getValues());
         for (T obj : tag.getValues()) {
-            tagByObj.computeIfAbsent(obj, (k) -> new HashSet<>()).add(tag.getKey().getKey());
+            tagByObj.computeIfAbsent(obj, (k) -> new HashSet<>()).add(tagName);
         }
     }
 
@@ -101,5 +99,10 @@ public class VanillaTagHelper {
         for (Tag<Material> tag : Bukkit.getTags("items", Material.class)) {
             addMaterialTag(tag);
         }
+    }
+
+    static String getTagName(Tag<?> tag) {
+        NamespacedKey key = tag.getKey();
+        return key.getNamespace().equals("minecraft") ? key.getKey() : key.toString();
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.EntityType;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 public class VanillaTagHelper {
 
@@ -20,6 +21,55 @@ public class VanillaTagHelper {
     public static HashMap<EntityType, HashSet<String>> tagsByEntity = new HashMap<>();
 
     public static HashMap<String, HashSet<EntityType>> entityTagsByKey = new HashMap<>();
+
+    public static void addOrUpdateMaterialTag(Tag<Material> tag) {
+        if (materialTagsByKey.containsKey(tag.getKey().getKey())) {
+            updateMaterialTag(tag);
+        }
+        else {
+            addMaterialTag(tag);
+        }
+    }
+
+    public static void addOrUpdateEntityTag(Tag<EntityType> tag) {
+        if (entityTagsByKey.containsKey(tag.getKey().getKey())) {
+            updateEntityTag(tag);
+        }
+        else {
+            addEntityTag(tag);
+        }
+    }
+
+    static <T extends Keyed> void update(Tag<T> tag, HashMap<T, HashSet<String>> tagByObj, HashMap<String, HashSet<T>> objByTag) {
+        String tagStr = tag.getKey().getKey();
+        Set<T> objs = objByTag.get(tagStr);
+        if (objs == null) {
+            return;
+        }
+        for (T obj : objs) {
+            Set<String> tags = tagByObj.get(obj);
+            if (tags.size() == 1) {
+                tagByObj.remove(obj);
+            }
+            else {
+                tags.remove(tagStr);
+            }
+        }
+        Set<T> newObjs = tag.getValues();
+        for (T obj : newObjs) {
+            tagByObj.computeIfAbsent(obj, k -> new HashSet<>()).add(tagStr);
+        }
+        objs.clear();
+        objs.addAll(newObjs);
+    }
+
+    public static void updateMaterialTag(Tag<Material> tag) {
+        update(tag, tagsByMaterial, materialTagsByKey);
+    }
+
+    public static void updateEntityTag(Tag<EntityType> tag) {
+        update(tag, tagsByEntity, entityTagsByKey);
+    }
 
     static <T extends Keyed> void add(Tag<T> tag, HashMap<T, HashSet<String>> tagByObj, HashMap<String, HashSet<T>> objByTag) {
         objByTag.computeIfAbsent(tag.getKey().getKey(), (k) -> new HashSet<>()).addAll(tag.getValues());

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/ReflectionMappingsInfo.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/ReflectionMappingsInfo.java
@@ -122,4 +122,10 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.tags.TagNetworkSerialization$NetworkPayload
     public static String TagNetworkSerialization_NetworkPayload_tags = "a";
+
+    // net.minecraft.core.HolderSet$Named
+    public static String HolderSet_Named_bind = "b";
+
+    // net.minecraft.core.Holder$Reference
+    public static String Holder_Reference_bindTags = "a";
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
@@ -384,8 +384,8 @@ public class BlockHelperImpl implements BlockHelper {
         });
         List<TagKey<net.minecraft.world.level.block.Block>> newNmsTags = new ArrayList<>();
         for (String tag : tags) {
-            TagKey<net.minecraft.world.level.block.Block> newTag = TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(tag));
-            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getOrCreateTag(newTag);
+            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(tag));
+            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getOrCreateTag(newNmsTag);
             List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
             nmsHolders.add(nmsHolder);
             try {
@@ -394,8 +394,8 @@ public class BlockHelperImpl implements BlockHelper {
             catch (Throwable ex) {
                 Debug.echoError(ex);
             }
-            newNmsTags.add(newTag);
-            VanillaTagHelper.addOrUpdateMaterialTag(new CraftBlockTag(Registry.BLOCK, newTag));
+            newNmsTags.add(newNmsTag);
+            VanillaTagHelper.addOrUpdateMaterialTag(new CraftBlockTag(Registry.BLOCK, newNmsTag));
         }
         try {
             Holder_Reference_bindTags.invoke(nmsHolder, newNmsTags);

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
@@ -122,4 +122,10 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.tags.TagNetworkSerialization$NetworkPayload
     public static String TagNetworkSerialization_NetworkPayload_tags = "a";
+
+    // net.minecraft.core.HolderSet$Named
+    public static String HolderSet_Named_bind = "b";
+
+    // net.minecraft.core.Holder$Reference
+    public static String Holder_Reference_bindTags = "a";
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTagBuilder;
 import com.denizenscript.denizen.nms.v1_19.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_19.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.VanillaTagHelper;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.google.common.collect.Iterables;
 import com.mojang.authlib.GameProfile;
@@ -13,9 +14,13 @@ import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
+import net.minecraft.core.*;
+import net.minecraft.core.Registry;
+import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.TagKey;
+import net.minecraft.tags.TagNetworkSerialization;
 import net.minecraft.util.InclusiveRange;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.random.SimpleWeightedRandomList;
@@ -31,23 +36,24 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.material.PushReaction;
-import org.bukkit.Color;
-import org.bukkit.Instrument;
-import org.bukkit.Location;
-import org.bukkit.Material;
+import org.bukkit.*;
 import org.bukkit.block.*;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R1.CraftChunk;
+import org.bukkit.craftbukkit.v1_19_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R1.block.*;
 import org.bukkit.craftbukkit.v1_19_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_19_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_19_R1.tag.CraftBlockTag;
 import org.bukkit.craftbukkit.v1_19_R1.util.CraftMagicNumbers;
+import org.bukkit.entity.Player;
 import org.bukkit.event.world.PortalCreateEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class BlockHelperImpl implements BlockHelper {
 
@@ -355,6 +361,54 @@ public class BlockHelperImpl implements BlockHelper {
     public Color getMapColor(Block block) {
         CraftBlock craftBlock = (CraftBlock) block;
         return Color.fromRGB(craftBlock.getNMS().getMapColor(craftBlock.getHandle(), craftBlock.getPosition()).col);
+    }
+
+    public static MethodHandle HolderSet_Named_bind = ReflectionHelper.getMethodHandle(HolderSet.Named.class, ReflectionMappingsInfo.HolderSet_Named_bind, List.class);
+    public static MethodHandle Holder_Reference_bindTags = ReflectionHelper.getMethodHandle(Holder.Reference.class, ReflectionMappingsInfo.Holder_Reference_bindTags, Collection.class);
+
+    @Override
+    public void setVanillaTags(Material material, Set<String> tags) {
+        Holder<net.minecraft.world.level.block.Block> nmsHolder = getMaterialBlock(material).builtInRegistryHolder();
+        nmsHolder.tags().forEach(nmsTag -> {
+            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getTag(nmsTag).orElse(null);
+            if (nmsHolderSet == null) {
+                return;
+            }
+            List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
+            nmsHolders.remove(nmsHolder);
+            try {
+                HolderSet_Named_bind.invoke(nmsHolderSet, nmsHolders);
+            }
+            catch (Throwable ex) {
+                Debug.echoError(ex);
+            }
+            VanillaTagHelper.updateMaterialTag(new CraftBlockTag(Registry.BLOCK, nmsTag));
+        });
+        List<TagKey<net.minecraft.world.level.block.Block>> newTags = new ArrayList<>();
+        for (String tag : tags) {
+            TagKey<net.minecraft.world.level.block.Block> newTag = TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(tag));
+            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getOrCreateTag(newTag);
+            List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
+            nmsHolders.add(nmsHolder);
+            try {
+                HolderSet_Named_bind.invoke(nmsHolderSet, nmsHolders);
+            }
+            catch (Throwable ex) {
+                Debug.echoError(ex);
+            }
+            newTags.add(newTag);
+            VanillaTagHelper.addOrUpdateMaterialTag(new CraftBlockTag(Registry.BLOCK, newTag));
+        }
+        try {
+            Holder_Reference_bindTags.invoke(nmsHolder, newTags);
+        }
+        catch (Throwable ex) {
+            Debug.echoError(ex);
+        }
+        ClientboundUpdateTagsPacket tagsPacket = new ClientboundUpdateTagsPacket(TagNetworkSerialization.serializeTagsToNetwork(((CraftServer) Bukkit.getServer()).getServer().registryAccess()));
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            PacketHelperImpl.send(player, tagsPacket);
+        }
     }
 
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
@@ -384,10 +384,10 @@ public class BlockHelperImpl implements BlockHelper {
             }
             VanillaTagHelper.updateMaterialTag(new CraftBlockTag(Registry.BLOCK, nmsTag));
         });
-        List<TagKey<net.minecraft.world.level.block.Block>> newTags = new ArrayList<>();
+        List<TagKey<net.minecraft.world.level.block.Block>> newNmsTags = new ArrayList<>();
         for (String tag : tags) {
-            TagKey<net.minecraft.world.level.block.Block> newTag = TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(tag));
-            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getOrCreateTag(newTag);
+            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(tag));
+            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getOrCreateTag(newNmsTag);
             List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
             nmsHolders.add(nmsHolder);
             try {
@@ -396,11 +396,11 @@ public class BlockHelperImpl implements BlockHelper {
             catch (Throwable ex) {
                 Debug.echoError(ex);
             }
-            newTags.add(newTag);
-            VanillaTagHelper.addOrUpdateMaterialTag(new CraftBlockTag(Registry.BLOCK, newTag));
+            newNmsTags.add(newNmsTag);
+            VanillaTagHelper.addOrUpdateMaterialTag(new CraftBlockTag(Registry.BLOCK, newNmsTag));
         }
         try {
-            Holder_Reference_bindTags.invoke(nmsHolder, newTags);
+            Holder_Reference_bindTags.invoke(nmsHolder, newNmsTags);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);


### PR DESCRIPTION
## Additions

- `MaterialTag.vanilla_tags` mechanism - Sets a material's vanilla tags.
- `VanillaTagHelper` -
   > `update` - updates a tag's values in a map of objects to sets of tags, and in a map of tags to sets of objects.
   > `updateMaterialTag` - calls the `update` method for the given material tag.
   > `updateEntityTag` - calls the `update` method for the given entity tag.
   > `addOrUpdateMaterialTag` - calls the `addMaterialTag` or `updateMaterialTag` (if it's already in `VanillaTagHelper`) methods for the given material tag.
   > `addOrUpdateEntityTag` - calls the `addEntityTag` or `updateEntityTag` (if it's already in `VanillaTagHelper`) methods for the given material tag.
   > `getTagName` - returns a tag's name; just the key if it's in the `minecraft` namespace, or the full `namespace:key` pair if it's not.
   > `isValidTagName` - returns whether a string is a valid tag name.
- `BlockHelper#setVanillaTags` - Sets a material's vanilla tags, used in the `MaterialTag.vanilla_tags` mechanism. Implemented in `1.18` and `1.19`.

## Changes

- `VanillaTagHelper#add` now uses `VanillaTagHelper#getTagName` to get the tag's name.
- Custom namespaces are now supported for tags - tags in the `mineacraft` namespace will remain the same (just the key), but tags in any other namespace will now use the full `namespace:key` pair.

## Notes

- Currently tag name validation is done in the mech code, should that be done in `BlockHelper#setVanillaTags`?