### PR TITLE
Raid Events

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -230,6 +230,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerTakesFromFurnaceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerTakesFromLecternScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerThrowsEggScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerTriggersRaidScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerUsesPortalScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerWalkScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerWalksOverScriptEvent.class);
@@ -270,6 +271,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(LootGenerateScriptEvent.class);
         ScriptEvent.registerScriptEvent(PortalCreateScriptEvent.class);
         ScriptEvent.registerScriptEvent(PotionSplashScriptEvent.class);
+        ScriptEvent.registerScriptEvent(RaidFinishesScriptEvent.class);
+        ScriptEvent.registerScriptEvent(RaidSpawnsWaveScriptEvent.class);
+        ScriptEvent.registerScriptEvent(RaidStopsScriptEvent.class);
         ScriptEvent.registerScriptEvent(SpawnChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(StructureGrowsScriptEvent.class);
         ScriptEvent.registerScriptEvent(ThunderChangesScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
@@ -1,0 +1,46 @@
+package com.denizenscript.denizen.events.player;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizen.utilities.world.RaidData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.raid.RaidTriggerEvent;
+
+public class PlayerTriggersRaidScriptEvent extends BukkitScriptEvent implements Listener {
+
+    public PlayerTriggersRaidScriptEvent() {
+        registerCouldMatcher("player triggers raid");
+    }
+
+    public RaidTriggerEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, event.getPlayer().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("raid")) {
+            return RaidData.toMap(event.getRaid());
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerTriggersRaid(RaidTriggerEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
@@ -1,17 +1,16 @@
 package com.denizenscript.denizen.events.player;
 
-import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.events.world.RaidScriptEvent;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.utilities.world.RaidData;
-import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.raid.RaidTriggerEvent;
 
-public class PlayerTriggersRaidScriptEvent extends BukkitScriptEvent implements Listener {
+public class PlayerTriggersRaidScriptEvent extends RaidScriptEvent<RaidTriggerEvent> implements Listener {
 
     public PlayerTriggersRaidScriptEvent() {
+        super(false);
         registerCouldMatcher("player triggers raid");
     }
 
@@ -23,14 +22,6 @@ public class PlayerTriggersRaidScriptEvent extends BukkitScriptEvent implements 
             return false;
         }
         return super.matches(path);
-    }
-
-    @Override
-    public ObjectTag getContext(String name) {
-        if (name.equals("raid")) {
-            return RaidData.toMap(event.getRaid());
-        }
-        return super.getContext(name);
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
@@ -9,6 +9,25 @@ import org.bukkit.event.raid.RaidTriggerEvent;
 
 public class PlayerTriggersRaidScriptEvent extends RaidScriptEvent<RaidTriggerEvent> implements Listener {
 
+    // <--[event]
+    // @Events
+    // player triggers raid
+    //
+    // @Group Player
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a player triggers a village raid.
+    //
+    // @Context
+    // <context.raid> returns the raid data. See <@link language Raid Event Data>.
+    //
+    // @Player Always.
+    //
+    // -->
+
     public PlayerTriggersRaidScriptEvent() {
         super(false);
         registerCouldMatcher("player triggers raid");

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerTriggersRaidScriptEvent.java
@@ -33,8 +33,6 @@ public class PlayerTriggersRaidScriptEvent extends RaidScriptEvent<RaidTriggerEv
         registerCouldMatcher("player triggers raid");
     }
 
-    public RaidTriggerEvent event;
-
     @Override
     public boolean matches(ScriptPath path) {
         if (!runInCheck(path, event.getPlayer().getLocation())) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidFinishesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidFinishesScriptEvent.java
@@ -10,6 +10,22 @@ import org.bukkit.event.raid.RaidFinishEvent;
 
 public class RaidFinishesScriptEvent extends RaidScriptEvent<RaidFinishEvent> implements Listener {
 
+    // <--[event]
+    // @Events
+    // raid finishes
+    //
+    // @Group World
+    //
+    // @Location true
+    //
+    // @Triggers when a village raid finishes normally.
+    //
+    // @Context
+    // <context.raid> returns the raid data. See <@link language Raid Event Data>.
+    // <context.winners> returns the ListTag of players who completed the raid. This is separate from the raid's heroes in that the winners are guaranteed to be online.
+    //
+    // -->
+
     public RaidFinishesScriptEvent() {
         super(true);
         registerCouldMatcher("raid finishes");

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidFinishesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidFinishesScriptEvent.java
@@ -1,0 +1,49 @@
+package com.denizenscript.denizen.events.world;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.world.RaidData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.raid.RaidFinishEvent;
+
+public class RaidFinishesScriptEvent extends BukkitScriptEvent implements Listener {
+
+    public RaidFinishesScriptEvent() {
+        registerCouldMatcher("raid finishes");
+    }
+
+    public RaidFinishEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, event.getRaid().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "winners":
+                ListTag list = new ListTag();
+                for (Player player : event.getWinners()) {
+                    list.addObject(new PlayerTag(player));
+                }
+                return list;
+            case "raid":
+                return RaidData.toMap(event.getRaid());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onRaidFinishes(RaidFinishEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidFinishesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidFinishesScriptEvent.java
@@ -1,8 +1,6 @@
 package com.denizenscript.denizen.events.world;
 
-import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.PlayerTag;
-import com.denizenscript.denizen.utilities.world.RaidData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import org.bukkit.entity.Player;
@@ -10,20 +8,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.raid.RaidFinishEvent;
 
-public class RaidFinishesScriptEvent extends BukkitScriptEvent implements Listener {
+public class RaidFinishesScriptEvent extends RaidScriptEvent<RaidFinishEvent> implements Listener {
 
     public RaidFinishesScriptEvent() {
+        super(true);
         registerCouldMatcher("raid finishes");
-    }
-
-    public RaidFinishEvent event;
-
-    @Override
-    public boolean matches(ScriptPath path) {
-        if (!runInCheck(path, event.getRaid().getLocation())) {
-            return false;
-        }
-        return super.matches(path);
     }
 
     @Override
@@ -35,8 +24,6 @@ public class RaidFinishesScriptEvent extends BukkitScriptEvent implements Listen
                     list.addObject(new PlayerTag(player));
                 }
                 return list;
-            case "raid":
-                return RaidData.toMap(event.getRaid());
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
@@ -58,7 +58,7 @@ public class RaidScriptEvent<T extends RaidEvent> extends BukkitScriptEvent {
             raiders.addObject(new EntityTag(raider));
         }
         data.putObject("raiders", raiders);
-        data.putObject("status", new ElementTag(CoreUtilities.toLowerCase(raid.getStatus().name()), true));
+        data.putObject("status", new ElementTag(raid.getStatus().name(), true));
         data.putObject("ticks", new ElementTag(raid.getActiveTicks()));
         data.putObject("level", new ElementTag(raid.getBadOmenLevel()));
         data.putObject("total_groups", new ElementTag(raid.getTotalGroups()));

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
@@ -1,20 +1,31 @@
-package com.denizenscript.denizen.utilities.world;
+package com.denizenscript.denizen.events.world;
 
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.Raid;
 import org.bukkit.entity.Raider;
+import org.bukkit.event.raid.RaidEvent;
 
 import java.util.UUID;
 
-public class RaidData {
+public class RaidScriptEvent<T extends RaidEvent> extends BukkitScriptEvent {
 
-    public static MapTag toMap(Raid raid) {
+    public boolean checkRaidLocation;
+
+    public RaidScriptEvent(boolean checkRaidLocation) {
+        this.checkRaidLocation = checkRaidLocation;
+    }
+
+    public T event;
+
+    public static MapTag getRaidMap(Raid raid) {
         MapTag data = new MapTag();
         data.putObject("location", new LocationTag(raid.getLocation()));
         ListTag heroes = new ListTag();
@@ -35,5 +46,22 @@ public class RaidData {
         data.putObject("health", new ElementTag(raid.getTotalHealth()));
         data.putObject("waves", new ElementTag(raid.getTotalWaves()));
         return data;
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (checkRaidLocation && !runInCheck(path, event.getRaid().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "raid":
+                return getRaidMap(event.getRaid());
+        }
+        return super.getContext(name);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
@@ -17,6 +17,26 @@ import java.util.UUID;
 
 public class RaidScriptEvent<T extends RaidEvent> extends BukkitScriptEvent {
 
+    // <--[language]
+    // @name Raid Event Data
+    // @group Useful Lists
+    // @description
+    // Every event related to village raids has a <context.raid> property, a MapTag wrapper around raid data (see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Raid.html>).
+    // These events are <@link event player triggers raid>, <@link event raid finishes>, <@link event raid spawns wave>, and <@link event raid stops>.
+    //
+    // The data format is as follows:
+    // location: a LocationTag of the raid's center
+    // heroes: a list of PlayerTags that have participated in the raid
+    // raiders: a list of raider EntityTags that remain in the current wave
+    // status: the current status of the raid. See <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Raid.RaidStatus.html>
+    // ticks: the raid's age in ticks
+    // level: the Bad Omen level that the raid was started with
+    // spawned_groups: the amount of raider groups spawned
+    // total_groups: the number of groups planned to spawn or already spawned
+    // health: the combined health of all current raiders
+    // waves: the number of waves in the raid
+    // -->
+
     public boolean checkRaidLocation;
 
     public RaidScriptEvent(boolean checkRaidLocation) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidScriptEvent.java
@@ -5,10 +5,10 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.Raid;
 import org.bukkit.entity.Raider;
 import org.bukkit.event.raid.RaidEvent;
@@ -59,7 +59,7 @@ public class RaidScriptEvent<T extends RaidEvent> extends BukkitScriptEvent {
         }
         data.putObject("raiders", raiders);
         data.putObject("status", new ElementTag(raid.getStatus().name(), true));
-        data.putObject("ticks", new ElementTag(raid.getActiveTicks()));
+        data.putObject("ticks", new DurationTag(raid.getActiveTicks()));
         data.putObject("level", new ElementTag(raid.getBadOmenLevel()));
         data.putObject("total_groups", new ElementTag(raid.getTotalGroups()));
         data.putObject("spawned_groups", new ElementTag(raid.getSpawnedGroups()));

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidSpawnsWaveScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidSpawnsWaveScriptEvent.java
@@ -1,8 +1,6 @@
 package com.denizenscript.denizen.events.world;
 
-import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.utilities.world.RaidData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import org.bukkit.entity.Raider;
@@ -10,20 +8,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.raid.RaidSpawnWaveEvent;
 
-public class RaidSpawnsWaveScriptEvent extends BukkitScriptEvent implements Listener {
+public class RaidSpawnsWaveScriptEvent extends RaidScriptEvent<RaidSpawnWaveEvent> implements Listener {
 
     public RaidSpawnsWaveScriptEvent() {
+        super(true);
         registerCouldMatcher("raid spawns wave");
-    }
-
-    public RaidSpawnWaveEvent event;
-
-    @Override
-    public boolean matches(ScriptPath path) {
-        if (!runInCheck(path, event.getRaid().getLocation())) {
-            return false;
-        }
-        return super.matches(path);
     }
 
     @Override
@@ -37,8 +26,6 @@ public class RaidSpawnsWaveScriptEvent extends BukkitScriptEvent implements List
                     raiders.addObject(new EntityTag(raider));
                 }
                 return raiders;
-            case "raid":
-                return RaidData.toMap(event.getRaid());
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidSpawnsWaveScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidSpawnsWaveScriptEvent.java
@@ -1,0 +1,51 @@
+package com.denizenscript.denizen.events.world;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.world.RaidData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import org.bukkit.entity.Raider;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.raid.RaidSpawnWaveEvent;
+
+public class RaidSpawnsWaveScriptEvent extends BukkitScriptEvent implements Listener {
+
+    public RaidSpawnsWaveScriptEvent() {
+        registerCouldMatcher("raid spawns wave");
+    }
+
+    public RaidSpawnWaveEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, event.getRaid().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "leader":
+                return new EntityTag(event.getPatrolLeader());
+            case "new_raiders":
+                ListTag raiders = new ListTag();
+                for (Raider raider : event.getRaiders()) {
+                    raiders.addObject(new EntityTag(raider));
+                }
+                return raiders;
+            case "raid":
+                return RaidData.toMap(event.getRaid());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onRaidSpawnsWave(RaidSpawnWaveEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidSpawnsWaveScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidSpawnsWaveScriptEvent.java
@@ -10,6 +10,23 @@ import org.bukkit.event.raid.RaidSpawnWaveEvent;
 
 public class RaidSpawnsWaveScriptEvent extends RaidScriptEvent<RaidSpawnWaveEvent> implements Listener {
 
+    // <--[event]
+    // @Events
+    // raid spawns wave
+    //
+    // @Group World
+    //
+    // @Location true
+    //
+    // @Triggers when a village raid spawns a new wave of raiders.
+    //
+    // @Context
+    // <context.raid> returns the raid data. See <@link language Raid Event Data>.
+    // <context.leader> returns the EntityTag of the patrol leader of the wave.
+    // <context.new_raiders> returns the ListTag of all new raiders.
+    //
+    // -->
+
     public RaidSpawnsWaveScriptEvent() {
         super(true);
         registerCouldMatcher("raid spawns wave");

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
@@ -9,6 +9,24 @@ import org.bukkit.event.raid.RaidStopEvent;
 
 public class RaidStopsScriptEvent extends RaidScriptEvent<RaidStopEvent> implements Listener {
 
+    // <--[event]
+    // @Events
+    // raid stops
+    //
+    // @Group World
+    //
+    // @Location true
+    //
+    // @Switch reason:<reason> to only process the event if the raid stopped for a certain reason.
+    //
+    // @Triggers when a village raid stops for any reason.
+    //
+    // @Context
+    // <context.raid> returns the raid data. See <@link language Raid Event Data>.
+    // <context.reason> returns the reason for stopping. See <@link url https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/raid/RaidStopEvent.Reason.html>.
+    //
+    // -->
+
     public RaidStopsScriptEvent() {
         super(true);
         registerCouldMatcher("raid stops");

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
@@ -1,0 +1,48 @@
+package com.denizenscript.denizen.events.world;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.utilities.world.RaidData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.raid.RaidStopEvent;
+
+public class RaidStopsScriptEvent extends BukkitScriptEvent implements Listener {
+
+    public RaidStopsScriptEvent() {
+        registerCouldMatcher("raid stops");
+        registerSwitches("reason");
+    }
+
+    public RaidStopEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (path.switches.containsKey("reason") && !path.checkSwitch("reason", CoreUtilities.toLowerCase(event.getReason().name()))) {
+            return false;
+        }
+        if (!runInCheck(path, event.getRaid().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "reason":
+                return new ElementTag(CoreUtilities.toLowerCase(event.getReason().name()), true);
+            case "raid":
+                return RaidData.toMap(event.getRaid());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onRaidStops(RaidStopEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
@@ -2,7 +2,6 @@ package com.denizenscript.denizen.events.world;
 
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.raid.RaidStopEvent;
@@ -45,7 +44,7 @@ public class RaidStopsScriptEvent extends RaidScriptEvent<RaidStopEvent> impleme
     public ObjectTag getContext(String name) {
         switch (name) {
             case "reason":
-                return new ElementTag(CoreUtilities.toLowerCase(event.getReason().name()), true);
+                return new ElementTag(event.getReason().name(), true);
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/RaidStopsScriptEvent.java
@@ -1,7 +1,5 @@
 package com.denizenscript.denizen.events.world;
 
-import com.denizenscript.denizen.events.BukkitScriptEvent;
-import com.denizenscript.denizen.utilities.world.RaidData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
@@ -9,21 +7,17 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.raid.RaidStopEvent;
 
-public class RaidStopsScriptEvent extends BukkitScriptEvent implements Listener {
+public class RaidStopsScriptEvent extends RaidScriptEvent<RaidStopEvent> implements Listener {
 
     public RaidStopsScriptEvent() {
+        super(true);
         registerCouldMatcher("raid stops");
         registerSwitches("reason");
     }
 
-    public RaidStopEvent event;
-
     @Override
     public boolean matches(ScriptPath path) {
-        if (path.switches.containsKey("reason") && !path.checkSwitch("reason", CoreUtilities.toLowerCase(event.getReason().name()))) {
-            return false;
-        }
-        if (!runInCheck(path, event.getRaid().getLocation())) {
+        if (!runGenericSwitchCheck(path, "reason", event.getReason().name())) {
             return false;
         }
         return super.matches(path);
@@ -34,8 +28,6 @@ public class RaidStopsScriptEvent extends BukkitScriptEvent implements Listener 
         switch (name) {
             case "reason":
                 return new ElementTag(CoreUtilities.toLowerCase(event.getReason().name()), true);
-            case "raid":
-                return RaidData.toMap(event.getRaid());
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/world/RaidData.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/world/RaidData.java
@@ -1,0 +1,39 @@
+package com.denizenscript.denizen.utilities.world;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.Raid;
+import org.bukkit.entity.Raider;
+
+import java.util.UUID;
+
+public class RaidData {
+
+    public static MapTag toMap(Raid raid) {
+        MapTag data = new MapTag();
+        data.putObject("location", new LocationTag(raid.getLocation()));
+        ListTag heroes = new ListTag();
+        for (UUID uuid : raid.getHeroes()) {
+            heroes.addObject(new PlayerTag(uuid));
+        }
+        data.putObject("heroes", heroes);
+        ListTag raiders = new ListTag();
+        for (Raider raider : raid.getRaiders()) {
+            raiders.addObject(new EntityTag(raider));
+        }
+        data.putObject("raiders", raiders);
+        data.putObject("status", new ElementTag(CoreUtilities.toLowerCase(raid.getStatus().name()), true));
+        data.putObject("ticks", new ElementTag(raid.getActiveTicks()));
+        data.putObject("level", new ElementTag(raid.getBadOmenLevel()));
+        data.putObject("total_groups", new ElementTag(raid.getTotalGroups()));
+        data.putObject("spawned_groups", new ElementTag(raid.getSpawnedGroups()));
+        data.putObject("health", new ElementTag(raid.getTotalHealth()));
+        data.putObject("waves", new ElementTag(raid.getTotalWaves()));
+        return data;
+    }
+}


### PR DESCRIPTION
Draft pull request. Current implementation functions, but is lacking event meta + an entry for the Raid Data map structure. It's also worth checking the organization of the additions before going further.

## Additions
- `player triggers raid` event
- `raid finishes` event
- `raid spawns wave` event
- `raid stops` event

All of these events have a `raid` context tag, and all of them except for the player event have support for the `in` switch for the raid location.

- `RaidData` utility class that turns data from `Raid` into a MapTag
  - The main question is: should all these events get one superclass event? It would negate the need for this utility class addition, and also provide better organization for the individual events (raid context would be handled in the superclass).