### PR TITLE
Add `player inventory slot changes` event

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -45,6 +45,9 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerCompletesAdvancementScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerElytraBoostScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerEquipsArmorScriptEvent.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            ScriptEvent.registerScriptEvent(PlayerInventorySlotChangeScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerJumpsScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/AnvilBlockDamagedScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/AnvilBlockDamagedScriptEvent.java
@@ -21,6 +21,8 @@ public class AnvilBlockDamagedScriptEvent extends BukkitScriptEvent implements L
     //
     // @Location true
     //
+    // @Plugin Paper
+    //
     // @Cancellable true
     //
     // @Switch state:<state> to only process the event if the anvil's new damage state matches the specified state.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
@@ -27,8 +27,8 @@ public class PlayerInventorySlotChangeScriptEvent extends BukkitScriptEvent impl
     // @Switch to:<item> to only process the event if the new item in the slot matches the specified item.
     // @Switch slot:<slot> to only process the event if a specific slot was clicked.
     //
-    // @Triggers When the item in a slot of a player's inventory changes.
-    // Note that this fires for every item in the player's inventory when they join
+    // @Triggers when the item in a slot of a player's inventory changes.
+    // Note that this fires for every item in the player's inventory when they join.
     //
     // @Context
     // <context.new_item> returns an ItemTag of the new item in the slot.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
@@ -45,11 +45,10 @@ public class PlayerInventorySlotChangeScriptEvent extends BukkitScriptEvent impl
     public PlayerInventorySlotChangeEvent event;
     public ItemTag oldItem;
     public ItemTag newItem;
-    public int slot;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runGenericSwitchCheck(path, "slot", String.valueOf(slot))) {
+        if (!runGenericSwitchCheck(path, "slot", String.valueOf(event.getSlot() + 1))) {
             return false;
         }
         if (!runWithCheck(path, oldItem, "from")) {
@@ -69,8 +68,8 @@ public class PlayerInventorySlotChangeScriptEvent extends BukkitScriptEvent impl
         switch (name) {
             case "new_item": return newItem;
             case "old_item": return oldItem;
-            case "slot": return new ElementTag(slot);
-            case "raw_slot": return new ElementTag(event.getSlot());
+            case "slot": return new ElementTag(event.getSlot() + 1);
+            case "raw_slot": return new ElementTag(event.getRawSlot());
         }
         return super.getContext(name);
     }
@@ -87,7 +86,6 @@ public class PlayerInventorySlotChangeScriptEvent extends BukkitScriptEvent impl
         }
         oldItem = new ItemTag(event.getOldItemStack());
         newItem = new ItemTag(event.getNewItemStack());
-        slot = event.getPlayer().getOpenInventory().convertSlot(event.getSlot()) + 1;
         this.event = event;
         fire(event);
     }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
@@ -35,6 +35,9 @@ public class PlayerInventorySlotChangeScriptEvent extends BukkitScriptEvent impl
     // <context.old_item> returns an ItemTag of the previous item in the slot.
     // <context.slot> returns an ElementTag(Number) of the slot that was changed.
     // <context.raw_slot> returns an ElementTag(Number) of the raw number of the slot that was changed.
+    //
+    // @Player Always.
+    //
     // -->
 
     public PlayerInventorySlotChangeScriptEvent() {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerInventorySlotChangeScriptEvent.java
@@ -1,0 +1,94 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import io.papermc.paper.event.player.PlayerInventorySlotChangeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerInventorySlotChangeScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player inventory slot changes
+    //
+    // @Group Paper
+    //
+    // @Location true
+    //
+    // @Plugin Paper
+    //
+    // @Switch from:<item> to only process the event if the previous item in the slot matches the specified item.
+    // @Switch to:<item> to only process the event if the new item in the slot matches the specified item.
+    // @Switch slot:<slot> to only process the event if a specific slot was clicked.
+    //
+    // @Triggers When the item in a slot of a player's inventory changes.
+    // Note that this fires for every item in the player's inventory when they join
+    //
+    // @Context
+    // <context.new_item> returns an ItemTag of the new item in the slot.
+    // <context.old_item> returns an ItemTag of the previous item in the slot.
+    // <context.slot> returns an ElementTag(Number) of the slot that was changed.
+    // <context.raw_slot> returns an ElementTag(Number) of the raw number of the slot that was changed.
+    // -->
+
+    public PlayerInventorySlotChangeScriptEvent() {
+        registerCouldMatcher("player inventory slot changes");
+        registerSwitches("from", "to", "slot");
+    }
+
+    public PlayerInventorySlotChangeEvent event;
+    public ItemTag oldItem;
+    public ItemTag newItem;
+    public int slot;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runGenericSwitchCheck(path, "slot", String.valueOf(slot))) {
+            return false;
+        }
+        if (!runWithCheck(path, oldItem, "from")) {
+            return false;
+        }
+        if (!runWithCheck(path, newItem, "to")) {
+            return false;
+        }
+        if (!runInCheck(path, event.getPlayer().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "new_item": return newItem;
+            case "old_item": return oldItem;
+            case "slot": return new ElementTag(slot);
+            case "raw_slot": return new ElementTag(event.getSlot());
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerInventorySlotChange(PlayerInventorySlotChangeEvent event) {
+        if (EntityTag.isNPC(event.getPlayer())) {
+            return;
+        }
+        oldItem = new ItemTag(event.getOldItemStack());
+        newItem = new ItemTag(event.getNewItemStack());
+        slot = event.getPlayer().getOpenInventory().convertSlot(event.getSlot()) + 1;
+        this.event = event;
+        fire(event);
+    }
+}


### PR DESCRIPTION
## Additions

- `player inventory slot changes` event - Triggers when the item in a slot of a player's inventory changes.

## Changes

- Added missing `@Plugin Paper` meta to `AnvilBlockDamagedScriptEvent`.