### PR TITLE
Fix `BiomeTag` mechanisms on 1.19

### DIFF
--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
@@ -268,7 +268,7 @@ public class Handler extends NMSHandler {
     @Override
     public BiomeNMS getBiomeNMS(World world, String name) {
         BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), name);
-        if (impl.biomeBase == null) {
+        if (impl.biomeHolder == null) {
             return null;
         }
         return impl;

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
@@ -63,9 +63,7 @@ public class ReflectionMappingsInfo {
     public static String Biome_climateSettings = "i";
 
     // net.minecraft.world.level.biome.Biome$ClimateSettings
-    public static String BiomeClimateSettings_precipitation = "b";
-    public static String BiomeClimateSettings_temperature = "c";
-    public static String BiomeClimateSettings_downfall = "e";
+    public static String BiomeClimateSettings_temperatureModifier = "d";
 
     // net.minecraft.network.Connection
     public static String Connection_receiving = "k";

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ChunkHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ChunkHelperImpl.java
@@ -95,7 +95,7 @@ public class ChunkHelperImpl implements ChunkHelper {
 
     @Override
     public void setAllBiomes(Chunk chunk, BiomeNMS biome) {
-        Holder<Biome> nmsBiome = ((BiomeNMSImpl) biome).biomeBase;
+        Holder<Biome> nmsBiome = ((BiomeNMSImpl) biome).biomeHolder;
         LevelChunk nmsChunk = ((CraftChunk) chunk).getHandle();
         ChunkPos chunkcoordintpair = nmsChunk.getPos();
         int i = QuartPos.fromBlock(chunkcoordintpair.getMinBlockX());

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/WorldHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/WorldHelperImpl.java
@@ -41,7 +41,7 @@ public class WorldHelperImpl implements WorldHelper {
     @Override
     public Location getNearestBiomeLocation(Location start, BiomeTag biome) {
         Pair<BlockPos, Holder<Biome>> result = ((CraftWorld) start.getWorld()).getHandle()
-                .findClosestBiome3d(b -> b.is(((BiomeNMSImpl) biome.getBiome()).biomeBase.unwrapKey().get()), new BlockPos(start.getBlockX(), start.getBlockY(), start.getBlockZ()), 6400, 32, 64);
+                .findClosestBiome3d(b -> b.is(((BiomeNMSImpl) biome.getBiome()).biomeHolder.unwrapKey().get()), new BlockPos(start.getBlockX(), start.getBlockY(), start.getBlockZ()), 6400, 32, 64);
         if (result == null || result.getFirst() == null) {
             return null;
         }


### PR DESCRIPTION
`Biome(NMS)$ClimateSettings` was changed from a class to a record in 1.19, which makes the fields for it's properties immutable breaking all `BiomeTag` mechanisms.
This PR changes the 1.19 `BiomeNMSImpl` to construct a new `ClimateSettings` object and set it into the biome object instead of modifying the existing one.

## Additions

- `BiomeNMSImpl#setClimate` method - constructors a new `Biome(NMS)$ClimateSettings` and sets it into the biome object.
- `BiomeNMSImpl#getTemperatureModifier` method - gets the biome's `Biome(NMS)$TemperatureModifier`, currently only used for `setClimate`.

## Changes

- `BiomeNMSImpl.biomeBase` field renamed to `biomeHolder`, as `BiomeBase` is the NMS biome class's name in the Spigot mappings, which are no longer used.
- `BiomeNMSImpl#getClimate` changed to use the biome object instead of using the biome's holder (I.e. added a `.value()` call).