### PR TITLE
Fix time command

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TimeCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TimeCommand.java
@@ -154,7 +154,13 @@ public class TimeCommand extends AbstractCommand {
                         Bukkit.getScheduler().cancelTask(existingTask);
                         resetTasks.remove(player.getUniqueId());
                     }
-                    player.setPlayerTime(value.getTicks(), freeze == null || !freeze.asBoolean());
+                    if (freeze == null || !freeze.asBoolean()) {
+                        // sets a relative time, so subtract by the world time to keep the command absolute
+                        player.setPlayerTime(value.getTicks() - player.getWorld().getTime(), true);
+                    }
+                    else {
+                        player.setPlayerTime(value.getTicks(), false);
+                    }
                     if (resetAfter != null) {
                         int newTask = Bukkit.getScheduler().scheduleSyncDelayedTask(Denizen.getInstance(), player::resetPlayerTime, resetAfter.getTicks());
                         resetTasks.put(player.getUniqueId(), newTask);


### PR DESCRIPTION
The time command seems to be intended for setting absolute times, but `setPlayerTime` uses a relative offset when the boolean flag is true, as pointed out by the documentation:
https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Player.html#setPlayerTime(long,boolean)

This simply takes that into account to stay consistent with other command usages (such as `freeze`, `global`, or specifying a world)