### PR TITLE
`entity death` event advanced text support

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
@@ -19,6 +19,7 @@ import org.bukkit.block.Sign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.Inventory;
@@ -191,5 +192,15 @@ public class PaperAdvancedTextImpl extends AdvancedTextImpl {
             }
         }
         return false;
+    }
+
+    @Override
+    public String getDeathMessage(PlayerDeathEvent event) {
+        return PaperModule.stringifyComponent(event.deathMessage(), ChatColor.WHITE);
+    }
+
+    @Override
+    public void setDeathMessage(PlayerDeathEvent event, String message) {
+        event.deathMessage(PaperModule.parseFormattedText(message, ChatColor.WHITE));
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityDeathScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityDeathScriptEvent.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.events.entity;
 
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.AdvancedTextImpl;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.*;
@@ -139,7 +140,7 @@ public class EntityDeathScriptEvent extends BukkitScriptEvent implements Listene
             return true;
         }
         else if (event instanceof PlayerDeathEvent) {
-            ((PlayerDeathEvent) event).setDeathMessage(determination);
+            AdvancedTextImpl.instance.setDeathMessage((PlayerDeathEvent) event, determination);
             return true;
         }
         else {
@@ -158,7 +159,7 @@ public class EntityDeathScriptEvent extends BukkitScriptEvent implements Listene
             case "entity": return entity.getDenizenObject();
             case "projectile": return projectile == null ? null : projectile.getDenizenObject();
             case "damager": return damager == null ? null : damager.getDenizenObject();
-            case "message": return event instanceof PlayerDeathEvent ? new ElementTag(((PlayerDeathEvent) event).getDeathMessage()) : null;
+            case "message": return event instanceof PlayerDeathEvent ? new ElementTag(AdvancedTextImpl.instance.getDeathMessage((PlayerDeathEvent) event)) : null;
             case "cause": return cause;
             case "xp": return new ElementTag(event.getDroppedExp());
             case "drops":

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/AdvancedTextImpl.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/AdvancedTextImpl.java
@@ -10,6 +10,7 @@ import org.bukkit.block.Sign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.Inventory;
@@ -116,5 +117,13 @@ public class AdvancedTextImpl {
 
     public boolean isDenizenMix(ItemStack currInput, ItemStack ingredient) {
         return false;
+    }
+
+    public String getDeathMessage(PlayerDeathEvent event) {
+        return event.getDeathMessage();
+    }
+
+    public void setDeathMessage(PlayerDeathEvent event, String message) {
+        event.setDeathMessage(message);
     }
 }


### PR DESCRIPTION
## Additions

- `AdvancedTextImpl#get/setDeathMessage` - controls the death message of a `PlayerDeathEvent`.

## Changes

- `EntityDeathScriptEvent` now uses `AdvancedTextImpl#get/setDeathMessage` for it's message context and determination.