### PR TITLE
Add `EntityTag.aggressive` property

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityArmsRaised.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityArmsRaised.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.paper.properties;
 
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.Property;
@@ -8,6 +9,7 @@ import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.destroystokyo.paper.entity.RangedEntity;
 
+@Deprecated
 public class EntityArmsRaised implements Property {
 
     public static boolean describes(ObjectTag entity) {
@@ -24,15 +26,21 @@ public class EntityArmsRaised implements Property {
         }
     }
 
-    public static final String[] handledMechs = new String[]{
-            "arms_raised"
-    };
-
     private EntityArmsRaised(EntityTag _entity) {
         entity = _entity;
     }
 
     EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "arms_raised";
+    }
 
     public static void registerTags() {
 
@@ -42,44 +50,35 @@ public class EntityArmsRaised implements Property {
         // @mechanism EntityTag.arms_raised
         // @group properties
         // @Plugin Paper
+        // @deprecated use 'aggressive'
         // @description
-        // Returns whether a ranged mob (skeleton, stray, wither skeleton, drowned, illusioner, or piglin) is "charging" up an attack (its arms are raised).
+        // Deprecated in favor of <@link tag EntityTag.aggressive>.
         // -->
         PropertyParser.registerTag(EntityArmsRaised.class, ElementTag.class, "arms_raised", (attribute, object) -> {
+            BukkitImplDeprecations.entityArmsRaised.warn(attribute.context);
             return new ElementTag(object.getRanged().isChargingAttack());
         });
-    }
-
-    public RangedEntity getRanged() {
-        return (RangedEntity) entity.getBukkitEntity();
-    }
-
-    @Override
-    public String getPropertyString() {
-        return String.valueOf(getRanged().isChargingAttack());
-    }
-
-    @Override
-    public String getPropertyId() {
-        return "arms_raised";
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
 
         // <--[mechanism]
         // @object EntityTag
         // @name arms_raised
         // @input ElementTag(Boolean)
         // @Plugin Paper
+        // @deprecated use 'aggressive'
         // @description
-        // Sets whether a ranged mob (skeleton, stray, wither skeleton, drowned, illusioner, or piglin) is "charging" up an attack (its arms are raised).
-        // Some entities may require <@link mechanism EntityTag.is_aware> to be set to false.
+        // Deprecated in favor of <@link mechanism EntityTag.aggressive>.
         // @tags
         // <EntityTag.arms_raised>
         // -->
-        if (mechanism.matches("arms_raised") && mechanism.requireBoolean()) {
-            getRanged().setChargingAttack(mechanism.getValue().asBoolean());
-        }
+        PropertyParser.registerMechanism(EntityArmsRaised.class, ElementTag.class, "arms_raised", (object, mechanism, input) -> {
+            BukkitImplDeprecations.entityArmsRaised.warn(mechanism.context);
+            if (mechanism.requireBoolean()) {
+                object.getRanged().setChargingAttack(input.asBoolean());
+            }
+        });
+    }
+
+    public RangedEntity getRanged() {
+        return (RangedEntity) entity.getBukkitEntity();
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/AnimationHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/AnimationHelper.java
@@ -1,7 +1,11 @@
 package com.denizenscript.denizen.nms.abstracts;
 
+import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.interfaces.EntityAnimation;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Mob;
 import org.bukkit.entity.Villager;
 
 import java.util.HashMap;
@@ -15,6 +19,18 @@ public abstract class AnimationHelper {
         entityAnimations.put("villager_shake_head", entity -> {
             if (entity instanceof Villager) {
                 ((Villager) entity).shakeHead();
+            }
+        });
+        entityAnimations.put("skeleton_start_arm_swing", entity -> {
+            if (entity.getType() == EntityType.SKELETON) {
+                BukkitImplDeprecations.skeletonSwingArm.warn();
+                NMSHandler.entityHelper.setAggressive((Mob) entity, true);
+            }
+        });
+        entityAnimations.put("skeleton_stop_arm_swing", entity -> {
+            if (entity.getType() == EntityType.SKELETON) {
+                BukkitImplDeprecations.skeletonSwingArm.warn();
+                NMSHandler.entityHelper.setAggressive((Mob) entity, false);
             }
         });
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -429,4 +429,8 @@ public abstract class EntityHelper {
     public void setTrackingRange(Entity entity, int range) {
         throw new UnsupportedOperationException();
     }
+
+    public abstract boolean isAggressive(Mob mob);
+
+    public abstract void setAggressive(Mob mob, boolean aggressive);
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -27,6 +27,7 @@ public class PropertyRegistry {
 
         // register core EntityTag properties
         PropertyParser.registerProperty(EntityAge.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityAggressive.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAI.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAnger.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAngry.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAggressive.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAggressive.java
@@ -1,0 +1,76 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.entity.Mob;
+
+public class EntityAggressive implements Property {
+
+    public static boolean describes(ObjectTag object) {
+        return object instanceof EntityTag
+                && ((EntityTag) object).getBukkitEntity() instanceof Mob;
+    }
+
+    public static EntityAggressive getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        else {
+            return new EntityAggressive((EntityTag) entity);
+        }
+    }
+
+    EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(NMSHandler.entityHelper.isAggressive(getMob()));
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "aggressive";
+    }
+
+    public EntityAggressive(EntityTag entity) {
+        this.entity = entity;
+    }
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <EntityTag.aggressive>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.aggressive
+        // @group properties
+        // @description
+        // Returns whether the entity is currently aggressive.
+        // -->
+        PropertyParser.registerTag(EntityAggressive.class, ElementTag.class, "aggressive", (attribute, object) -> {
+            return new ElementTag(NMSHandler.entityHelper.isAggressive(object.getMob()));
+        });
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name aggressive
+        // @input ElementTag(Boolean)
+        // @description
+        // Sets whether the entity is currently aggressive.
+        // @tags
+        // <EntityTag.aggressive>
+        // -->
+        PropertyParser.registerMechanism(EntityAggressive.class, ElementTag.class, "aggressive", (object, mechanism, input) -> {
+            if (mechanism.requireBoolean()) {
+                NMSHandler.entityHelper.setAggressive(object.getMob(), input.asBoolean());
+            }
+        });
+    }
+
+    public Mob getMob() {
+        return (Mob) entity.getBukkitEntity();
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -173,6 +173,10 @@ public class BukkitImplDeprecations {
     // Added 2022/07/28
     public static Warning internalEventReflectionContext = new SlowWarning("internalEventReflectionContext", "The context.field_<name> and fields special tags for 'internal bukkit event' are deprecated in favor of the 'reflect_event' global context.");
 
+    // Added 2022/10/14
+    public static Warning skeletonSwingArm = new SlowWarning("skeletonSwingArm", "The 'SKELETON_START/STOP_SWING_ARM' animations are deprecated in favor of the 'EntityTag.aggressive' property.");
+    public static Warning entityArmsRaised = new SlowWarning("entityArmsRaised", "The 'EntityTag.arms_raised' property is deprecated in favor of 'EntityTag.aggressive'.");
+
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.
 
@@ -180,7 +184,7 @@ public class BukkitImplDeprecations {
     public static Warning interactScriptPriority = new VerySlowWarning("interactScriptPriority", "Assignment script 'interact scripts' section should not have numbered priority values, these were removed years ago. Check https://guide.denizenscript.com/guides/troubleshooting/updates-since-videos.html#assignment-script-updates for more info.");
 
     // Added 2021/10/24, bump to normal slow warning by 2023.
-    public static Warning entityArmorPose = new VerySlowWarning("entityArmorPose", "The old EntityTag.armor_pose and armor_pose_list tags are dperecated in favor of armor_pose_map.");
+    public static Warning entityArmorPose = new VerySlowWarning("entityArmorPose", "The old EntityTag.armor_pose and armor_pose_list tags are deprecated in favor of armor_pose_map.");
 
     // Added 2020/06/13, bump to normal slow warning by 2023.
     public static Warning listStyleTags = new VerySlowWarning("listStyleTags", "'list_' tags are deprecated: just remove the 'list_' prefix.");

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/AnimationHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/AnimationHelperImpl.java
@@ -5,7 +5,6 @@ import net.minecraft.server.v1_16_R3.Entity;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftHorse;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPolarBear;
-import org.bukkit.craftbukkit.v1_16_R3.entity.CraftSkeleton;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.IronGolem;
@@ -13,16 +12,6 @@ import org.bukkit.entity.IronGolem;
 public class AnimationHelperImpl extends AnimationHelper {
 
     public AnimationHelperImpl() {
-        register("SKELETON_START_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(true);
-            }
-        });
-        register("SKELETON_STOP_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(false);
-            }
-        });
         register("POLAR_BEAR_START_STANDING", entity -> {
             if (entity.getType() == EntityType.POLAR_BEAR) {
                 ((CraftPolarBear) entity).getHandle().t(true);

--- a/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
+++ b/v1_16/src/main/java/com/denizenscript/denizen/nms/v1_16/helpers/EntityHelperImpl.java
@@ -614,4 +614,14 @@ public class EntityHelperImpl extends EntityHelper {
             CraftEventFactory.entityDamage = null;
         }
     }
+
+    @Override
+    public boolean isAggressive(org.bukkit.entity.Mob mob) {
+        return ((CraftMob) mob).getHandle().isAggressive();
+    }
+
+    @Override
+    public void setAggressive(org.bukkit.entity.Mob mob, boolean aggressive) {
+        ((CraftMob) mob).getHandle().setAggressive(aggressive);
+    }
 }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/AnimationHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/AnimationHelperImpl.java
@@ -5,7 +5,6 @@ import net.minecraft.world.entity.Entity;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftHorse;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPolarBear;
-import org.bukkit.craftbukkit.v1_17_R1.entity.CraftSkeleton;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.IronGolem;
@@ -13,16 +12,6 @@ import org.bukkit.entity.IronGolem;
 public class AnimationHelperImpl extends AnimationHelper {
 
     public AnimationHelperImpl() {
-        register("SKELETON_START_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(true);
-            }
-        });
-        register("SKELETON_STOP_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(false);
-            }
-        });
         register("POLAR_BEAR_START_STANDING", entity -> {
             if (entity.getType() == EntityType.POLAR_BEAR) {
                 ((CraftPolarBear) entity).getHandle().setStanding(true);

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -697,4 +697,14 @@ public class EntityHelperImpl extends EntityHelper {
             Debug.echoError(ex);
         }
     }
+
+    @Override
+    public boolean isAggressive(org.bukkit.entity.Mob mob) {
+        return ((CraftMob) mob).getHandle().isAggressive();
+    }
+
+    @Override
+    public void setAggressive(org.bukkit.entity.Mob mob, boolean aggressive) {
+        ((CraftMob) mob).getHandle().setAggressive(aggressive);
+    }
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/AnimationHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/AnimationHelperImpl.java
@@ -5,7 +5,6 @@ import net.minecraft.world.entity.Entity;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftHorse;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPolarBear;
-import org.bukkit.craftbukkit.v1_18_R2.entity.CraftSkeleton;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.IronGolem;
@@ -13,16 +12,6 @@ import org.bukkit.entity.IronGolem;
 public class AnimationHelperImpl extends AnimationHelper {
 
     public AnimationHelperImpl() {
-        register("SKELETON_START_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(true);
-            }
-        });
-        register("SKELETON_STOP_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(false);
-            }
-        });
         register("POLAR_BEAR_START_STANDING", entity -> {
             if (entity.getType() == EntityType.POLAR_BEAR) {
                 ((CraftPolarBear) entity).getHandle().setStanding(true);

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -776,4 +776,14 @@ public class EntityHelperImpl extends EntityHelper {
             Debug.echoError(ex);
         }
     }
+
+    @Override
+    public boolean isAggressive(org.bukkit.entity.Mob mob) {
+        return ((CraftMob) mob).getHandle().isAggressive();
+    }
+
+    @Override
+    public void setAggressive(org.bukkit.entity.Mob mob, boolean aggressive) {
+        ((CraftMob) mob).getHandle().setAggressive(aggressive);
+    }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/AnimationHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/AnimationHelperImpl.java
@@ -5,7 +5,6 @@ import net.minecraft.world.entity.Entity;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftHorse;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPolarBear;
-import org.bukkit.craftbukkit.v1_19_R1.entity.CraftSkeleton;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.IronGolem;
@@ -13,16 +12,6 @@ import org.bukkit.entity.IronGolem;
 public class AnimationHelperImpl extends AnimationHelper {
 
     public AnimationHelperImpl() {
-        register("SKELETON_START_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(true);
-            }
-        });
-        register("SKELETON_STOP_SWING_ARM", entity -> {
-            if (entity.getType() == EntityType.SKELETON) {
-                ((CraftSkeleton) entity).getHandle().setAggressive(false);
-            }
-        });
         register("POLAR_BEAR_START_STANDING", entity -> {
             if (entity.getType() == EntityType.POLAR_BEAR) {
                 ((CraftPolarBear) entity).getHandle().setStanding(true);

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -775,4 +775,14 @@ public class EntityHelperImpl extends EntityHelper {
             Debug.echoError(ex);
         }
     }
+
+    @Override
+    public boolean isAggressive(org.bukkit.entity.Mob mob) {
+        return ((CraftMob) mob).getHandle().isAggressive();
+    }
+
+    @Override
+    public void setAggressive(org.bukkit.entity.Mob mob, boolean aggressive) {
+        ((CraftMob) mob).getHandle().setAggressive(aggressive);
+    }
 }


### PR DESCRIPTION
## Additions

- `EntityTag.aggressive` property - Controls whether the entity is currently aggressive.
- `EntityHelper#is/setAggressive` - Controls whether an entity is aggressive.
- 2 new deprecation warnings, `skeletonSwingArm` and `entityArmsRaised`.

## Changes

- Deprecated `EntityTag.arms_raised` in favor of `EntityTag.aggressive` (both use the same setter internally).
- Deprecated the `SKELETON_START/STOP_SWING_ARM` animations in favor of `EntityTag.aggressive`.
- Moved implementation of `SKELETON_START/STOP_SWING_ARM` to `AnimationHelper` (as opposed to it's NMS impls) using the new `EntityHelper#is/setAggressive` methods to avoid duplicate code.
- Updated `arms_raised` to modern mechanism registration.

## Notes

- Could maybe improve the wording on `EntityTag.aggressive` meta, used `currently` to make it clear that it's weather the entity is currently aggressive, and not just weather it _can be_ aggressive.
- `EntityHelper#is/setAggressive` is implemented on all supported versions as a special edge-case: as everything it deprecates is implemented on all supported versions I thought it'd be easier to provide support for and all if it replaced deprecated alternatives on every version, let me know if that should be changed.
- `arms_raised` was updated to modern mech registration as it's a very small change, and made sense to avoid having legacy code around when possible - let me know if that should be reverted.