### PR TITLE
Add `server resources reloaded` event

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -49,6 +49,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PreEntitySpawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(ProjectileCollideScriptEvent.class);
         ScriptEvent.registerScriptEvent(ServerListPingScriptEventPaperImpl.class);
+        ScriptEvent.registerScriptEvent(ServerResourcesReloadedScriptEvent.class);
         ScriptEvent.registerScriptEvent(TNTPrimesScriptEvent.class);
         ScriptEvent.registerScriptEvent(UnknownCommandScriptEvent.class);
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerResourcesReloadedScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerResourcesReloadedScriptEvent.java
@@ -1,0 +1,64 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import io.papermc.paper.event.server.ServerResourcesReloadedEvent;
+
+public class ServerResourcesReloadedScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // server resources reloaded
+    //
+    // @Plugin Paper
+    //
+    // @Group Paper
+    //
+    // @Switch cause:<cause> to only process the event if the cause of the resource reload matches the specified cause.
+    //
+    // @Triggers when vanilla resources (such as datapacks) are reloaded (by vanilla commands or by plugins).
+    //
+    // @Context
+    // <context.cause> Returns the cause of the resource reload. Refer to <@link url https://jd.papermc.io/paper/1.19/io/papermc/paper/event/server/ServerResourcesReloadedEvent.Cause.html>
+    //
+    // -->
+
+    public ServerResourcesReloadedScriptEvent() {
+        instance = this;
+        registerCouldMatcher("server resources reloaded");
+        registerSwitches("cause");
+    }
+
+    public static ServerResourcesReloadedScriptEvent instance;
+    public ElementTag cause;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runGenericSwitchCheck(path, "cause", cause.asString())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "ServerResourcesReloaded";
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "cause": return cause;
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onServerResourcesReloaded(ServerResourcesReloadedEvent event) {
+        cause = new ElementTag(event.getCause().name());
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -624,7 +624,7 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Sets a material's vanilla tags.
         // Any tag name will be accepted - meaning, any tag name input will be added to the material, regardless of whether it previously existed or not.
-        // Note that this gets reset once server resources are reloaded (which happens when the vanilla /reload command is used, or when a data pack gets enabled).
+        // Note that this gets reset once server resources are reloaded (see <@link event server resources reloaded>).
         // @tags
         // <MaterialTag.vanilla_tags>
         // @example

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2509,7 +2509,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @description
         // Sends the player a list of climbable materials.
         // To climb a block, the player has to stand in it, which means only non-full blocks can be climbed.
-        // Note that this gets reset once the player rejoins or once server resources are reloaded (which happens when the vanilla /reload command is used, or when a data pack gets enabled).
+        // Note that this gets reset once the player rejoins or once server resources are reloaded (see <@link event server resources reloaded>).
         // @tags
         // <server.vanilla_tagged_materials[<tag>]>
         // @example


### PR DESCRIPTION
## Additions

- `server resources reloaded` event - Fires when vanilla resources (such as datapacks) are reloaded (by vanilla commands or by plugins).

## Changes

- Changed `PlayerTag.send_climbable_materials` and `MaterialTag.vanilla_tags` meta to mention the `server resources reloaded` event