### PR TITLE
Block Helper Cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/PortalCreateScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/PortalCreateScriptEvent.java
@@ -4,11 +4,10 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
-import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import org.bukkit.Location;
+import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.PortalCreateEvent;
@@ -55,21 +54,16 @@ public class PortalCreateScriptEvent extends BukkitScriptEvent implements Listen
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("entity") && event.getEntity() != null) {
-            return new EntityTag(event.getEntity()).getDenizenObject();
-        }
-        else if (name.equals("world")) {
-            return new WorldTag(event.getWorld());
-        }
-        else if (name.equals("reason")) {
-            return reason;
-        }
-        else if (name.equals("blocks")) {
-            ListTag blocks = new ListTag();
-            for (Location location : NMSHandler.blockHelper.getBlocksList(event)) {
-                blocks.addObject(new LocationTag(location));
-            }
-            return blocks;
+        switch (name) {
+            case "entity": return event.getEntity() != null ? new EntityTag(event.getEntity()).getDenizenObject() : null;
+            case "world": return new WorldTag(event.getWorld());
+            case "reason": return reason;
+            case "blocks":
+                ListTag blocks = new ListTag();
+                for (BlockState blockState : event.getBlocks()) {
+                    blocks.addObject(new LocationTag(blockState.getLocation()));
+                }
+                return blocks;
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -9,10 +9,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.*;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.List;
 import java.util.Set;
 
 public interface BlockHelper {
@@ -34,13 +32,11 @@ public interface BlockHelper {
 
     BlockState generateBlockState(Block block, Material mat);
 
-    List<Location> getBlocksList(PortalCreateEvent event);
-
     String getPushReaction(Material mat);
 
     void setPushReaction(Material mat, String reaction);
 
-    float getBlockStength(Material mat);
+    float getBlockStrength(Material mat);
 
     void setBlockStrength(Material mat, float strength);
 
@@ -64,13 +60,8 @@ public interface BlockHelper {
             material = text.substring(0, openBracket);
             otherData = text.substring(openBracket);
         }
-        if (material.startsWith("minecraft:")) {
-            material = material.substring("minecraft:".length());
-        }
-        return parseBlockData(Material.getMaterial(material.toUpperCase()), otherData);
+        return Material.matchMaterial(material).createBlockData(otherData);
     }
-
-    BlockData parseBlockData(Material material, String otherData);
 
     default void makeBlockStateRaw(BlockState state) {
         throw new UnsupportedOperationException();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -558,8 +558,7 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // This is a representation of how much time mining is needed to break a block.
         // -->
         tagProcessor.registerTag(ElementTag.class, "block_strength", (attribute, object) -> {
-            float res = NMSHandler.blockHelper.getBlockStength(object.material);
-            return new ElementTag(res);
+            return new ElementTag(NMSHandler.blockHelper.getBlockStrength(object.material));
         });
 
         tagProcessor.registerTag(ElementTag.class, "has_vanilla_data_tag", (attribute, object) -> {

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/BlockHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/BlockHelperImpl.java
@@ -16,7 +16,6 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_16_R3.CraftChunk;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R3.block.CraftBlockEntityState;
@@ -24,12 +23,9 @@ import org.bukkit.craftbukkit.v1_16_R3.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_16_R3.block.CraftSkull;
 import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
-import org.bukkit.event.world.PortalCreateEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 public class BlockHelperImpl implements BlockHelper {
@@ -52,20 +48,6 @@ public class BlockHelperImpl implements BlockHelper {
     public void applyPhysics(Location location) {
         BlockPosition pos = new BlockPosition(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         ((CraftWorld) location.getWorld()).getHandle().applyPhysics(pos, CraftMagicNumbers.getBlock(location.getBlock().getType()));
-    }
-
-    @Override
-    public BlockData parseBlockData(Material material, String otherData) {
-        return CraftBlockData.newData(material, otherData);
-    }
-
-    @Override
-    public List<Location> getBlocksList(PortalCreateEvent event) {
-        List<Location> blocks = new ArrayList<>();
-        for (org.bukkit.block.BlockState block : event.getBlocks()) {
-            blocks.add(block.getLocation());
-        }
-        return blocks;
     }
 
     public <T extends TileEntity> T getTE(CraftBlockEntityState<T> cbs) {
@@ -195,7 +177,7 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public float getBlockStength(Material mat) {
+    public float getBlockStrength(Material mat) {
         return getMaterialBlock(mat).getBlockData().strength;
     }
 

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/BlockHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/BlockHelperImpl.java
@@ -27,19 +27,15 @@ import org.bukkit.Instrument;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.*;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_17_R1.CraftChunk;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.block.*;
 import org.bukkit.craftbukkit.v1_17_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
-import org.bukkit.event.world.PortalCreateEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
@@ -63,20 +59,6 @@ public class BlockHelperImpl implements BlockHelper {
     public void applyPhysics(Location location) {
         BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         ((CraftWorld) location.getWorld()).getHandle().updateNeighborsAt(pos, CraftMagicNumbers.getBlock(location.getBlock().getType()));
-    }
-
-    @Override
-    public BlockData parseBlockData(Material material, String otherData) {
-        return CraftBlockData.newData(material, otherData);
-    }
-
-    @Override
-    public List<Location> getBlocksList(PortalCreateEvent event) {
-        List<Location> blocks = new ArrayList<>();
-        for (org.bukkit.block.BlockState block : event.getBlocks()) {
-            blocks.add(block.getLocation());
-        }
-        return blocks;
     }
 
     public static <T extends BlockEntity> T getTE(CraftBlockEntityState<T> cbs) {
@@ -213,7 +195,7 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public float getBlockStength(Material mat) {
+    public float getBlockStrength(Material mat) {
         return getMaterialBlock(mat).defaultBlockState().destroySpeed;
     }
 

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
@@ -37,7 +37,6 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.*;
 import org.bukkit.block.*;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.CraftChunk;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
@@ -47,7 +46,6 @@ import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.tag.CraftBlockTag;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
 import org.bukkit.entity.Player;
-import org.bukkit.event.world.PortalCreateEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
@@ -74,20 +72,6 @@ public class BlockHelperImpl implements BlockHelper {
     public void applyPhysics(Location location) {
         BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         ((CraftWorld) location.getWorld()).getHandle().updateNeighborsAt(pos, CraftMagicNumbers.getBlock(location.getBlock().getType()));
-    }
-
-    @Override
-    public BlockData parseBlockData(Material material, String otherData) {
-        return CraftBlockData.newData(material, otherData);
-    }
-
-    @Override
-    public List<Location> getBlocksList(PortalCreateEvent event) {
-        List<Location> blocks = new ArrayList<>();
-        for (org.bukkit.block.BlockState block : event.getBlocks()) {
-            blocks.add(block.getLocation());
-        }
-        return blocks;
     }
 
     public static <T extends BlockEntity> T getTE(CraftBlockEntityState<T> cbs) {
@@ -223,7 +207,7 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public float getBlockStength(Material mat) {
+    public float getBlockStrength(Material mat) {
         return getMaterialBlock(mat).defaultBlockState().destroySpeed;
     }
 

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
@@ -38,7 +38,6 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.*;
 import org.bukkit.block.*;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R1.CraftChunk;
 import org.bukkit.craftbukkit.v1_19_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
@@ -48,7 +47,6 @@ import org.bukkit.craftbukkit.v1_19_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R1.tag.CraftBlockTag;
 import org.bukkit.craftbukkit.v1_19_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Player;
-import org.bukkit.event.world.PortalCreateEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
@@ -75,20 +73,6 @@ public class BlockHelperImpl implements BlockHelper {
     public void applyPhysics(Location location) {
         BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         ((CraftWorld) location.getWorld()).getHandle().updateNeighborsAt(pos, CraftMagicNumbers.getBlock(location.getBlock().getType()));
-    }
-
-    @Override
-    public BlockData parseBlockData(Material material, String otherData) {
-        return CraftBlockData.newData(material, otherData);
-    }
-
-    @Override
-    public List<Location> getBlocksList(PortalCreateEvent event) {
-        List<Location> blocks = new ArrayList<>();
-        for (org.bukkit.block.BlockState block : event.getBlocks()) {
-            blocks.add(block.getLocation());
-        }
-        return blocks;
     }
 
     public static <T extends BlockEntity> T getTE(CraftBlockEntityState<T> cbs) {
@@ -224,7 +208,7 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public float getBlockStength(Material mat) {
+    public float getBlockStrength(Material mat) {
         return getMaterialBlock(mat).defaultBlockState().destroySpeed;
     }
 


### PR DESCRIPTION
## Changes

- `BlockHelper#getBlocksList` was removed as the API is now the same on all supported versions.
- `PortalCreateScriptEvent` now uses `getBlocks` directly instead of `BlockHelper#getBlocksList`.
- `PortalCreateScriptEvent` was updated to use `switch` in `getContext` as I was already modifying arguments anyway ^.
- `BlockHelper#getBlockStength` was renamed to `BlockHelper#getBlockStrength` (Typo fix).
- `BlockHelper#parseBlockData(Material, String)` was removed in favor of `Material#createBlockData(String)` (which does the same thing internally).
- `BlockHelper#parseBlockData(String)` now uses `Material#matchMaterial` instead of `Material#getMaterial`, as it handles removing the `minecraft:` prefix and casing.