### PR TITLE
Add `type` switches for `PlayerPlacesBlock` and `VehicleCollidesEvent`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPlacesBlockScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPlacesBlockScriptEvent.java
@@ -23,7 +23,7 @@ public class PlayerPlacesBlockScriptEvent extends BukkitScriptEvent implements L
     //
     // @Switch using:<hand_type> to only process the event if the player is using the specified hand type (HAND or OFF_HAND).
     // @Switch against:<location> to only process the event if block that this new block is being placed against matches the specified LocationTag matcher.
-    // @Switch type:<material> to only run if the block placed matches the MaterialTag matcher input.
+    // @Switch type:<material> to only process the event if the block placed matches the MaterialTag matcher input.
     //
     // @Cancellable true
     //
@@ -49,7 +49,9 @@ public class PlayerPlacesBlockScriptEvent extends BukkitScriptEvent implements L
     // on player places cactus against:sand:
     //
     // @Example
-    // on player places block type:cactus:
+    // # This example process the event only if the player places any block except tnt.
+    // on player places block type:!tnt:
+    // - announce "<player.name> hasn't placed a tnt block. Lucky!"
     //
     // -->
 

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPlacesBlockScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPlacesBlockScriptEvent.java
@@ -23,6 +23,7 @@ public class PlayerPlacesBlockScriptEvent extends BukkitScriptEvent implements L
     //
     // @Switch using:<hand_type> to only process the event if the player is using the specified hand type (HAND or OFF_HAND).
     // @Switch against:<location> to only process the event if block that this new block is being placed against matches the specified LocationTag matcher.
+    // @Switch type:<material> to only run if the block placed matches the MaterialTag matcher input.
     //
     // @Cancellable true
     //
@@ -47,18 +48,21 @@ public class PlayerPlacesBlockScriptEvent extends BukkitScriptEvent implements L
     // @Example
     // on player places cactus against:sand:
     //
+    // @Example
+    // on player places block type:cactus:
+    //
     // -->
 
     public PlayerPlacesBlockScriptEvent() {
         registerCouldMatcher("player places <material>");
-        registerSwitches("using", "against");
+        registerSwitches("using", "against", "type");
     }
 
+    public BlockPlaceEvent event;
     public LocationTag location, against;
     public MaterialTag material;
     public ElementTag hand;
     public ItemTag item_in_hand;
-    public BlockPlaceEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -75,6 +79,9 @@ public class PlayerPlacesBlockScriptEvent extends BukkitScriptEvent implements L
         if (!path.tryObjectSwitch("against", against)) {
             return false;
         }
+        if (!path.tryObjectSwitch("type", material)) {
+            return false;
+        }
         return super.matches(path);
     }
 
@@ -86,18 +93,12 @@ public class PlayerPlacesBlockScriptEvent extends BukkitScriptEvent implements L
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "location":
-                return location;
-            case "material":
-                return material;
-            case "old_material":
-                return new MaterialTag(event.getBlockReplacedState());
-            case "item_in_hand":
-                return item_in_hand;
-            case "hand":
-                return hand;
-            case "against":
-                return against;
+            case "location": return location;
+            case "material": return material;
+            case "old_material": return new MaterialTag(event.getBlockReplacedState());
+            case "item_in_hand": return item_in_hand;
+            case "hand": return hand;
+            case "against": return against;
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/vehicle/VehicleCollidesEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/vehicle/VehicleCollidesEntityScriptEvent.java
@@ -3,10 +3,10 @@ package com.denizenscript.denizen.events.vehicle;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
-import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
@@ -26,6 +26,8 @@ public class VehicleCollidesEntityScriptEvent extends BukkitScriptEvent implemen
     //
     // @Location true
     //
+    // @Switch type:<entity> to only run if the colliding entity matches the EntityTag matcher input.
+    //
     // @Cancellable true
     //
     // @Triggers when a vehicle collides with an entity.
