### PR TITLE
`ElementTag.parse/to_minimessage` tags

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizen.paper.events.*;
 import com.denizenscript.denizen.paper.properties.*;
+import com.denizenscript.denizen.paper.tags.PaperElementExtensions;
 import com.denizenscript.denizen.paper.tags.PaperTagBase;
 import com.denizenscript.denizen.paper.utilities.PaperAPIToolsImpl;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
@@ -76,6 +77,7 @@ public class PaperModule {
         PropertyParser.registerProperty(PaperItemTagProperties.class, ItemTag.class);
         PropertyParser.registerProperty(PaperWorldProperties.class, WorldTag.class);
         PaperPlayerExtensions.register();
+        PaperElementExtensions.register();
 
         // Paper Tags
         new PaperTagBase();
@@ -86,10 +88,14 @@ public class PaperModule {
     }
 
     public static Component parseFormattedText(String text, ChatColor baseColor) {
+        return parseFormattedText(text, baseColor, true);
+    }
+
+    public static Component parseFormattedText(String text, ChatColor baseColor, boolean cleanBase) {
         if (text == null) {
             return null;
         }
-        return jsonToComponent(ComponentSerializer.toString(FormattedTextHelper.parse(text, baseColor)));
+        return jsonToComponent(ComponentSerializer.toString(FormattedTextHelper.parse(text, baseColor, cleanBase)));
     }
 
     public static String stringifyComponent(Component component) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -8,7 +8,6 @@ import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizen.paper.events.*;
 import com.denizenscript.denizen.paper.properties.*;
-import com.denizenscript.denizen.paper.tags.PaperElementExtensions;
 import com.denizenscript.denizen.paper.tags.PaperTagBase;
 import com.denizenscript.denizen.paper.utilities.PaperAPIToolsImpl;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
@@ -88,14 +87,10 @@ public class PaperModule {
     }
 
     public static Component parseFormattedText(String text, ChatColor baseColor) {
-        return parseFormattedText(text, baseColor, true);
-    }
-
-    public static Component parseFormattedText(String text, ChatColor baseColor, boolean cleanBase) {
         if (text == null) {
             return null;
         }
-        return jsonToComponent(ComponentSerializer.toString(FormattedTextHelper.parse(text, baseColor, cleanBase)));
+        return jsonToComponent(ComponentSerializer.toString(FormattedTextHelper.parse(text, baseColor)));
     }
 
     public static String stringifyComponent(Component component) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperElementExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperElementExtensions.java
@@ -20,8 +20,7 @@ public class PaperElementExtensions {
             // @returns ElementTag
             // @Plugin Paper
             // @description
-            // Returns the element with all MiniMessage tags parsed.
-            // See also <@link tag ElementTag.parse_color>
+            // Returns the element with all MiniMessage tags parsed, see <@link url https://docs.adventure.kyori.net/minimessage/format.html> for more information.
             // -->
             ElementTag.tagProcessor.registerTag(ElementTag.class, "parse_minimessage", (attribute, object) -> {
                 return new ElementTag(PaperModule.stringifyComponent(MiniMessage.miniMessage().deserialize(object.asString())));

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperElementExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperElementExtensions.java
@@ -1,9 +1,11 @@
-package com.denizenscript.denizen.paper.tags;
+package com.denizenscript.denizen.paper.properties;
 
 import com.denizenscript.denizen.paper.PaperModule;
+import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.chat.ComponentSerializer;
 
 public class PaperElementExtensions {
 
@@ -16,6 +18,7 @@ public class PaperElementExtensions {
         // @Plugin Paper
         // @description
         // Returns the element with all MiniMessage tags parsed.
+        // See also <@link tag ElementTag.parse_color>
         // -->
         ElementTag.tagProcessor.registerTag(ElementTag.class, "parse_minimessage", (attribute, object) -> {
             return new ElementTag(PaperModule.stringifyComponent(MiniMessage.miniMessage().deserialize(object.asString())));
@@ -29,7 +32,9 @@ public class PaperElementExtensions {
         // Returns the element with all text formatting parsed into MiniMessage format.
         // -->
         ElementTag.tagProcessor.registerTag(ElementTag.class, "to_minimessage", (attribute, object) -> {
-            return new ElementTag(MiniMessage.miniMessage().serialize(PaperModule.parseFormattedText(object.asString(), ChatColor.WHITE, false)));
+            return new ElementTag(MiniMessage.miniMessage().serialize(
+                    PaperModule.jsonToComponent(ComponentSerializer.toString(FormattedTextHelper.parse(object.asString(), ChatColor.WHITE, false)))
+            ));
         });
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperElementExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperElementExtensions.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.paper.properties;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -11,30 +13,32 @@ public class PaperElementExtensions {
 
 
     public static void register() {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
 
-        // <--[tag]
-        // @attribute <ElementTag.parse_minimessage>
-        // @returns ElementTag
-        // @Plugin Paper
-        // @description
-        // Returns the element with all MiniMessage tags parsed.
-        // See also <@link tag ElementTag.parse_color>
-        // -->
-        ElementTag.tagProcessor.registerTag(ElementTag.class, "parse_minimessage", (attribute, object) -> {
-            return new ElementTag(PaperModule.stringifyComponent(MiniMessage.miniMessage().deserialize(object.asString())));
-        });
+            // <--[tag]
+            // @attribute <ElementTag.parse_minimessage>
+            // @returns ElementTag
+            // @Plugin Paper
+            // @description
+            // Returns the element with all MiniMessage tags parsed.
+            // See also <@link tag ElementTag.parse_color>
+            // -->
+            ElementTag.tagProcessor.registerTag(ElementTag.class, "parse_minimessage", (attribute, object) -> {
+                return new ElementTag(PaperModule.stringifyComponent(MiniMessage.miniMessage().deserialize(object.asString())));
+            });
 
-        // <--[tag]
-        // @attribute <ElementTag.to_minimessage>
-        // @returns ElementTag
-        // @Plugin Paper
-        // @description
-        // Returns the element with all text formatting parsed into MiniMessage format.
-        // -->
-        ElementTag.tagProcessor.registerTag(ElementTag.class, "to_minimessage", (attribute, object) -> {
-            return new ElementTag(MiniMessage.miniMessage().serialize(
-                    PaperModule.jsonToComponent(ComponentSerializer.toString(FormattedTextHelper.parse(object.asString(), ChatColor.WHITE, false)))
-            ));
-        });
+            // <--[tag]
+            // @attribute <ElementTag.to_minimessage>
+            // @returns ElementTag
+            // @Plugin Paper
+            // @description
+            // Returns the element with all text formatting parsed into MiniMessage format.
+            // -->
+            ElementTag.tagProcessor.registerTag(ElementTag.class, "to_minimessage", (attribute, object) -> {
+                return new ElementTag(MiniMessage.miniMessage().serialize(
+                        PaperModule.jsonToComponent(ComponentSerializer.toString(FormattedTextHelper.parse(object.asString(), ChatColor.WHITE, false)))
+                ));
+            });
+        }
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperElementExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/tags/PaperElementExtensions.java
@@ -1,0 +1,35 @@
+package com.denizenscript.denizen.paper.tags;
+
+import com.denizenscript.denizen.paper.PaperModule;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.md_5.bungee.api.ChatColor;
+
+public class PaperElementExtensions {
+
+
+    public static void register() {
+
+        // <--[tag]
+        // @attribute <ElementTag.parse_minimessage>
+        // @returns ElementTag
+        // @Plugin Paper
+        // @description
+        // Returns the element with all MiniMessage tags parsed.
+        // -->
+        ElementTag.tagProcessor.registerTag(ElementTag.class, "parse_minimessage", (attribute, object) -> {
+            return new ElementTag(PaperModule.stringifyComponent(MiniMessage.miniMessage().deserialize(object.asString())));
+        });
+
+        // <--[tag]
+        // @attribute <ElementTag.to_minimessage>
+        // @returns ElementTag
+        // @Plugin Paper
+        // @description
+        // Returns the element with all text formatting parsed into MiniMessage format.
+        // -->
+        ElementTag.tagProcessor.registerTag(ElementTag.class, "to_minimessage", (attribute, object) -> {
+            return new ElementTag(MiniMessage.miniMessage().serialize(PaperModule.parseFormattedText(object.asString(), ChatColor.WHITE, false)));
+        });
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/bukkit/BukkitElementExtensions.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/bukkit/BukkitElementExtensions.java
@@ -364,6 +364,7 @@ public class BukkitElementExtensions {
         // Returns the element with all color codes parsed.
         // Optionally, specify a character to prefix the color ids. Defaults to '&' if not specified.
         // This allows old-style colors like '&b', or Essentials-style hex codes like '&#ff00ff'
+        // See also <@link tag ElementTag.parse_minimessage>
         // -->
         ElementTag.tagProcessor.registerStaticTag(ElementTag.class, "parse_color", (attribute, object) -> {
             char prefix = '&';


### PR DESCRIPTION
## Additions

- `ElementTag.parse_minimessage` - Returns the element with all MiniMessage tags parsed.
- `ElementTag.to_minimessage` - Returns the element with all text formatting parsed into MiniMessage format.
- `PaperElementExtensions` extension class