### PR TITLE
playerCompletesAdvancement paper additions

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -40,6 +40,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerBeaconEffectScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClicksFakeEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClicksInRecipeBookScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerElytraBoostScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerEquipsArmorScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerJumpsScriptEventPaperImpl.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerCompletesAdvancementScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerCompletesAdvancementScriptEventPaperImpl.java
@@ -3,13 +3,9 @@ package com.denizenscript.denizen.paper.events;
 import com.denizenscript.denizen.events.player.PlayerCompletesAdvancementScriptEvent;
 import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.ChatColor;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.PlayerAdvancementDoneEvent;
 
 public class PlayerCompletesAdvancementScriptEventPaperImpl extends PlayerCompletesAdvancementScriptEvent {
 
@@ -19,42 +15,27 @@ public class PlayerCompletesAdvancementScriptEventPaperImpl extends PlayerComple
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("criteria")) {
-            ListTag criteria = new ListTag();
-            criteria.addAll(event.getAdvancement().getCriteria());
-            return criteria;
-        }
-        else if (name.equals("advancement")) {
-            return new ElementTag(event.getAdvancement().getKey().getKey());
-        }
-        else if (name.equals("message")) {
-            return new ElementTag(PaperModule.stringifyComponent(event.message(), ChatColor.WHITE));
+        switch (name) {
+            case "message": return new ElementTag(PaperModule.stringifyComponent(event.message(), ChatColor.WHITE));
         }
         return super.getContext(name);
     }
 
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        String determination = determinationObj.toString();
-        String lower = CoreUtilities.toLowerCase(determination);
-        if (lower.startsWith("no_message")) {
-            event.message(null);
-            return true;
-        }
-        else if (event instanceof PlayerAdvancementDoneEvent) {
-            event.message(Component.text(determination));
+        if (determinationObj instanceof ElementTag) {
+            String determination = determinationObj.toString();
+            String lower = CoreUtilities.toLowerCase(determination);
+            if (lower.equals("no_message")) {
+                event.message(null);
+                return true;
+            }
+            event.message(PaperModule.parseFormattedText(determination, ChatColor.WHITE));
             return true;
         }
         else {
             return super.applyDetermination(path, determinationObj);
         }
-    }
-
-    @EventHandler
-    public void onPlayerCompletesAdvancement(PlayerAdvancementDoneEvent event) {
-        // TODO: Should this not fire if it's a 'fake' advancement created by Denizen?
-        this.event = event;
-        fire(event);
     }
 }
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerCompletesAdvancementScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerCompletesAdvancementScriptEventPaperImpl.java
@@ -1,48 +1,20 @@
 package com.denizenscript.denizen.paper.events;
 
-import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.events.player.PlayerCompletesAdvancementScriptEvent;
+import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerAdvancementDoneEvent;
 
-import static com.denizenscript.denizen.paper.PaperModule.stringifyComponent;
-
-public class PlayerCompletesAdvancementScriptEventPaperImpl extends BukkitScriptEvent implements Listener {
+public class PlayerCompletesAdvancementScriptEventPaperImpl extends PlayerCompletesAdvancementScriptEvent {
 
     public PlayerCompletesAdvancementScriptEventPaperImpl() {
         instance = this;
-    }
-    public static PlayerCompletesAdvancementScriptEventPaperImpl instance;
-    public PlayerAdvancementDoneEvent event;
-    @Override
-    public boolean couldMatch(ScriptPath path) {
-        return path.eventLower.startsWith("player completes advancement");
-    }
-
-    @Override
-    public boolean matches(ScriptPath path) {
-        if (!runGenericSwitchCheck(path, "name", event.getAdvancement().getKey().getKey())) {
-            return false;
-        }
-        return super.matches(path);
-    }
-
-    @Override
-    public String getName() {
-        return "PlayerCompletesAdvancement";
-    }
-
-    @Override
-    public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(event.getPlayer());
     }
 
     @Override
@@ -56,10 +28,11 @@ public class PlayerCompletesAdvancementScriptEventPaperImpl extends BukkitScript
             return new ElementTag(event.getAdvancement().getKey().getKey());
         }
         else if (name.equals("message")) {
-            return new ElementTag(stringifyComponent(event.message(), ChatColor.WHITE));
+            return new ElementTag(PaperModule.stringifyComponent(event.message(), ChatColor.WHITE));
         }
         return super.getContext(name);
     }
+
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
         String determination = determinationObj.toString();

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerCompletesAdvancementScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerCompletesAdvancementScriptEventPaperImpl.java
@@ -1,4 +1,4 @@
-package com.denizenscript.denizen.events.player;
+package com.denizenscript.denizen.paper.events;
 
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
@@ -6,44 +6,22 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerAdvancementDoneEvent;
 
