### PR TITLE
Add EntityExhaustionEvent

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -183,13 +183,13 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerEditsBookScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerEmptiesBucketScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerEntersBedScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerIncreasesExhaustionLevelScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerFillsBucketScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerFishesScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerFlyingScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerHearsSoundScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerHoldsItemEvent.class);
         ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerIncreasesExhaustionLevelScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerJoinsScriptEvent.class);
         if (!Denizen.supportsPaper) {
             ScriptEvent.registerScriptEvent(PlayerJumpScriptEvent.PlayerJumpsSpigotScriptEventImpl.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -188,8 +188,8 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerFlyingScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerHearsSoundScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerHoldsItemEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerIncreasesExhaustionLevelScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerJoinsScriptEvent.class);
         if (!Denizen.supportsPaper) {
             ScriptEvent.registerScriptEvent(PlayerJumpScriptEvent.PlayerJumpsSpigotScriptEventImpl.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -105,6 +105,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(EntityDropsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityEntersPortalScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityEntersVehicleScriptEvent.class);
+        ScriptEvent.registerScriptEvent(EntityExhaustsScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExitsPortalScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExitsVehicleScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExplodesScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -105,7 +105,6 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(EntityDropsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityEntersPortalScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityEntersVehicleScriptEvent.class);
-        ScriptEvent.registerScriptEvent(EntityExhaustsScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExitsPortalScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExitsVehicleScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExplodesScriptEvent.class);
@@ -184,6 +183,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerEditsBookScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerEmptiesBucketScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerEntersBedScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerIncreasesExhaustionLevelScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerFillsBucketScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerFishesScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerFlyingScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
@@ -29,7 +29,7 @@ public class EntityExhaustsScriptEvent extends BukkitScriptEvent implements List
     //
     // @Context
     // <context.entity> returns the entity.
-    // <context.exhaustion> returns the amount of exhaustion.
+    // <context.exhaustion> returns the amount of exhaustion added to the entity.
     // <context.reason> returns the reason of exhaustion. See <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityExhaustionEvent.ExhaustionReason.html> for a list of valid reasons.
     //
     // @Determine

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
@@ -1,0 +1,104 @@
+package com.denizenscript.denizen.events.entity;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExhaustionEvent;
+
+public class EntityExhaustsScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // <entity> exhausts
+    //
+    // @Group Entity
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers when an entity exhausts.
+    //
+    // @Switch reason:<reason> to only process the event if the reason matches a specific reason.
+    //
+    // @Context
+    // <context.entity> returns the entity.
+    // <context.exhaustion> returns the amount of exhaustion.
+    // <context.reason> returns the reason of exhaustion. See <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityExhaustionEvent.ExhaustionReason.html> for a list of valid reasons.
+    //
+    // @Determine
+    // ElementTag(Decimal) to change the amount of exhaustion.
+    //
+    // @Player when the exhausting entity is a player.
+    //
+    // @NPC when the exhausting entity is a npc.
+    //
+    // -->
+
+    public EntityExhaustsScriptEvent() {
+        registerCouldMatcher("<entity> exhausts");
+        registerSwitches("reason");
+    }
+
+    public EntityExhaustionEvent event;
+
+    public ElementTag reason;
+    public EntityTag entity;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        String entityName = path.eventArgLowerAt(0);
+        if (!entity.tryAdvancedMatcher(entityName)) {
+            return false;
+        }
+        if (!runGenericSwitchCheck(path, "reason", reason.asString())) {
+            return false;
+        }
+        if (!runInCheck(path, entity.getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "entity": return entity;
+            case "exhaustion": return new ElementTag(event.getExhaustion());
+            case "reason": return reason;
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        if (determinationObj instanceof ElementTag) {
+            String lower = CoreUtilities.toLowerCase(determinationObj.toString());
+            ElementTag value = new ElementTag(lower);
+            if (value.isFloat()) {
+                event.setExhaustion(value.asFloat());
+                return true;
+            }
+        }
+        return super.applyDetermination(path, determinationObj);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(entity);
+    }
+
+    @EventHandler
+    public void onEntityExhausts(EntityExhaustionEvent event) {
+        reason = new ElementTag(event.getExhaustionReason().name());
+        entity = new EntityTag(event.getEntity());
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
@@ -39,6 +39,8 @@ public class EntityExhaustsScriptEvent extends BukkitScriptEvent implements List
     //
     // @NPC when the exhausting entity is a npc.
     //
+    // @Warning This event may fire very rapidly.
+    //
     // -->
 
     public EntityExhaustsScriptEvent() {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExhaustsScriptEvent.java
@@ -98,7 +98,7 @@ public class EntityExhaustsScriptEvent extends BukkitScriptEvent implements List
 
     @EventHandler
     public void onEntityExhausts(EntityExhaustionEvent event) {
-        reason = new ElementTag(event.getExhaustionReason().name());
+        reason = new ElementTag(event.getExhaustionReason().name(), true);
         entity = new EntityTag(event.getEntity());
         this.event = event;
         fire(event);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
@@ -33,7 +33,7 @@ public class PlayerIncreasesExhaustionLevelScriptEvent extends BukkitScriptEvent
     // <context.reason> returns the reason of exhaustion. See <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityExhaustionEvent.ExhaustionReason.html> for a list of valid reasons.
     //
     // @Determine
-    // ElementTag(Decimal) to change the amount of exhaustion.
+    // ElementTag(Decimal) to change the amount of exhaustion that will be added to the player.
     //
     // @Player Always.
     //
@@ -56,7 +56,7 @@ public class PlayerIncreasesExhaustionLevelScriptEvent extends BukkitScriptEvent
         if (!runGenericSwitchCheck(path, "reason", reason.asString())) {
             return false;
         }
-        if (!runInCheck(path, player.getLocation())) {
+        if (!runInCheck(path, event.getEntity().getLocation())) {
             return false;
         }
         return super.matches(path);
@@ -74,7 +74,7 @@ public class PlayerIncreasesExhaustionLevelScriptEvent extends BukkitScriptEvent
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
         if (determinationObj instanceof ElementTag) {
-            ElementTag value = new ElementTag(determinationObj.toString());
+            ElementTag value = determinationObj.asElement();
             if (value.isFloat()) {
                 event.setExhaustion(value.asFloat());
                 return true;
@@ -85,7 +85,7 @@ public class PlayerIncreasesExhaustionLevelScriptEvent extends BukkitScriptEvent
 
     @Override
     public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(player, null);
+        return new BukkitScriptEntryData(event.getEntity());
     }
 
     @EventHandler
@@ -94,7 +94,6 @@ public class PlayerIncreasesExhaustionLevelScriptEvent extends BukkitScriptEvent
             return;
         }
         reason = new ElementTag(event.getExhaustionReason().name(), true);
-        player = new PlayerTag((Player) event.getEntity());
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
@@ -2,12 +2,10 @@ package com.denizenscript.denizen.events.player;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExhaustionEvent;

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
@@ -24,7 +24,7 @@ public class PlayerIncreasesExhaustionLevelScriptEvent extends BukkitScriptEvent
     //
     // @Cancellable true
     //
-    // @Triggers when a player experience exhaustion.
+    // @Triggers when a player does an activity that increases their exhaustion level, which increases the rate of hunger.
     //
     // @Switch reason:<reason> to only process the event if the reason matches a specific reason.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerIncreasesExhaustionLevelScriptEvent.java
@@ -49,7 +49,6 @@ public class PlayerIncreasesExhaustionLevelScriptEvent extends BukkitScriptEvent
     public EntityExhaustionEvent event;
 
     public ElementTag reason;
-    public PlayerTag player;
 
     @Override
     public boolean matches(ScriptPath path) {


### PR DESCRIPTION
Adds the `on <entity> exhausts` event, which fire's when an entity (player or npc) exhausts.

Context tags:

- `<context.entity>` returns the entity.
- `<context.exhaustion>` returns the amount of exhaustion added to the entity.
- `<context.reason>` returns the reason of exhaustion.

Determine:
- `ElementTag(Decimal)` to change the amount of exhaustion.