### PR TITLE
Invisible command `for:` argument

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -31,6 +31,10 @@ public abstract class EntityHelper {
         // Do nothing on older versions
     }
 
+    public boolean isInvisible(Entity entity) {
+        throw new UnsupportedOperationException();
+    }
+
     public abstract double getAbsorption(LivingEntity entity);
 
     public abstract void setAbsorption(LivingEntity entity, double value);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
@@ -43,6 +43,7 @@ public class InvisibleCommand extends AbstractCommand {
     // If an NPC was specified, the 'invisible' trait is applied.
     //
     // Optionally specify 'for:' with a list of players to fake the entity's visibility state for these players.
+    // When using the 'toggle' state with the 'for:' argument, the visibility state will be toggled for each player separately.
     // Note that using the 'for:' argument won't apply the 'invisible' trait to NPCs.
     // If unspecified, will be set globally.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
@@ -133,7 +133,7 @@ public class InvisibleCommand extends AbstractCommand {
         else if (entity.isLivingEntity() && !entity.isFake) {
             entity.getLivingEntity().setInvisible(invisible);
             if (!invisible) {
-                // Remove the invisibility potion effect for compact with old uses (the command used to add the potion effect)
+                // Remove the invisibility potion effect for compact with old uses (the command used to add it)
                 entity.getLivingEntity().removePotionEffect(PotionEffectType.INVISIBILITY);
             }
         }
@@ -214,7 +214,8 @@ public class InvisibleCommand extends AbstractCommand {
             return !((ItemFrame) entity).isVisible();
         }
         else if (entity instanceof LivingEntity) {
-            return ((LivingEntity) entity).isInvisible();
+            // Check for the invisibility potion effect for compact with old uses (the command used to add it)
+            return ((LivingEntity) entity).isInvisible() || ((LivingEntity) entity).hasPotionEffect(PotionEffectType.INVISIBILITY);
         }
         else {
             return NMSHandler.entityHelper.isInvisible(entity);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
@@ -24,7 +24,7 @@ public class InvisibleCommand extends AbstractCommand {
 
     public InvisibleCommand() {
         setName("invisible");
-        setSyntax("invisible [<entity>] (state:true/false/toggle/reset) (for:<player>|...)");
+        setSyntax("invisible (<entity>) (state:true/false/toggle/reset) (for:<player>|...)");
         setPrefixesHandled("for");
         setRequiredArguments(0, 3);
         isProcedural = false;
@@ -32,7 +32,7 @@ public class InvisibleCommand extends AbstractCommand {
 
     // <--[command]
     // @Name Invisible
-    // @Syntax invisible [<entity>] (state:true/false/toggle/reset) (for:<player>|...)
+    // @Syntax invisible (<entity>) (state:true/false/toggle/reset) (for:<player>|...)
     // @Required 0
     // @Maximum 3
     // @Short Sets whether an NPC or entity are invisible.
@@ -60,7 +60,7 @@ public class InvisibleCommand extends AbstractCommand {
     // - invisible
     //
     // @Usage
-    // Use to make the linked NPC visible if previously invisible, and invisible if not
+    // Use to make the linked NPC visible if previously invisible, and invisible if not.
     // - invisible <npc> state:toggle
     //
     // @Usage
@@ -83,10 +83,6 @@ public class InvisibleCommand extends AbstractCommand {
                 scriptEntry.addObject("state", arg.asElement());
             }
             else if (!scriptEntry.hasObject("target")
-                    && arg.matchesArgumentType(EntityTag.class)) {
-                scriptEntry.addObject("target", arg.asType(EntityTag.class));
-            }
-            else if (!scriptEntry.hasObject("target")
                     && arg.matches("player")
                     && Utilities.entryHasPlayer(scriptEntry)) {
                 scriptEntry.addObject("target", Utilities.getEntryPlayer(scriptEntry).getDenizenEntity());
@@ -95,6 +91,10 @@ public class InvisibleCommand extends AbstractCommand {
                     && arg.matches("npc")
                     && Utilities.entryHasNPC(scriptEntry)) {
                 scriptEntry.addObject("target", Utilities.getEntryNPC(scriptEntry).getDenizenEntity());
+            }
+            else if (!scriptEntry.hasObject("target")
+                    && arg.matchesArgumentType(EntityTag.class)) {
+                scriptEntry.addObject("target", arg.asType(EntityTag.class));
             }
             else {
                 arg.reportUnhandled();
@@ -145,7 +145,7 @@ public class InvisibleCommand extends AbstractCommand {
     @Override
     public void execute(ScriptEntry scriptEntry) {
         EntityTag target = scriptEntry.getObjectTag("target");
-        if (target == null || target.isFake) {
+        if (target == null) {
             Debug.echoError(scriptEntry, "Must specify a valid target.");
             return;
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/InvisibleCommand.java
@@ -17,6 +17,7 @@ import org.bukkit.entity.*;
 import org.bukkit.potion.PotionEffectType;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -178,10 +179,27 @@ public class InvisibleCommand extends AbstractCommand {
                 }
                 break;
             case RESET:
-                HashMap<UUID, Boolean> playerMap = invisibleEntities.remove(target.getUUID());
-                if (playerMap != null) {
+                HashMap<UUID, Boolean> playerMap = invisibleEntities.get(target.getUUID());
+                if (playerMap == null) {
+                    return;
+                }
+                HashSet<UUID> playersToUpdate = new HashSet<>();
+                if (forPlayers == null) {
+                    playersToUpdate.addAll(playerMap.keySet());
+                    invisibleEntities.remove(target.getUUID());
+                }
+                else {
+                    for (PlayerTag player : forPlayers) {
+                        playerMap.remove(player.getUUID());
+                        playersToUpdate.add(player.getUUID());
+                    }
+                    if (playerMap.isEmpty()) {
+                        invisibleEntities.remove(target.getUUID());
+                    }
+                }
+                if (!playersToUpdate.isEmpty()) {
                     for (Player player : NMSHandler.entityHelper.getPlayersThatSee(target.getBukkitEntity())) {
-                        if (playerMap.containsKey(player.getUniqueId())) {
+                        if (playersToUpdate.contains(player.getUniqueId())) {
                             NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(player, target.getBukkitEntity());
                         }
                     }

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
@@ -47,6 +47,11 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
+    public boolean isInvisible(Entity entity) {
+        return ((CraftEntity) entity).getHandle().isInvisible();
+    }
+
+    @Override
     public double getAbsorption(LivingEntity entity) {
         return entity.getAbsorptionAmount();
     }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -84,6 +84,11 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
+    public boolean isInvisible(Entity entity) {
+        return ((CraftEntity) entity).getHandle().isInvisible();
+    }
+
+    @Override
     public double getAbsorption(LivingEntity entity) {
         return entity.getAbsorptionAmount();
     }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -91,6 +91,11 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
+    public boolean isInvisible(Entity entity) {
+        return ((CraftEntity) entity).getHandle().isInvisible();
+    }
+
+    @Override
     public double getAbsorption(LivingEntity entity) {
         return entity.getAbsorptionAmount();
     }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -92,6 +92,11 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
+    public boolean isInvisible(Entity entity) {
+        return ((CraftEntity) entity).getHandle().isInvisible();
+    }
+
+    @Override
     public double getAbsorption(LivingEntity entity) {
         return entity.getAbsorptionAmount();
     }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -11,6 +11,7 @@ import com.denizenscript.denizen.nms.v1_19.impl.entities.EntityFakePlayerImpl;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.scripts.commands.entity.FakeEquipCommand;
+import com.denizenscript.denizen.scripts.commands.entity.InvisibleCommand;
 import com.denizenscript.denizen.scripts.commands.entity.RenameCommand;
 import com.denizenscript.denizen.scripts.commands.entity.SneakCommand;
 import com.denizenscript.denizen.scripts.commands.player.DisguiseCommand;
@@ -706,7 +707,7 @@ public class DenizenNetworkManagerImpl extends Connection {
     }
 
     public ClientboundSetEntityDataPacket getModifiedMetadataFor(ClientboundSetEntityDataPacket metadataPacket) {
-        if (!RenameCommand.hasAnyDynamicRenames() && SneakCommand.forceSetSneak.isEmpty()) {
+        if (!RenameCommand.hasAnyDynamicRenames() && SneakCommand.forceSetSneak.isEmpty() && InvisibleCommand.invisibleEntities.isEmpty()) {
             return null;
         }
         try {
@@ -717,7 +718,8 @@ public class DenizenNetworkManagerImpl extends Connection {
             }
             String nameToApply = RenameCommand.getCustomNameFor(ent.getUUID(), player.getBukkitEntity(), false);
             Boolean forceSneak = SneakCommand.shouldSneak(ent.getUUID(), player.getUUID());
-            if (nameToApply == null && forceSneak == null) {
+            Boolean isInvisible = InvisibleCommand.isInvisible(ent.getBukkitEntity(), player.getUUID(), true);
+            if (nameToApply == null && forceSneak == null && isInvisible == null) {
                 return null;
             }
             List<SynchedEntityData.DataItem<?>> data = new ArrayList<>(metadataPacket.getUnpackedData());
@@ -726,13 +728,23 @@ public class DenizenNetworkManagerImpl extends Connection {
                 SynchedEntityData.DataItem<?> item = data.get(i);
                 EntityDataAccessor<?> watcherObject = item.getAccessor();
                 int watcherId = watcherObject.getId();
-                if (watcherId == 0 && forceSneak != null) { // 0: Entity flags
+                if (watcherId == 0 && (forceSneak != null || isInvisible != null)) { // 0: Entity flags
                     byte val = (Byte) item.getValue();
-                    if (forceSneak) {
-                        val |= 0x02; // 8: Crouching
+                    if (forceSneak != null) {
+                        if (forceSneak) {
+                            val |= 0x02; // 8: Crouching
+                        }
+                        else {
+                            val &= ~0x02;
+                        }
                     }
-                    else {
-                        val &= ~0x02;
+                    if (isInvisible != null) {
+                        if (isInvisible) {
+                            val |= 0x20;
+                        }
+                        else {
+                            val &= ~0x20;
+                        }
                     }
                     data.set(i, new SynchedEntityData.DataItem(watcherObject, val));
                     any = true;


### PR DESCRIPTION
## Additions
- `invisible` command:

> - `for:<player>|...` argument - fakes the entity's visibility state for the specified players.
> - `state:reset` option - resets an entity's fake visibility state (for all players).
> - specifying no target will now default to the linked player (or NPC, if there isn't one).
> - Tab completion for the `state:` argument.
> - `#setInvisibleForPlayer(EntityTag target, PlayerTag player, boolean invisible)` - Sets an entity's invisibility state for a specific player.
> - `#isInvisible(Entity entity, UUID player, boolean fakeOnly)` - Returns whether an entity is invisible. if a player is given, will check whether an entity is invisible to that player as well. if `fakeOnly` is `true`, returns null if there's no fake visibility set for that player. 

- `EntityHelper#isInvisible` - returns weather an entity is invisible, counterpart of `EntityHelper#setInvisible`. Used for the `toggle` argument.

## Changes

- `InvisibleCommand#setInvisible` - flipped the boolean param, as it used to be weather the entity should be visible, not invisible.
- Using the `toggle` state with the `for:` argument will toggle the entity's invisibility for each player separately.
- Changed `DenizenNetworkManagerImpl#getModifiedMetadataFor` to set the `invisible` flag according to 
`InvisibleCommand.invisibleEntities`.
## Notes

- `EntityHelper#isInvisible` - is implemented in all supported versions as opposed to only recent ones, as it's a counterpart to `setInvisible` and they're used together for the `toggle` argument.
- `isInvisible/setInvisible` - checks / removes the invisibility potion effect for compact with old uses. 