-public class PlayerCompletesAdvancementScriptEvent extends BukkitScriptEvent implements Listener {
+import static com.denizenscript.denizen.paper.PaperModule.stringifyComponent;
 
-    // <--[event]
-    // @Events
-    // player completes advancement
-    //
-    // @Regex ^on player completes advancement$
-    //
-    // @Group Player
-    //
-    // @Switch name:<name> to only fire if the advancement has the specified name.
-    //
-    // @Triggers when a player has completed all criteria in an advancement.
-    //
-    // @Context
-    // <context.criteria> returns all the criteria present in this advancement.
-    // <context.advancement> returns the completed advancement's minecraft ID key.
-    // <context.message> returns an ElementTag of the advancement message (only on Paper).
-    //
-    // @Determine
-    // ElementTag to change the advancement message (only on Paper).
-    // "NO_MESSAGE" to hide the advancement message (only on Paper).
-    //
-    // @Player Always.
-    //
-    // -->
+public class PlayerCompletesAdvancementScriptEventPaperImpl extends BukkitScriptEvent implements Listener {
 
-    public PlayerCompletesAdvancementScriptEvent() {
+    public PlayerCompletesAdvancementScriptEventPaperImpl() {
         instance = this;
     }
-
-    public static PlayerCompletesAdvancementScriptEvent instance;
+    public static PlayerCompletesAdvancementScriptEventPaperImpl instance;
     public PlayerAdvancementDoneEvent event;
-
     @Override
     public boolean couldMatch(ScriptPath path) {
         return path.eventLower.startsWith("player completes advancement");
@@ -77,7 +55,26 @@ public class PlayerCompletesAdvancementScriptEvent extends BukkitScriptEvent imp
         else if (name.equals("advancement")) {
             return new ElementTag(event.getAdvancement().getKey().getKey());
         }
+        else if (name.equals("message")) {
+            return new ElementTag(stringifyComponent(event.message(), ChatColor.WHITE));
+        }
         return super.getContext(name);
+    }
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        String determination = determinationObj.toString();
+        String lower = CoreUtilities.toLowerCase(determination);
+        if (lower.startsWith("no_message")) {
+            event.message(null);
+            return true;
+        }
+        else if (event instanceof PlayerAdvancementDoneEvent) {
+            event.message(Component.text(determination));
+            return true;
+        }
+        else {
+            return super.applyDetermination(path, determinationObj);
+        }
     }
 
     @EventHandler
@@ -87,3 +84,4 @@ public class PlayerCompletesAdvancementScriptEvent extends BukkitScriptEvent imp
         fire(event);
     }
 }
+

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -172,7 +172,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerClicksInInventoryScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClosesInvScriptEvent.class);
         if (!Denizen.supportsPaper) {
-            ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEvent.PlayerCompletesAdvancementSpigotScriptEvent.class);
+            ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEvent.class);
         }
         ScriptEvent.registerScriptEvent(PlayerConsumesScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerCraftsItemScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -172,7 +172,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerClicksInInventoryScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClosesInvScriptEvent.class);
         if (!Denizen.supportsPaper) {
-            ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEvent.class);
+            ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEvent.PlayerCompletesAdvancementSpigotScriptEvent.class);
         }
         ScriptEvent.registerScriptEvent(PlayerConsumesScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerCraftsItemScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -171,7 +171,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerClicksBlockScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClicksInInventoryScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClosesInvScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEvent.class);
+        if (!Denizen.supportsPaper) {
+            ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerConsumesScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerCraftsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerDamagesBlockScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerCompletesAdvancementScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerCompletesAdvancementScriptEvent.java
@@ -79,11 +79,13 @@ public class PlayerCompletesAdvancementScriptEvent extends BukkitScriptEvent imp
         }
         return super.getContext(name);
     }
+    public static class PlayerCompletesAdvancementSpigotScriptEvent extends PlayerCompletesAdvancementScriptEvent {
 
-    @EventHandler
-    public void onPlayerCompletesAdvancement(PlayerAdvancementDoneEvent event) {
-        // TODO: Should this not fire if it's a 'fake' advancement created by Denizen?
-        this.event = event;
-        fire(event);
+        @EventHandler
+        public void onPlayerCompletesAdvancement(PlayerAdvancementDoneEvent event) {
+            // TODO: Should this not fire if it's a 'fake' advancement created by Denizen?
+            this.event = event;
+            fire(event);
+        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerCompletesAdvancementScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerCompletesAdvancementScriptEvent.java
@@ -79,13 +79,11 @@ public class PlayerCompletesAdvancementScriptEvent extends BukkitScriptEvent imp
         }
         return super.getContext(name);
     }
-    public static class PlayerCompletesAdvancementSpigotScriptEvent extends PlayerCompletesAdvancementScriptEvent {
 
-        @EventHandler
-        public void onPlayerCompletesAdvancement(PlayerAdvancementDoneEvent event) {
-            // TODO: Should this not fire if it's a 'fake' advancement created by Denizen?
-            this.event = event;
-            fire(event);
-        }
+    @EventHandler
+    public void onPlayerCompletesAdvancement(PlayerAdvancementDoneEvent event) {
+        // TODO: Should this not fire if it's a 'fake' advancement created by Denizen?
+        this.event = event;
+        fire(event);
     }
 }


### PR DESCRIPTION
This PR adds following additions to the player completes advancements event on paper:

Context tags:

- `<context.message>` returns an ElementTag of the advancement message (only on Paper).

Determine options:

- `ElementTag` to change the advancement message (only on Paper).
-  `"NO_MESSAGE"` to hide the advancement message (only on Paper).