### PR TITLE
Item Helper Cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -5,15 +5,11 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.IntArrayTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import com.denizenscript.denizen.objects.ItemTag;
-import com.google.common.collect.Multimap;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 
 import java.util.List;
@@ -24,8 +20,6 @@ public abstract class ItemHelper {
     public abstract void setMaxStackSize(Material material, int size);
 
     public abstract Integer burnTime(Material material);
-
-    public abstract Recipe getRecipeById(NamespacedKey key);
 
     public abstract void removeRecipe(NamespacedKey key);
 
@@ -38,10 +32,6 @@ public abstract class ItemHelper {
     public abstract void registerShapelessRecipe(String keyName, String group, ItemStack result, List<ItemStack[]> ingredients, boolean[] exact);
 
     public abstract void setShapedRecipeIngredient(ShapedRecipe recipe, char c, ItemStack[] item, boolean exact);
-
-    public abstract String getInternalNameFromMaterial(Material material);
-
-    public abstract Material getMaterialFromInternalName(String internalName);
 
     public abstract String getJsonString(ItemStack itemStack);
 
@@ -74,10 +64,6 @@ public abstract class ItemHelper {
     public abstract void setLore(ItemTag item, List<String> lore);
 
     public boolean renderEntireMap(int mapId, int xMin, int zMin, int xMax, int zMax) {
-        throw new UnsupportedOperationException();
-    }
-
-    public Multimap<Attribute, AttributeModifier> getDefaultAttributes(ItemStack item, org.bukkit.inventory.EquipmentSlot slot) {
         throw new UnsupportedOperationException();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemAttributeModifiers.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.objects.properties.item;
 
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.properties.entity.EntityAttributeModifiers;
 import com.denizenscript.denizencore.objects.Mechanism;
@@ -103,15 +104,15 @@ public class ItemAttributeModifiers implements Property {
         // Slot must be one of: HAND, OFF_HAND, FEET, LEGS, CHEST, or HEAD
         // -->
         PropertyParser.registerTag(ItemAttributeModifiers.class, MapTag.class, "default_attribute_modifiers", (attribute, object) -> {
-            if (!attribute.hasParam()) {
+            if (!attribute.hasParam() || !NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
                 return null;
             }
             EquipmentSlot slot = attribute.getParamElement().asEnum(EquipmentSlot.class);
             if (slot == null) {
-                attribute.echoError("Invalid slot.");
+                attribute.echoError("Invalid slot specified: " + attribute.getParam());
                 return null;
             }
-            return getAttributeModifiersFor(NMSHandler.itemHelper.getDefaultAttributes(object.item.getItemStack(), slot));
+            return getAttributeModifiersFor(object.item.getBukkitMaterial().getDefaultAttributeModifiers(slot));
         });
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -232,8 +232,7 @@ public class ServerTagBase {
         // For shaped recipes, this will include 'air' for slots that are part of the shape but don't require an item.
         // -->
         if (attribute.startsWith("recipe_items") && attribute.hasParam()) {
-            NamespacedKey key = Utilities.parseNamespacedKey(attribute.getParam());
-            Recipe recipe = NMSHandler.itemHelper.getRecipeById(key);
+            Recipe recipe = Bukkit.getRecipe(Utilities.parseNamespacedKey(attribute.getParam()));
             if (recipe == null) {
                 return;
             }
@@ -277,8 +276,7 @@ public class ServerTagBase {
         // Returns the shape of a shaped recipe, like '2x2' or '3x3'.
         // -->
         if (attribute.startsWith("recipe_shape") && attribute.hasParam()) {
-            NamespacedKey key = Utilities.parseNamespacedKey(attribute.getParam());
-            Recipe recipe = NMSHandler.itemHelper.getRecipeById(key);
+            Recipe recipe = Bukkit.getRecipe(Utilities.parseNamespacedKey(attribute.getParam()));
             if (!(recipe instanceof ShapedRecipe)) {
                 return;
             }
@@ -295,8 +293,7 @@ public class ServerTagBase {
         // Will be one of FURNACE, BLASTING, SHAPED, SHAPELESS, SMOKING, CAMPFIRE, STONECUTTING, SMITHING.
         // -->
         if (attribute.startsWith("recipe_type") && attribute.hasParam()) {
-            NamespacedKey key = Utilities.parseNamespacedKey(attribute.getParam());
-            Recipe recipe = NMSHandler.itemHelper.getRecipeById(key);
+            Recipe recipe = Bukkit.getRecipe(Utilities.parseNamespacedKey(attribute.getParam()));
             if (recipe == null) {
                 return;
             }
@@ -311,8 +308,7 @@ public class ServerTagBase {
         // Returns the item that a recipe will create when crafted.
         // -->
         if (attribute.startsWith("recipe_result") && attribute.hasParam()) {
-            NamespacedKey key = Utilities.parseNamespacedKey(attribute.getParam());
-            Recipe recipe = NMSHandler.itemHelper.getRecipeById(key);
+            Recipe recipe = Bukkit.getRecipe(Utilities.parseNamespacedKey(attribute.getParam()));
             if (recipe == null) {
                 return;
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
@@ -189,7 +189,7 @@ public class CustomNBT {
         if (compoundTag.getValue().containsKey(key)) {
             List<StringTag> temp = (List<StringTag>) compoundTag.getValue().get(key).getValue();
             for (StringTag tag : temp) {
-                materials.add(NMSHandler.itemHelper.getMaterialFromInternalName(tag.getValue()));
+                materials.add(Material.matchMaterial(tag.getValue()));
             }
         }
         return materials;
@@ -206,7 +206,7 @@ public class CustomNBT {
         }
         List<StringTag> internalMaterials = new ArrayList<>();
         for (Material material : materials) {
-            internalMaterials.add(new StringTag(NMSHandler.itemHelper.getInternalNameFromMaterial(material)));
+            internalMaterials.add(new StringTag(material.getKey().toString()));
         }
         JNBTListTag lt = new JNBTListTag(StringTag.class, internalMaterials);
         compoundTag = compoundTag.createBuilder().put(key, lt).build();

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/ItemHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/ItemHelperImpl.java
@@ -12,7 +12,6 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -28,7 +27,6 @@ import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftNamespacedKey;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -50,7 +48,7 @@ public class ItemHelperImpl extends ItemHelper {
     public void setMaxStackSize(Material material, int size) {
         try {
             ReflectionHelper.getFinalSetter(Material.class, "maxStack").invoke(material, size);
-            ReflectionHelper.getFinalSetter(Item.class, "maxStackSize").invoke(IRegistry.ITEM.get(MinecraftKey.a(material.getKey().getKey())), size);
+            ReflectionHelper.getFinalSetter(Item.class, "maxStackSize").invoke(IRegistry.ITEM.get(CraftNamespacedKey.toMinecraft(material.getKey())), size);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -60,15 +58,6 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public Integer burnTime(Material material) {
         return TileEntityFurnace.f().get(CraftMagicNumbers.getItem(material));
-    }
-
-    @Override
-    public Recipe getRecipeById(NamespacedKey key) {
-        IRecipe<?> recipe = getNMSRecipe(key);
-        if (recipe == null) {
-            return null;
-        }
-        return recipe.toBukkitRecipe();
     }
 
     @Override
@@ -163,17 +152,6 @@ public class ItemHelperImpl extends ItemHelper {
         }
         ShapelessRecipes recipe = new ShapelessRecipes(key, group, CraftItemStack.asNMSCopy(result), NonNullList.a(null, ingredientList.toArray(new RecipeItemStack[0])));
         ((CraftServer) Bukkit.getServer()).getServer().getCraftingManager().addRecipe(recipe);
-    }
-
-    @Override
-    public String getInternalNameFromMaterial(Material material) {
-        // In 1.13+ Material names match their internal name
-        return "minecraft:" + CoreUtilities.toLowerCase(material.name());
-    }
-
-    @Override
-    public Material getMaterialFromInternalName(String internalName) {
-        return Material.matchMaterial(internalName);
     }
 
     @Override

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/ItemHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/ItemHelperImpl.java
@@ -15,7 +15,6 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -49,7 +48,6 @@ import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftNamespacedKey;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -71,7 +69,7 @@ public class ItemHelperImpl extends ItemHelper {
     public void setMaxStackSize(Material material, int size) {
         try {
             ReflectionHelper.getFinalSetter(Material.class, "maxStack").invoke(material, size);
-            ReflectionHelper.getFinalSetter(Item.class, ReflectionMappingsInfo.Item_maxStackSize).invoke(Registry.ITEM.get(ResourceLocation.tryParse(material.getKey().getKey())), size);
+            ReflectionHelper.getFinalSetter(Item.class, ReflectionMappingsInfo.Item_maxStackSize).invoke(Registry.ITEM.get(CraftNamespacedKey.toMinecraft(material.getKey())), size);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -81,15 +79,6 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public Integer burnTime(Material material) {
         return AbstractFurnaceBlockEntity.getFuel().get(CraftMagicNumbers.getItem(material));
-    }
-
-    @Override
-    public Recipe getRecipeById(NamespacedKey key) {
-        net.minecraft.world.item.crafting.Recipe<?> recipe = getNMSRecipe(key);
-        if (recipe == null) {
-            return null;
-        }
-        return recipe.toBukkitRecipe();
     }
 
     @Override
@@ -184,17 +173,6 @@ public class ItemHelperImpl extends ItemHelper {
         }
         ShapelessRecipe recipe = new ShapelessRecipe(key, group, CraftItemStack.asNMSCopy(result), NonNullList.of(null, ingredientList.toArray(new Ingredient[0])));
         ((CraftServer) Bukkit.getServer()).getServer().getRecipeManager().addRecipe(recipe);
-    }
-
-    @Override
-    public String getInternalNameFromMaterial(Material material) {
-        // In 1.13+ Material names match their internal name
-        return "minecraft:" + CoreUtilities.toLowerCase(material.name());
-    }
-
-    @Override
-    public Material getMaterialFromInternalName(String internalName) {
-        return Material.matchMaterial(internalName);
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
@@ -12,7 +12,6 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -23,8 +22,6 @@ import net.minecraft.core.Registry;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.crafting.*;
@@ -45,8 +42,6 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_18_R2.attribute.CraftAttributeInstance;
-import org.bukkit.craftbukkit.v1_18_R2.attribute.CraftAttributeMap;
 import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
@@ -54,7 +49,6 @@ import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftNamespacedKey;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -77,7 +71,7 @@ public class ItemHelperImpl extends ItemHelper {
     public void setMaxStackSize(Material material, int size) {
         try {
             ReflectionHelper.getFinalSetter(Material.class, "maxStack").invoke(material, size);
-            ReflectionHelper.getFinalSetter(Item.class, ReflectionMappingsInfo.Item_maxStackSize).invoke(Registry.ITEM.get(ResourceLocation.tryParse(material.getKey().getKey())), size);
+            ReflectionHelper.getFinalSetter(Item.class, ReflectionMappingsInfo.Item_maxStackSize).invoke(Registry.ITEM.get(CraftNamespacedKey.toMinecraft(material.getKey())), size);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -87,15 +81,6 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public Integer burnTime(Material material) {
         return AbstractFurnaceBlockEntity.getFuel().get(CraftMagicNumbers.getItem(material));
-    }
-
-    @Override
-    public Recipe getRecipeById(NamespacedKey key) {
-        net.minecraft.world.item.crafting.Recipe<?> recipe = getNMSRecipe(key);
-        if (recipe == null) {
-            return null;
-        }
-        return recipe.toBukkitRecipe();
     }
 
     public static Field RECIPE_MANAGER_BY_NAME = ReflectionHelper.getFields(RecipeManager.class).get(ReflectionMappingsInfo.RecipeManager_byName, Map.class);
@@ -210,17 +195,6 @@ public class ItemHelperImpl extends ItemHelper {
         }
         ShapelessRecipe recipe = new ShapelessRecipe(key, group, CraftItemStack.asNMSCopy(result), NonNullList.of(null, ingredientList.toArray(new Ingredient[0])));
         ((CraftServer) Bukkit.getServer()).getServer().getRecipeManager().addRecipe(recipe);
-    }
-
-    @Override
-    public String getInternalNameFromMaterial(Material material) {
-        // In 1.13+ Material names match their internal name
-        return "minecraft:" + CoreUtilities.toLowerCase(material.name());
-    }
-
-    @Override
-    public Material getMaterialFromInternalName(String internalName) {
-        return Material.matchMaterial(internalName);
     }
 
     @Override
@@ -523,17 +497,6 @@ public class ItemHelperImpl extends ItemHelper {
         }
         renderFullMap(worldmap, xMin, zMin, xMax, zMax);
         return true;
-    }
-
-    @Override
-    public Multimap<org.bukkit.attribute.Attribute, org.bukkit.attribute.AttributeModifier> getDefaultAttributes(ItemStack item, org.bukkit.inventory.EquipmentSlot slot) {
-        net.minecraft.world.item.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
-        Multimap<Attribute, AttributeModifier> attributes = nmsStack.getItem().getDefaultAttributeModifiers(net.minecraft.world.entity.EquipmentSlot.values()[slot.ordinal()]);
-        LinkedHashMultimap<org.bukkit.attribute.Attribute, org.bukkit.attribute.AttributeModifier> bukkit = LinkedHashMultimap.create();
-        for (Map.Entry<Attribute, AttributeModifier> entry : attributes.entries()) {
-            bukkit.put(CraftAttributeMap.fromMinecraft(Registry.ATTRIBUTE.getKey(entry.getKey()).getPath()), CraftAttributeInstance.convert(entry.getValue()));
-        }
-        return bukkit;
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
@@ -12,7 +12,6 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -23,8 +22,6 @@ import net.minecraft.core.Registry;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.crafting.*;
@@ -45,8 +42,6 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_19_R1.attribute.CraftAttributeInstance;
-import org.bukkit.craftbukkit.v1_19_R1.attribute.CraftAttributeMap;
 import org.bukkit.craftbukkit.v1_19_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_19_R1.inventory.CraftInventoryPlayer;
 import org.bukkit.craftbukkit.v1_19_R1.inventory.CraftItemStack;
@@ -54,7 +49,6 @@ import org.bukkit.craftbukkit.v1_19_R1.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_19_R1.util.CraftNamespacedKey;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -77,7 +71,7 @@ public class ItemHelperImpl extends ItemHelper {
     public void setMaxStackSize(Material material, int size) {
         try {
             ReflectionHelper.getFinalSetter(Material.class, "maxStack").invoke(material, size);
-            ReflectionHelper.getFinalSetter(Item.class, ReflectionMappingsInfo.Item_maxStackSize).invoke(Registry.ITEM.get(ResourceLocation.tryParse(material.getKey().getKey())), size);
+            ReflectionHelper.getFinalSetter(Item.class, ReflectionMappingsInfo.Item_maxStackSize).invoke(Registry.ITEM.get(CraftNamespacedKey.toMinecraft(material.getKey())), size);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -87,15 +81,6 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public Integer burnTime(Material material) {
         return AbstractFurnaceBlockEntity.getFuel().get(CraftMagicNumbers.getItem(material));
-    }
-
-    @Override
-    public Recipe getRecipeById(NamespacedKey key) {
-        net.minecraft.world.item.crafting.Recipe<?> recipe = getNMSRecipe(key);
-        if (recipe == null) {
-            return null;
-        }
-        return recipe.toBukkitRecipe();
     }
 
     public static Field RECIPE_MANAGER_BY_NAME = ReflectionHelper.getFields(RecipeManager.class).get(ReflectionMappingsInfo.RecipeManager_byName, Map.class);
@@ -210,17 +195,6 @@ public class ItemHelperImpl extends ItemHelper {
         }
         ShapelessRecipe recipe = new ShapelessRecipe(key, group, CraftItemStack.asNMSCopy(result), NonNullList.of(null, ingredientList.toArray(new Ingredient[0])));
         ((CraftServer) Bukkit.getServer()).getServer().getRecipeManager().addRecipe(recipe);
-    }
-
-    @Override
-    public String getInternalNameFromMaterial(Material material) {
-        // In 1.13+ Material names match their internal name
-        return "minecraft:" + CoreUtilities.toLowerCase(material.name());
-    }
-
-    @Override
-    public Material getMaterialFromInternalName(String internalName) {
-        return Material.matchMaterial(internalName);
     }
 
     @Override
@@ -523,17 +497,6 @@ public class ItemHelperImpl extends ItemHelper {
         }
         renderFullMap(worldmap, xMin, zMin, xMax, zMax);
         return true;
-    }
-
-    @Override
-    public Multimap<org.bukkit.attribute.Attribute, org.bukkit.attribute.AttributeModifier> getDefaultAttributes(ItemStack item, org.bukkit.inventory.EquipmentSlot slot) {
-        net.minecraft.world.item.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
-        Multimap<Attribute, AttributeModifier> attributes = nmsStack.getItem().getDefaultAttributeModifiers(net.minecraft.world.entity.EquipmentSlot.values()[slot.ordinal()]);
-        LinkedHashMultimap<org.bukkit.attribute.Attribute, org.bukkit.attribute.AttributeModifier> bukkit = LinkedHashMultimap.create();
-        for (Map.Entry<Attribute, AttributeModifier> entry : attributes.entries()) {
-            bukkit.put(CraftAttributeMap.fromMinecraft(Registry.ATTRIBUTE.getKey(entry.getKey()).getPath()), CraftAttributeInstance.convert(entry.getValue()));
-        }
-        return bukkit;
     }
 
     @Override


### PR DESCRIPTION
## Changes

- `ItemHelper#getRecipeById` was removed in favor of `Bukkit#getRecipe`.
- `ItemHelper#getInternalNameFromMaterial` was removed in favor of `Material#getKey#toString`.
- `ItemHelper#getMaterialFromInternalName` was removed as the API it uses (`Material#matchMaterial`) is identical on all supported versions.
- `ItemHelper#getDefaultAttributes` was removed in favor of `Material#getDefaultAttributeModifiers`.
- `ItemHelper#setMaxStackSize` now uses `CraftNamespacedKey#toMinecraft` instead of `ResourceLocation#tryParse`.