@@ -36,36 +38,31 @@ public class VehicleCollidesEntityScriptEvent extends BukkitScriptEvent implemen
     // <context.pickup> returns whether the vehicle can pick up the entity.
     //
     // @Determine
-    // "PICKUP:TRUE" to allow the vehicle to pick up the entity.
-    // "PICKUP:FALSE" to stop the vehicle from picking up the entity.
+    // "PICKUP:" + ElementTag(Boolean) to set whether the vehicle is allowed to pick up the entity or not.
     //
     // @Player when a vehicle collides with a player.
     //
     // @NPC when a vehicle collides with an NPC.
     //
+    // @Example
+    // on vehicle collides with entity:
+    //
+    // @Example
+    // on minecart collides with sheep:
+    //
+    // @Example
+    // on vehicle collides with entity type:creeper:
+    //
     // -->
 
     public VehicleCollidesEntityScriptEvent() {
+        registerCouldMatcher("<vehicle> collides with <entity>");
+        registerSwitches("type");
     }
 
-
+    public VehicleEntityCollisionEvent event;
     public EntityTag vehicle;
     public EntityTag entity;
-    public VehicleEntityCollisionEvent event;
-
-    @Override
-    public boolean couldMatch(ScriptPath path) {
-        if (!path.eventLower.contains("collides with")) {
-            return false;
-        }
-        if (!couldMatchEntity(path.eventArgLowerAt(3))) {
-            return false;
-        }
-        if (!exactMatchesVehicle(path.eventArgLowerAt(0))) {
-            return false;
-        }
-        return true;
-    }
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -78,15 +75,18 @@ public class VehicleCollidesEntityScriptEvent extends BukkitScriptEvent implemen
         if (!runInCheck(path, vehicle.getLocation())) {
             return false;
         }
+        if (!path.tryObjectSwitch("type", entity)) {
+            return false;
+        }
         return super.matches(path);
     }
 
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
         if (determinationObj instanceof ElementTag) {
-            Argument arg = Argument.valueOf(determinationObj.toString());
-            if (arg.matchesPrefix("pickup")) {
-                event.setPickupCancelled(!arg.asElement().asBoolean());
+            String lower = CoreUtilities.toLowerCase(determinationObj.toString());
+            if (lower.startsWith("pickup:")) {
+                event.setPickupCancelled(!(new ElementTag(lower.substring("pickup:".length())).asBoolean()));
                 return true;
             }
         }
@@ -101,12 +101,9 @@ public class VehicleCollidesEntityScriptEvent extends BukkitScriptEvent implemen
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "vehicle":
-                return vehicle;
-            case "entity":
-                return entity.getDenizenObject();
-            case "pickup":
-                return new ElementTag(!event.isPickupCancelled());
+            case "vehicle": return vehicle;
+            case "entity": return entity.getDenizenObject();
+            case "pickup": return new ElementTag(!event.isPickupCancelled());
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/vehicle/VehicleCollidesEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/vehicle/VehicleCollidesEntityScriptEvent.java
@@ -26,7 +26,7 @@ public class VehicleCollidesEntityScriptEvent extends BukkitScriptEvent implemen
     //
     // @Location true
     //
-    // @Switch type:<entity> to only run if the colliding entity matches the EntityTag matcher input.
+    // @Switch type:<entity> to only process the event if the colliding entity matches the EntityTag matcher input.
     //
     // @Cancellable true
     //
@@ -51,7 +51,9 @@ public class VehicleCollidesEntityScriptEvent extends BukkitScriptEvent implemen
     // on minecart collides with sheep:
     //
     // @Example
+    // # This example disambiguates this event from the "projectile collides with entity" event for specific entity types.
     // on vehicle collides with entity type:creeper:
+    // - announce "A <context.centity.entity_type> collided with a creeper!"
     //
     // -->
 


### PR DESCRIPTION
This PR adds the `type` switch for `on player places block` and `<vehicle> collides with <entity>` event, to avoid matching with the `PlayerPlacesHanging` and `ProjectileCollide` events.

Also did a cleanup of the VehicleCollidesEvent to match ScriptEvent standards.