### PR TITLE
Player Helper Cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityDamagedScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityDamagedScriptEvent.java
@@ -194,7 +194,7 @@ public class EntityDamagedScriptEvent extends BukkitScriptEvent implements Liste
             return false;
         }
         Player player = damager.getPlayer();
-        if (NMSHandler.playerHelper.getAttackCooldownPercent(player) < 0.999) { // attack cooldown is also checked in that method earlier
+        if (player.getAttackCooldown() < 0.999) { // attack cooldown is also checked in that method earlier
             return false;
         }
         if (player.getFallDistance() <= 0 || player.isOnGround() || player.isClimbing() || player.isInWater()) {

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -7,15 +7,18 @@ import com.denizenscript.denizen.utilities.entity.DenizenEntityType;
 import com.denizenscript.denizen.utilities.entity.FakeEntity;
 import com.denizenscript.denizencore.objects.Mechanism;
 import org.bukkit.*;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.boss.BossBar;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 public abstract class PlayerHelper {
 
-    public abstract void stopSound(Player player, String sound, SoundCategory category);
+    public abstract void stopSound(Player player, String sound, SoundCategory category); // TODO: 1.19 - remove the category param
 
     public FakeEntity sendEntitySpawn(List<PlayerTag> players, DenizenEntityType entityType, LocationTag location, ArrayList<Mechanism> mechanisms, int customId, UUID customUUID, boolean autoTrack) {
         throw new UnsupportedOperationException();
@@ -37,13 +40,9 @@ public abstract class PlayerHelper {
 
     public abstract float getMaxAttackCooldownTicks(Player player);
 
-    public abstract float getAttackCooldownPercent(Player player);
-
     public abstract void setAttackCooldown(Player player, int ticks);
 
     public abstract boolean hasChunkLoaded(Player player, Chunk chunk);
-
-    public abstract int getPing(Player player);
 
     public abstract void setTemporaryOp(Player player, boolean op);
 
@@ -86,10 +85,6 @@ public abstract class PlayerHelper {
 
     public void setBossBarTitle(BossBar bar, String title) {
         bar.setTitle(title);
-    }
-
-    public void doAttack(Player attacker, Entity victim) {
-        throw new UnsupportedOperationException();
     }
 
     public boolean getSpawnForced(Player player) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.objects;
 
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.nms.interfaces.EntityAnimation;
 import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizen.objects.properties.entity.EntityAge;
@@ -2865,7 +2864,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 attribute.echoError("Only player-type entities can have attack_cooldowns!");
                 return null;
             }
-            return new ElementTag(NMSHandler.playerHelper.getAttackCooldownPercent((Player) object.getLivingEntity()) * 100);
+            return new ElementTag(((Player) object.getLivingEntity()).getAttackCooldown() * 100);
         });
 
         // <--[tag]
@@ -3751,13 +3750,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Does not work with passive mobs, non-living entities, etc.
         // -->
         if (mechanism.matches("melee_attack") && mechanism.requireObject(EntityTag.class)) {
-            Entity target = mechanism.valueAsType(EntityTag.class).getBukkitEntity();
-            if (getLivingEntity() instanceof Player && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_17)) {
-                NMSHandler.playerHelper.doAttack((Player) getLivingEntity(), target);
-            }
-            else {
-                getLivingEntity().attack(target);
-            }
+            getLivingEntity().attack(mechanism.valueAsType(EntityTag.class).getBukkitEntity());
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -1674,8 +1674,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
 
             else if (attribute.startsWith("percent", 2)) {
                 attribute.fulfill(1);
-                return new ElementTag(NMSHandler.playerHelper
-                        .getAttackCooldownPercent(object.getPlayerEntity()) * 100);
+                return new ElementTag(object.getPlayerEntity().getAttackCooldown() * 100);
             }
 
             Debug.echoError("The tag 'player.attack_cooldown...' must be followed by a sub-tag.");
@@ -1989,7 +1988,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Returns the player's current ping.
         // -->
         registerOnlineOnlyTag(ElementTag.class, "ping", (attribute, object) -> {
-            return new ElementTag(NMSHandler.playerHelper.getPing(object.getPlayerEntity()));
+            return new ElementTag(object.getPlayerEntity().getPing());
         });
 
         // <--[tag]
@@ -3703,19 +3702,16 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             SoundCategory category = null;
             String key = null;
             if (mechanism.hasValue()) {
-                try {
-                    if (mechanism.getValue().matchesEnum(SoundCategory.class)) {
-                        category = SoundCategory.valueOf(mechanism.getValue().asString().toUpperCase());
-                    }
-                    else {
-                        key = mechanism.getValue().asString();
+                if (mechanism.getValue().matchesEnum(SoundCategory.class)) {
+                    category = mechanism.getValue().asEnum(SoundCategory.class);
+                    if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) { // TODO: 1.19
+                        getPlayerEntity().stopSound(category);
+                        return;
                     }
                 }
-                catch (Exception e) {
+                else {
+                    key = mechanism.getValue().asString();
                 }
-            }
-            else {
-                category = SoundCategory.MASTER;
             }
             NMSHandler.playerHelper.stopSound(getPlayerEntity(), key, category);
         }

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/PlayerHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/PlayerHelperImpl.java
@@ -1,11 +1,13 @@
 package com.denizenscript.denizen.nms.v1_16.helpers;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
 import com.denizenscript.denizen.nms.enums.CustomEntityType;
+import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizen.nms.v1_16.Handler;
 import com.denizenscript.denizen.nms.v1_16.impl.ImprovedOfflinePlayerImpl;
-import com.denizenscript.denizen.nms.v1_16.impl.entities.EntityItemProjectileImpl;
 import com.denizenscript.denizen.nms.v1_16.impl.entities.CraftFakePlayerImpl;
+import com.denizenscript.denizen.nms.v1_16.impl.entities.EntityItemProjectileImpl;
 import com.denizenscript.denizen.nms.v1_16.impl.network.handlers.AbstractListenerPlayInImpl;
 import com.denizenscript.denizen.nms.v1_16.impl.network.handlers.DenizenNetworkManagerImpl;
 import com.denizenscript.denizen.objects.EntityTag;
@@ -16,17 +18,15 @@ import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.entity.DenizenEntityType;
 import com.denizenscript.denizen.utilities.entity.FakeEntity;
 import com.denizenscript.denizencore.objects.Mechanism;
-import com.mojang.authlib.GameProfile;
-import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
-import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.mojang.authlib.GameProfile;
 import net.md_5.bungee.api.ChatColor;
 import net.minecraft.server.v1_16_R3.*;
-import org.bukkit.*;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.SoundCategory;
+import org.bukkit.*;
 import org.bukkit.boss.BossBar;
 import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
@@ -245,11 +245,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public float getAttackCooldownPercent(Player player) {
-        return ((CraftPlayer) player).getHandle().getAttackCooldown(0.5f);
-    }
-
-    @Override
     public void setAttackCooldown(Player player, int ticks) {
         // Theoretically the a(EnumHand) method sets the ATTACK_COOLDOWN_TICKS field to 0 and performs an
         // animation, but I'm unable to confirm if the animation actually triggers.
@@ -268,11 +263,6 @@ public class PlayerHelperImpl extends PlayerHelper {
         return ((CraftWorld) chunk.getWorld()).getHandle().getChunkProvider().playerChunkMap
                 .a(new ChunkCoordIntPair(chunk.getX(), chunk.getZ()), false)
                 .anyMatch(entityPlayer -> entityPlayer.getUniqueID().equals(player.getUniqueId()));
-    }
-
-    @Override
-    public int getPing(Player player) {
-        return ((CraftPlayer) player).getHandle().ping;
     }
 
     @Override

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
@@ -1,7 +1,9 @@
 package com.denizenscript.denizen.nms.v1_17.helpers;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
 import com.denizenscript.denizen.nms.enums.CustomEntityType;
+import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizen.nms.v1_17.Handler;
 import com.denizenscript.denizen.nms.v1_17.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_17.impl.ImprovedOfflinePlayerImpl;
@@ -17,20 +19,18 @@ import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.entity.DenizenEntityType;
 import com.denizenscript.denizen.utilities.entity.FakeEntity;
 import com.denizenscript.denizencore.objects.Mechanism;
-import com.mojang.authlib.GameProfile;
-import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
-import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.mojang.authlib.GameProfile;
 import net.md_5.bungee.api.ChatColor;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerEntity;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.server.players.ServerOpList;
 import net.minecraft.server.players.ServerOpListEntry;
@@ -43,7 +43,6 @@ import org.bukkit.boss.BossBar;
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.boss.CraftBossBar;
-import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Entity;
@@ -261,11 +260,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public float getAttackCooldownPercent(Player player) {
-        return ((CraftPlayer) player).getHandle().getAttackStrengthScale(0.5f);
-    }
-
-    @Override
     public void setAttackCooldown(Player player, int ticks) {
         try {
             ATTACK_COOLDOWN_TICKS.setInt(((CraftPlayer) player).getHandle(), ticks);
@@ -281,11 +275,6 @@ public class PlayerHelperImpl extends PlayerHelper {
         return ((CraftWorld) chunk.getWorld()).getHandle().getChunkProvider().chunkMap
                 .getPlayers(new ChunkPos(chunk.getX(), chunk.getZ()), false)
                 .anyMatch(entityPlayer -> entityPlayer.getUUID().equals(player.getUniqueId()));
-    }
-
-    @Override
-    public int getPing(Player player) {
-        return ((CraftPlayer) player).getHandle().latency;
     }
 
     @Override
@@ -363,11 +352,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     public void setBossBarTitle(BossBar bar, String title) {
         ((CraftBossBar) bar).getHandle().name = Handler.componentToNMS(FormattedTextHelper.parse(title, ChatColor.WHITE));
         ((CraftBossBar) bar).getHandle().broadcast(ClientboundBossEventPacket::createUpdateNamePacket);
-    }
-
-    @Override
-    public void doAttack(Player attacker, Entity victim) {
-        ((CraftPlayer) attacker).getHandle().attack(((CraftEntity) victim).getHandle());
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
@@ -2,7 +2,9 @@ package com.denizenscript.denizen.nms.v1_18.helpers;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
 import com.denizenscript.denizen.nms.enums.CustomEntityType;
+import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizen.nms.v1_18.Handler;
 import com.denizenscript.denizen.nms.v1_18.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_18.impl.ImprovedOfflinePlayerImpl;
@@ -19,11 +21,9 @@ import com.denizenscript.denizen.utilities.entity.DenizenEntityType;
 import com.denizenscript.denizen.utilities.entity.FakeEntity;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.mojang.authlib.GameProfile;
-import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
-import com.denizenscript.denizen.nms.interfaces.PlayerHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.md_5.bungee.api.ChatColor;
@@ -33,10 +33,10 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerEntity;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.server.players.ServerOpList;
 import net.minecraft.server.players.ServerOpListEntry;
@@ -51,11 +51,10 @@ import org.bukkit.*;
 import org.bukkit.boss.BossBar;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_18_R2.boss.CraftBossBar;
-import org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -279,11 +278,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public float getAttackCooldownPercent(Player player) {
-        return ((CraftPlayer) player).getHandle().getAttackStrengthScale(0.5f);
-    }
-
-    @Override
     public void setAttackCooldown(Player player, int ticks) {
         try {
             ATTACK_COOLDOWN_TICKS.setInt(((CraftPlayer) player).getHandle(), ticks);
@@ -299,11 +293,6 @@ public class PlayerHelperImpl extends PlayerHelper {
         return ((CraftWorld) chunk.getWorld()).getHandle().getChunkSource().chunkMap
                 .getPlayers(new ChunkPos(chunk.getX(), chunk.getZ()), false).stream()
                 .anyMatch(entityPlayer -> entityPlayer.getUUID().equals(player.getUniqueId()));
-    }
-
-    @Override
-    public int getPing(Player player) {
-        return ((CraftPlayer) player).getHandle().latency;
     }
 
     @Override
@@ -384,11 +373,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public void doAttack(Player attacker, Entity victim) {
-        ((CraftPlayer) attacker).getHandle().attack(((CraftEntity) victim).getHandle());
-    }
-
-    @Override
     public boolean getSpawnForced(Player player) {
         return ((CraftPlayer) player).getHandle().isRespawnForced();
     }
@@ -433,12 +417,11 @@ public class PlayerHelperImpl extends PlayerHelper {
     @Override
     public void sendClimbableMaterials(Player player, List<Material> materials) {
         Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> packetInput = TagNetworkSerialization.serializeTagsToNetwork(((CraftServer) Bukkit.getServer()).getServer().registryAccess());
-        TagNetworkSerialization.NetworkPayload payload = packetInput.get(Registry.BLOCK_REGISTRY);
-        Map<ResourceLocation, IntList> tags = ReflectionHelper.getFieldValue(TagNetworkSerialization.NetworkPayload.class, ReflectionMappingsInfo.TagNetworkSerialization_NetworkPayload_tags, payload);
+        Map<ResourceLocation, IntList> tags = ReflectionHelper.getFieldValue(TagNetworkSerialization.NetworkPayload.class, ReflectionMappingsInfo.TagNetworkSerialization_NetworkPayload_tags, packetInput.get(Registry.BLOCK_REGISTRY));
         IntList intList = tags.get(BlockTags.CLIMBABLE.location());
         intList.clear();
         for (Material material : materials) {
-            intList.add(Registry.BLOCK.getId(((CraftBlockData) material.createBlockData()).getState().getBlock()));
+            intList.add(Registry.BLOCK.getId(CraftMagicNumbers.getBlock(material)));
         }
         PacketHelperImpl.send(player, new ClientboundUpdateTagsPacket(packetInput));
     }


### PR DESCRIPTION
## Changes

- `PlayerHelper#getAttackCooldownPercent` was removed in favor of `HumanEntity#getAttackCooldown` (both use the same method internally).
- `PlayerHelper#getPing` was removed in favor of `Player#getPing`.
- `PlayerHelper#doAttack` was removed in favor of `LivingEntity#attack`, which has the same special handling for players as `doAttack`.
- `PlayerTag.stop_sound` mechanism will now use `Player#stopSound(SoundCategory)` on `1.19`+ - this will allow for removing the `SoundCategory` param from `PlayerHelper#stopSound` once `1.18` support is dropped.
- `PlayerTag.stop_sound` mechanism will now default the category to `null` instead of `master` for stopping all sounds, as using `master` doesn't seem to stop all sounds anymore - tested on `1.16` and `1.19`.
- `PlayerHelper#sendClimbableMaterials` was cleaned up a bit - removed the redundant `payload` variable, and changed to `CraftMagicNumbers#getBlock(Material)` for getting an NMS `Block` from a Bukkit `Material`.
- Let Intellij reorder imports

## Notes

- `PlayerHelper#getMaxAttackCooldownTicks` uses `Player(NMS)#getCurrentItemAttackStrengthDelay`, which returns `1 / (ATTACK_SPEED attribute) * 20`, which can be very easily done with API - lmk if that should be changed to do so.