### PR TITLE
Fix `PlayerTag.skin` and `skin_blob` mechanisms (on paper)

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
@@ -241,4 +241,17 @@ public class PaperAdvancedTextImpl extends AdvancedTextImpl {
             });
         });
     }
+
+    @Override
+    public void setSkinBlob(Player player, String blob) {
+        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_18)) {
+            NMSHandler.instance.getProfileEditor().setPlayerSkinBlob(player, blob);
+            return;
+        }
+        // Note: this API is present on all supported versions, but currently used for 1.19+ only
+        List<String> split = CoreUtilities.split(blob, ';');
+        PlayerProfile playerProfile = player.getPlayerProfile();
+        playerProfile.setProperty(new ProfileProperty("textures", split.get(0), split.size() > 1 ? split.get(1) : null));
+        player.setPlayerProfile(playerProfile);
+    }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
@@ -209,6 +209,11 @@ public class PaperAdvancedTextImpl extends AdvancedTextImpl {
 
     @Override
     public void setSkin(Player player, String name) {
+        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_18)) {
+            NMSHandler.instance.getProfileEditor().setPlayerSkin(player, name);
+            return;
+        }
+        // Note: this API is present on all supported versions, but currently used for 1.19+ only
         PlayerProfile skinProfile = Bukkit.createProfile(name);
         boolean isOwnName = CoreUtilities.equalsIgnoreCase(player.getName(), name);
         if (isOwnName && modifiedTextures.contains(player.getUniqueId())) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
@@ -32,9 +32,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.potion.PotionBrewer;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 public class PaperAdvancedTextImpl extends AdvancedTextImpl {
 
@@ -207,9 +205,15 @@ public class PaperAdvancedTextImpl extends AdvancedTextImpl {
         event.deathMessage(PaperModule.parseFormattedText(message, ChatColor.WHITE));
     }
 
+    public Set<UUID> modifiedTextures = new HashSet<>();
+
     @Override
     public void setSkin(Player player, String name) {
         PlayerProfile skinProfile = Bukkit.createProfile(name);
+        boolean isOwnName = CoreUtilities.equalsIgnoreCase(player.getName(), name);
+        if (isOwnName && modifiedTextures.contains(player.getUniqueId())) {
+            skinProfile.removeProperty("textures");
+        }
         Bukkit.getScheduler().runTaskAsynchronously(Denizen.instance, () -> {
             if (!skinProfile.complete()) {
                 return;
@@ -220,6 +224,12 @@ public class PaperAdvancedTextImpl extends AdvancedTextImpl {
                         PlayerProfile playerProfile = player.getPlayerProfile();
                         playerProfile.setProperty(property);
                         player.setPlayerProfile(playerProfile);
+                        if (isOwnName) {
+                            modifiedTextures.remove(player.getUniqueId());
+                        }
+                        else {
+                            modifiedTextures.add(player.getUniqueId());
+                        }
                         return;
                     }
                 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAdvancedTextImpl.java
@@ -5,7 +5,10 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizen.utilities.AdvancedTextImpl;
+import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
 import io.papermc.paper.entity.RelativeTeleportFlag;
 import io.papermc.paper.potion.PotionMix;
 import net.kyori.adventure.text.Component;
@@ -202,5 +205,25 @@ public class PaperAdvancedTextImpl extends AdvancedTextImpl {
     @Override
     public void setDeathMessage(PlayerDeathEvent event, String message) {
         event.deathMessage(PaperModule.parseFormattedText(message, ChatColor.WHITE));
+    }
+
+    @Override
+    public void setSkin(Player player, String name) {
+        PlayerProfile skinProfile = Bukkit.createProfile(name);
+        Bukkit.getScheduler().runTaskAsynchronously(Denizen.instance, () -> {
+            if (!skinProfile.complete()) {
+                return;
+            }
+            DenizenCore.runOnMainThread(() -> {
+                for (ProfileProperty property : skinProfile.getProperties()) {
+                    if (property.getName().equals("textures")) {
+                        PlayerProfile playerProfile = player.getPlayerProfile();
+                        playerProfile.setProperty(property);
+                        player.setPlayerProfile(playerProfile);
+                        return;
+                    }
+                }
+            });
+        });
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -3788,11 +3788,10 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         if (mechanism.matches("skin") && mechanism.hasValue()) {
             String name = mechanism.getValue().asString();
             if (name.length() > 16) {
-                Debug.echoError("Must specify a name with no more than 16 characters.");
+                mechanism.echoError("Must specify a name with no more than 16 characters.");
+                return;
             }
-            else {
-                NMSHandler.instance.getProfileEditor().setPlayerSkin(getPlayerEntity(), mechanism.getValue().asString());
-            }
+            AdvancedTextImpl.instance.setSkin(getPlayerEntity(), name);
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -3806,7 +3806,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // <PlayerTag.skin_blob>
         // -->
         if (mechanism.matches("skin_blob") && mechanism.hasValue()) {
-            NMSHandler.instance.getProfileEditor().setPlayerSkinBlob(getPlayerEntity(), mechanism.getValue().asString());
+            AdvancedTextImpl.instance.setSkinBlob(getPlayerEntity(), mechanism.getValue().asString());
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/AdvancedTextImpl.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/AdvancedTextImpl.java
@@ -130,4 +130,8 @@ public class AdvancedTextImpl {
     public void setSkin(Player player, String name) {
         NMSHandler.instance.getProfileEditor().setPlayerSkin(player, name);
     }
+
+    public void setSkinBlob(Player player, String blob) {
+        NMSHandler.instance.getProfileEditor().setPlayerSkinBlob(player, blob);
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/AdvancedTextImpl.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/AdvancedTextImpl.java
@@ -126,4 +126,8 @@ public class AdvancedTextImpl {
     public void setDeathMessage(PlayerDeathEvent event, String message) {
         event.setDeathMessage(message);
     }
+
+    public void setSkin(Player player, String name) {
+        NMSHandler.instance.getProfileEditor().setPlayerSkin(player, name);
+    }
 }


### PR DESCRIPTION
## Additions

- `AdvancedTextImpl#setSkin(Player, String)` - sets a player's skin by player name.
- `AdvancedTextImpl#setSkinBlob(Player, String)` - set's a player's skin by skin blob.

## Changes

- `PlayerTag.skin` mechanism now uses `AdvancedTextImpl#setSkin`.
- `PlayerTag.skin_blob` mechanism now uses `AdvancedTextImpl#setSkinBlob`.