### PR TITLE
Add `<context.slot>` to `PlayerMendsItemEvent`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
@@ -22,8 +22,6 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
     // player item takes damage
     // player <item> takes damage
     //
-    // @Regex ^on player [^\s]+ takes damage$
-    //
     // @Synonyms item durability changes
     //
     // @Group Player
@@ -46,26 +44,13 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
     //
     // -->
 
+    public PlayerItemTakesDamageScriptEvent() {
+        registerCouldMatcher("player <item> takes damage");
+    }
+
     PlayerItemDamageEvent event;
     ItemTag item;
     LocationTag location;
-
-    public PlayerItemTakesDamageScriptEvent() {
-    }
-
-    @Override
-    public boolean couldMatch(ScriptPath path) {
-        if (!path.eventArgLowerAt(0).equals("player")) {
-            return false;
-        }
-        if (!path.eventArgsLowEqualStartingAt(2, "takes", "damage")) {
-            return false;
-        }
-        if (!couldMatchItem(path.eventArgLowerAt(1))) {
-            return false;
-        }
-        return true;
-    }
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -95,12 +80,9 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "item":
-                return item;
-            case "damage":
-                return new ElementTag(event.getDamage());
-            case "slot":
-                return new ElementTag(SlotHelper.slotForItem(event.getPlayer().getInventory(), item.getItemStack()) + 1);
+            case "item": return item;
+            case "damage": return new ElementTag(event.getDamage());
+            case "slot": return new ElementTag(SlotHelper.slotForItem(event.getPlayer().getInventory(), item.getItemStack()) + 1);
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
@@ -64,6 +64,16 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
     }
 
     @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "item": return item;
+            case "damage": return new ElementTag(event.getDamage());
+            case "slot": return new ElementTag(SlotHelper.slotForItem(event.getPlayer().getInventory(), item.getItemStack()) + 1);
+        }
+        return super.getContext(name);
+    }
+
+    @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
         if (determinationObj instanceof ElementTag && ((ElementTag) determinationObj).isInt()) {
             event.setDamage(((ElementTag) determinationObj).asInt());
@@ -75,16 +85,6 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
     @Override
     public BukkitScriptEntryData getScriptEntryData() {
         return new BukkitScriptEntryData(event.getPlayer());
-    }
-
-    @Override
-    public ObjectTag getContext(String name) {
-        switch (name) {
-            case "item": return item;
-            case "damage": return new ElementTag(event.getDamage());
-            case "slot": return new ElementTag(SlotHelper.slotForItem(event.getPlayer().getInventory(), item.getItemStack()) + 1);
-        }
-        return super.getContext(name);
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerMendsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerMendsItemScriptEvent.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
@@ -19,8 +20,6 @@ public class PlayerMendsItemScriptEvent extends BukkitScriptEvent implements Lis
     // player mends item
     // player mends <item>
     //
-    // @Regex ^on player mends [^\s]+$
-    //
     // @Group Player
     //
     // @Location true
@@ -33,6 +32,7 @@ public class PlayerMendsItemScriptEvent extends BukkitScriptEvent implements Lis
     // <context.item> returns the item that is repaired.
     // <context.repair_amount> returns how much durability the item recovers.
     // <context.xp_orb> returns the XP orb that triggered the event.
+    // <context.slot> returns the slot of the item that has been repaired. This value is a bit of a hack and is not reliable.
     //
     // @Determine
     // ElementTag(Number) to set the amount of durability the item recovers.
@@ -42,22 +42,12 @@ public class PlayerMendsItemScriptEvent extends BukkitScriptEvent implements Lis
     // -->
 
     public PlayerMendsItemScriptEvent() {
+        registerCouldMatcher("player mends <item>");
     }
 
-    public ItemTag item;
     public PlayerItemMendEvent event;
+    public ItemTag item;
     public LocationTag location;
-
-    @Override
-    public boolean couldMatch(ScriptPath path) {
-        if (!path.eventLower.startsWith("player mends")) {
-            return false;
-        }
-        if (!couldMatchItem(path.eventArgLowerAt(2))) {
-            return false;
-        }
-        return true;
-    }
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -68,6 +58,17 @@ public class PlayerMendsItemScriptEvent extends BukkitScriptEvent implements Lis
             return false;
         }
         return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "item": return item;
+            case "repair_amount": return new ElementTag(event.getRepairAmount());
+            case "xp_orb": return new EntityTag(event.getExperienceOrb());
+            case "slot": return new ElementTag(SlotHelper.slotForItem(event.getPlayer().getInventory(), item.getItemStack()) + 1);
+        }
+        return super.getContext(name);
     }
 
     @Override
@@ -82,19 +83,6 @@ public class PlayerMendsItemScriptEvent extends BukkitScriptEvent implements Lis
     @Override
     public ScriptEntryData getScriptEntryData() {
         return new BukkitScriptEntryData(event.getPlayer());
-    }
-
-    @Override
-    public ObjectTag getContext(String name) {
-        switch (name) {
-            case "item":
-                return item;
-            case "repair_amount":
-                return new ElementTag(event.getRepairAmount());
-            case "xp_orb":
-                return new EntityTag(event.getExperienceOrb());
-        }
-        return super.getContext(name);
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/SlotHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/SlotHelper.java
@@ -54,11 +54,11 @@ public class SlotHelper {
         if (item.equals(inventory.getHelmet())) {
             return HELMET;
         }
-        if (item.equals(inventory.getItemInOffHand())) {
-            return OFFHAND;
-        }
         if (item.equals(inventory.getItemInMainHand())) {
             return inventory.getHeldItemSlot();
+        }
+        if (item.equals(inventory.getItemInOffHand())) {
+            return OFFHAND;
         }
         ItemStack[] contents = inventory.getContents();
         for (int i = 0; i < contents.length; i++) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/SlotHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/SlotHelper.java
@@ -54,6 +54,9 @@ public class SlotHelper {
         if (item.equals(inventory.getHelmet())) {
             return HELMET;
         }
+        if (item.equals(inventory.getItemInOffHand())) {
+            return OFFHAND;
+        }
         if (item.equals(inventory.getItemInMainHand())) {
             return inventory.getHeldItemSlot();
         }
@@ -81,6 +84,7 @@ public class SlotHelper {
     // OFFHAND: equivalent to 41
     //
     // Note that some common alternate spellings may be automatically accepted as well.
+    //
     // -->
     public static EquipmentSlot indexToEquipSlot(int index) {
         switch (index) {


### PR DESCRIPTION
This PR adds the `<context.slot>` tag to the `PlayerMendsItemEvent` by using the `SlotHelper.slotForItem` method. 

Also added a pre-check for the offhand item to `SlotHelper.slotForItem` and cleaned the events for consistency.