### PR TITLE
Kick event determination now not always lowercase.

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerKickedScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerKickedScriptEvent.java
@@ -62,17 +62,18 @@ public class PlayerKickedScriptEvent extends BukkitScriptEvent implements Listen
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
         if (determinationObj instanceof ElementTag) {
-            String lower = CoreUtilities.toLowerCase(determinationObj.toString());
+            String determination = determinationObj.toString();
+            String lower = CoreUtilities.toLowerCase(determination);
             if (lower.startsWith("message:")) {
-                event.setLeaveMessage(lower.substring("message:".length()));
+                event.setLeaveMessage(determination.substring("message:".length()));
                 return true;
             }
             else if (lower.startsWith("reason:")) {
-                event.setReason(lower.substring("reason:".length()));
+                event.setReason(determination.substring("reason:".length()));
                 return true;
             }
             else if (lower.startsWith("fly_cooldown:")) {
-                DurationTag duration = DurationTag.valueOf(lower.substring("fly_cooldown:".length()), getTagContext(path));
+                DurationTag duration = DurationTag.valueOf(determination.substring("fly_cooldown:".length()), getTagContext(path));
                 if (duration != null) {
                     NMSHandler.playerHelper.setFlyKickCooldown(player.getPlayerEntity(), (int) duration.getTicks());
                     cancelled = true;


### PR DESCRIPTION
### `player kicked (for flying)` event now keeps casing of determination. 

#### Changes:
- `PlayerKickedScriptEvent#applyDetermination` has new variable to store the determination result before it is made lowercase. That variable is used when determining kick messages, and not the lowercase one.

[Requested by Mergu](https://discord.com/channels/315163488085475337/1014323580126888036/1014323582253400124) 🤠