### PR TITLE
Update `ChunkTag`, `AreaContainmentObject` and `ColorTag` tag param usage.

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/AreaContainmentObject.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/AreaContainmentObject.java
@@ -191,9 +191,6 @@ public interface AreaContainmentObject extends ObjectTag {
         // Returns a boolean indicating whether the specified location is inside this area.
         // -->
         processor.registerTag(ElementTag.class, LocationTag.class, "contains", (attribute, area, loc) -> {
-            if (loc == null) {
-                return null;
-            }
             return new ElementTag(area.doesContainLocation(loc));
         }, "contains_location");
 
@@ -270,9 +267,6 @@ public interface AreaContainmentObject extends ObjectTag {
         // Returns whether this area is fully inside another cuboid.
         // -->
         processor.registerTag(ElementTag.class, CuboidTag.class, "is_within", (attribute, area, cub2) -> {
-            if (cub2 == null) {
-                return null;
-            }
             CuboidTag cuboid = area instanceof CuboidTag ? (CuboidTag) area : area.getCuboidBoundary();
             if (cub2 != null) {
                 boolean contains = true;
@@ -309,9 +303,6 @@ public interface AreaContainmentObject extends ObjectTag {
         // Returns a copy of the area, with the specified world.
         // -->
         processor.registerTag(type, WorldTag.class, "with_world", (attribute, area, world) -> {
-            if (world == null) {
-                return null;
-            }
             return (T) area.withWorld(world);
         });
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/AreaContainmentObject.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/AreaContainmentObject.java
@@ -190,11 +190,7 @@ public interface AreaContainmentObject extends ObjectTag {
         // @description
         // Returns a boolean indicating whether the specified location is inside this area.
         // -->
-        processor.registerTag(ElementTag.class, "contains", (attribute, area) -> {
-            if (!attribute.hasParam()) {
-                return null;
-            }
-            LocationTag loc = attribute.paramAsType(LocationTag.class);
+        processor.registerTag(ElementTag.class, LocationTag.class, "contains", (attribute, area, loc) -> {
             if (loc == null) {
                 return null;
             }
@@ -253,11 +249,8 @@ public interface AreaContainmentObject extends ObjectTag {
         // Gets a list of all block locations with a specified flag within the area.
         // Searches the internal flag lists, rather than through all possible blocks.
         // -->
-        processor.registerTag(ListTag.class, "blocks_flagged", (attribute, area) -> {
-            if (!attribute.hasParam()) {
-                return null;
-            }
-            return area.getBlocksFlagged(CoreUtilities.toLowerCase(attribute.getParam()), attribute);
+        processor.registerTag(ListTag.class, ElementTag.class, "blocks_flagged", (attribute, area, flagName) -> {
+            return area.getBlocksFlagged(CoreUtilities.toLowerCase(flagName.toString()), attribute);
         });
 
         // <--[tag]
@@ -276,11 +269,7 @@ public interface AreaContainmentObject extends ObjectTag {
         // @description
         // Returns whether this area is fully inside another cuboid.
         // -->
-        processor.registerTag(ElementTag.class, "is_within", (attribute, area) -> {
-            if (!attribute.hasParam()) {
-                return null;
-            }
-            CuboidTag cub2 = attribute.paramAsType(CuboidTag.class);
+        processor.registerTag(ElementTag.class, CuboidTag.class, "is_within", (attribute, area, cub2) -> {
             if (cub2 == null) {
                 return null;
             }
@@ -319,11 +308,7 @@ public interface AreaContainmentObject extends ObjectTag {
         // @description
         // Returns a copy of the area, with the specified world.
         // -->
-        processor.registerTag(type, "with_world", (attribute, area) -> {
-            if (!attribute.hasParam()) {
-                return null;
-            }
-            WorldTag world = attribute.paramAsType(WorldTag.class);
+        processor.registerTag(type, WorldTag.class, "with_world", (attribute, area, world) -> {
             if (world == null) {
                 return null;
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -290,12 +290,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates added to it.
         // -->
-        tagProcessor.registerTag(ChunkTag.class, "add", (attribute, object) -> {
-            if (!attribute.hasParam()) {
-                attribute.echoError("The tag ChunkTag.add[<#>,<#>] must have a value.");
-                return null;
-            }
-            List<String> coords = CoreUtilities.split(attribute.getParam(), ',');
+        tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "add", (attribute, object, addCoords) -> {
+            List<String> coords = CoreUtilities.split(addCoords.toString(), ',');
             if (coords.size() < 2) {
                 attribute.echoError("The tag ChunkTag.add[<#>,<#>] requires two values!");
                 return null;
@@ -317,12 +313,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates subtracted from it.
         // -->
-        tagProcessor.registerTag(ChunkTag.class, "sub", (attribute, object) -> {
-            if (!attribute.hasParam()) {
-                attribute.echoError("The tag ChunkTag.add[<#>,<#>] must have a value.");
-                return null;
-            }
-            List<String> coords = CoreUtilities.split(attribute.getParam(), ',');
+        tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "sub", (attribute, object, subCoords) -> {
+            List<String> coords = CoreUtilities.split(subCoords.toString(), ',');
             if (coords.size() < 2) {
                 attribute.echoError("The tag ChunkTag.sub[<#>,<#>] requires two values!");
                 return null;
@@ -644,16 +636,12 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Gets a list of all block locations with a specified flag within the CuboidTag.
         // Searches the internal flag lists, rather than through all possible blocks.
         // -->
-        tagProcessor.registerTag(ListTag.class, "blocks_flagged", (attribute, object) -> {
-            if (!attribute.hasParam()) {
-                attribute.echoError("ChunkTag.blocks_flagged[...] must have an input value.");
-                return null;
-            }
+        tagProcessor.registerTag(ListTag.class, ElementTag.class, "blocks_flagged", (attribute, object, flagNameInput) -> {
             Chunk chunk = object.getChunkForTag(attribute);
             if (chunk == null) {
                 return null;
             }
-            String flagName = CoreUtilities.toLowerCase(attribute.getParam());
+            String flagName = CoreUtilities.toLowerCase(flagNameInput.toString());
             ListTag blocks = new ListTag();
             LocationFlagSearchHelper.getFlaggedLocations(chunk, flagName, (loc) -> {
                 blocks.addObject(new LocationTag(loc));

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
@@ -475,10 +475,9 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the color that results if you mix this color with another.
         // -->
-        tagProcessor.registerTag(ColorTag.class, "mix", (attribute, object) -> { // Temporarily non-static because the input could be 'random'
-            ColorTag mixed_with = attribute.paramAsType(ColorTag.class);
-            if (mixed_with != null) {
-                return new ColorTag(object.mixWith(mixed_with));
+        tagProcessor.registerTag(ColorTag.class, ColorTag.class, "mix", (attribute, object, mixWith) -> { // Temporarily non-static because the input could be 'random'
+            if (mixWith != null) {
+                return new ColorTag(object.mixWith(mixWith));
             }
             else {
                 Debug.echoError("'" + attribute.getParam() + "' is not a valid color!");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
@@ -476,13 +476,7 @@ public class ColorTag implements ObjectTag {
         // Returns the color that results if you mix this color with another.
         // -->
         tagProcessor.registerTag(ColorTag.class, ColorTag.class, "mix", (attribute, object, mixWith) -> { // Temporarily non-static because the input could be 'random'
-            if (mixWith != null) {
-                return new ColorTag(object.mixWith(mixWith));
-            }
-            else {
-                Debug.echoError("'" + attribute.getParam() + "' is not a valid color!");
-                return null;
-            }
+            return new ColorTag(object.mixWith(mixWith));
         });
 
         // <--[tag]


### PR DESCRIPTION
### Update `ChunkTag`, `AreaContainmentObject`, and `ColorTag` tag param usage, as per request from issue #2355.

Tags updated:
- `<AreaObject.contains[]>`
- `<AreaObject.blocks_flagged[]>`
- `<AreaObject.is_within[]>`
- `<AreaObject.with_world[]>`
- `<ChunkTag.add[]>`
- `<ChunkTag.sub[]>`
- `<ChunkTag.blocks_flagged[]>`
- `<ColorTag.mix[]>`

Now they use the new ✨ fancy ✨ automated attribute processing.

I think I did this right. When I tested it it worked the same so :)

###### ive never used java before in my life 😳