### PR TITLE
`ChunkTag` and `ColorTag` Tag and Mech Examples

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -293,7 +293,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates added to it.
         // @example
-        // # Loads the chunk with 10 added onto the X and Z axes of the player's chunk, making the coordinates "15,15,world".
+        // # Adds 10 to the X and Z coordinates of the player's current chunk and loads it.
         // - chunkload <player.location.chunk.add[10,10]>
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "add", (attribute, object, addCoords) -> {
@@ -319,8 +319,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates subtracted from it.
         // @example
-        // # Loads the chunk with 10 subtracted onto the X and Z axes of the player's chunk, making the coordinates "-5,-5,world".
-        // - chunkload <chunk[5,5,world].sub[10,10]>
+        // # Subtracts 10 from the X and Z coordinates of the player's current chunk and loads it.
+        // - chunkload <player.location.chunk.sub[10,10]>
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "sub", (attribute, object, subCoords) -> {
             List<String> coords = CoreUtilities.split(subCoords.toString(), ',');

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -591,7 +591,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @example
         // # Narrates a list of players excluding the original player in the chunk formatted into a readable format.
         // # For example, this can return: "steve, alex, john, and jane".
-        // - narrate "Wow! Look at all these players in the same chunk as you: <player.location.chunk.players.exclude[<player>].parse[name].formatted>!"
+        // - narrate "Wow! Look at all these players in the same chunk as you: <player.location.chunk.players.exclude[<player>].formatted>!"
         // -->
         tagProcessor.registerTag(ListTag.class, "players", (attribute, object) -> {
             ListTag entities = new ListTag();
@@ -880,7 +880,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @tags
         // <ChunkTag.is_loaded>
         // @example
-        // - adjust <chunk[10,10]> load
+        // - adjust <player.location.chunk.add[100,0]> load
         // -->
         if (mechanism.matches("load")) {
             getChunk().load(true);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -293,8 +293,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates added to it.
         // @example
-        // # Notes the chunk with 10 added onto the X and Z axes of the chunk, making the coordinates "15,15,world".
-        // - note <chunk[5,5,world].add[10,10].cuboid> as:my_new_chunk_cuboid
+        // # Loads the chunk with 10 added onto the X and Z axes of the player's chunk, making the coordinates "15,15,world".
+        // - chunkload <player.location.chunk.add[10,10]>
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "add", (attribute, object, addCoords) -> {
             List<String> coords = CoreUtilities.split(addCoords.toString(), ',');
@@ -319,8 +319,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates subtracted from it.
         // @example
-        // # Notes the chunk with 5 subtracted onto the X and Z axes of the chunk, making the coordinates "-5,-5,world".
-        // - note <chunk[5,5,world].sub[10,10].cuboid> as:my_new_chunk_cuboid
+        // # Loads the chunk with 10 subtracted onto the X and Z axes of the player's chunk, making the coordinates "-5,-5,world".
+        // - chunkload <chunk[5,5,world].sub[10,10]>
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "sub", (attribute, object, subCoords) -> {
             List<String> coords = CoreUtilities.split(subCoords.toString(), ',');
@@ -345,12 +345,12 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns true if the chunk has already been generated.
         // @example
-        // # One way this can return "false" is if the player has been teleported to a location in the chunk while offline
-        // # to a chunk that has not been interacted or have not had a player nearby to generate it.
-        // - if <player.location.chunk.is_generated>:
-        //     - narrate "The chunk is generated! Woohoo!"
-        // - else:
-        //     - narrate "Hm, the chunk must not have generated yet!"
+        // # Loops though the chunks surrounding the player in a 20x20 radius and loads the chunk if it has not been generated yet.
+        // # Loading the chunk will generate it if it has not been generated already.
+        // - repeat 20 from:-10 as:x:
+        //     - repeat 20 from:-10 as:z:
+        //         - if !<player.location.chunk.add[<[x]>,<[z]>].is_generated>:
+        //             - chunkload <player.location.chunk.add[<[x]>,<[z]>]>
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_generated", (attribute, object) -> {
             return new ElementTag(object.getBukkitWorld().isChunkGenerated(object.chunkX, object.chunkZ));
@@ -362,11 +362,11 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns true if the chunk is currently loaded into memory.
         // @example
-        // # One way this can return "false" is if the player is offline and no other players are nearby to keep the chunk loaded.
-        // - if <player.location.chunk.is_loaded>:
-        //     - narrate "The chunk is loaded! Yippee!"
-        // - else:
-        //     - narrate "Hm, the chunk is not loaded yet!"
+        // # Loops though the chunks surrounding the player in a 20x20 radius and loads the chunk if it is not already loaded.
+        // - repeat 20 from:-10 as:x:
+        //     - repeat 20 from:-10 as:z:
+        //         - if !<player.location.chunk.add[<[x]>,<[z]>].is_loaded>:
+        //             - chunkload <player.location.chunk.add[<[x]>,<[z]>]>
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_loaded", (attribute, object) -> {
             return new ElementTag(object.isLoadedSafe());
@@ -402,7 +402,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @example
         // # Narrates the list of plugin names keeping the player's chunk loaded formatted into readable format.
         // # Example: "Plugins keeping your chunk loaded: Denizen and Citizens".
-        // - narrate "Plugins keeping your chunk loaded: <player.location.chunk.plugin_tickets.parse[name].formatted>"
+        // - narrate "Plugins keeping your chunk loaded: <player.location.chunk.plugin_tickets.formatted>"
         // -->
         tagProcessor.registerTag(ListTag.class, "plugin_tickets", (attribute, object) -> {
             if (!object.isLoadedSafe()) {
@@ -695,8 +695,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a list of the highest non-air surface blocks in the chunk.
         // @example
-        // # Spawns a creeper at a random surface block and adds 2 on the Y axis to prevent the creeper from suffocating.
-        // - spawn creeper <player.location.chunk.surface_blocks.random.add[0,2,0]>
+        // # Spawns a creeper above a random surface block to prevent the creeper from suffocating.
+        // - spawn creeper <player.location.chunk.surface_blocks.random.above>
         // -->
         tagProcessor.registerTag(ListTag.class, "surface_blocks", (attribute, object) -> {
             ListTag surface_blocks = new ListTag();
@@ -815,7 +815,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @tags
         // <ChunkTag.is_loaded>
         // @example
-        // - adjust <player.location.chunk> unload
+        // - adjust <player.location.chunk.add[20,20]> unload
         // -->
         if (mechanism.matches("unload")) {
             getBukkitWorld().unloadChunk(getX(), getZ(), true);
@@ -830,7 +830,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @tags
         // <chunk.is_loaded>
         // @example
-        // - adjust <player.location.chunk> unload_without_saving
+        // - adjust <player.location.chunk.add[20,20]> unload_without_saving
         // -->
         if (mechanism.matches("unload_without_saving")) {
             getBukkitWorld().unloadChunk(getX(), getZ(), false);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -292,6 +292,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ChunkTag
         // @description
         // Returns the chunk with the specified coordinates added to it.
+        // @example
+        // # Narrates "ch@10,10"
+        // - narrate <chunk[5,5,world].add[5,5]>
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "add", (attribute, object, addCoords) -> {
             List<String> coords = CoreUtilities.split(addCoords.toString(), ',');
@@ -315,6 +318,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ChunkTag
         // @description
         // Returns the chunk with the specified coordinates subtracted from it.
+        // @example
+        // # Narrates "ch@-5,-5,world"
+        // - narrate <chunk[5,5,world].sub[10,10]>
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "sub", (attribute, object, subCoords) -> {
             List<String> coords = CoreUtilities.split(subCoords.toString(), ',');
@@ -338,6 +344,11 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ElementTag(Boolean)
         // @description
         // Returns true if the chunk has already been generated.
+        // @example
+        // - if <player.location.chunk.is_generated>:
+        //     - narrate "The chunk is generated! Woohoo!"
+        // - else:
+        //     - narrate "Hm, the chunk must not have generated yet!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_generated", (attribute, object) -> {
             return new ElementTag(object.getBukkitWorld().isChunkGenerated(object.chunkX, object.chunkZ));
@@ -348,6 +359,11 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ElementTag(Boolean)
         // @description
         // Returns true if the chunk is currently loaded into memory.
+        // @example
+        // - if <player.location.chunk.is_loaded>:
+        //     - narrate "The chunk is loaded! Yippee!"
+        // - else:
+        //     - narrate "Hm, the chunk is not loaded yet!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_loaded", (attribute, object) -> {
             return new ElementTag(object.isLoadedSafe());
@@ -359,6 +375,11 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @mechanism ChunkTag.force_loaded
         // @description
         // Returns whether the chunk is forced to stay loaded at all times.
+        // @example
+        // - if <player.location.chunk.force_loaded>:
+        //     - narrate "This chunk is being forced to stay loaded!"
+        // - else:
+        //     - narrate "This chunk is NOT being forced to stay loaded!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "force_loaded", (attribute, object) -> {
             if (!object.isLoadedSafe()) {
@@ -375,6 +396,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a list of plugins that are keeping this chunk loaded.
         // This is related to the <@link command chunkload> command.
+        // @example
+        // # Narrates the list of plugin names keeping the player's chunk loaded separated by a comma and a space.
+        // # Example: "Plugins keeping your chunk loaded: Denizen, Citizens"
+        // - narrate "Plugins keeping your chunk loaded: <player.location.chunk.plugin_tickets.parse[name].separated_by[, ]>"
         // -->
         tagProcessor.registerTag(ListTag.class, "plugin_tickets", (attribute, object) -> {
             if (!object.isLoadedSafe()) {
@@ -393,6 +418,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ElementTag(Number)
         // @description
         // Returns the x coordinate of the chunk.
+        // @example
+        // # Narrates the player's chunk's X coordinate.
+        // # For example, if the player was in <chunk[5,10,world]>, the X coordinate would be "5"
+        // - narrate "Your current X chunk coordinate is: <player.location.chunk.x>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "x", (attribute, object) -> {
             return new ElementTag(object.chunkX);
@@ -403,6 +432,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ElementTag(Number)
         // @description
         // Returns the z coordinate of the chunk.
+        // @example
+        // # Narrates the player's chunk's Z coordinate.
+        // # For example, if the player was in <chunk[5,10,world]>, the Z coordinate would be "10"
+        // - narrate "Your current Z chunk coordinate is: <player.location.chunk.z>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "z", (attribute, object) -> {
             return new ElementTag(object.chunkZ);
@@ -413,6 +446,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns WorldTag
         // @description
         // Returns the world associated with the chunk.
+        // @example
+        // # Narrates the name of the player's chunk's associated world.
+        // # For example, if the player was in <chunk[5,10,world]>, the world the chunk is in would be "world"
+        // - narrate "The world your chunk is in is: <player.location.chunk.world.name>!"
         // -->
         tagProcessor.registerTag(WorldTag.class, "world", (attribute, object) -> {
             return object.world;
@@ -423,6 +460,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns CuboidTag
         // @description
         // Returns a cuboid of this chunk.
+        // @example
+        // # Plays the "TOTEM" effect at the player's chunk as a cuboid outlined along the player's Y coordinate.
+        // - playeffect effect:TOTEM at:<player.location.chunk.cuboid.outline_2d[<player.location.y>]> offset:0.0 targets:<player>
         // -->
         tagProcessor.registerTag(CuboidTag.class, "cuboid", (attribute, object) -> {
             int yMin = 0, yMax = 255;
@@ -442,6 +482,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ListTag(LocationTag)
         // @description
         // Returns a list of tile entity locations in the chunk.
+        // @example
+        // # Loops though the tile entities found in the player's chunk and narrates the name and location of it.
+        // - foreach <player.location.chunk.tile_entities> as:tile_entity_location:
+        //     - narrate "Found a <[tile_entity_location].material.name> at <[tile_entity_location].simple>!"
         // -->
         tagProcessor.registerTag(ListTag.class, "tile_entities", (attribute, object) -> {
             ListTag tiles = new ListTag();
@@ -467,6 +511,14 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a list of entities in the chunk.
         // Optionally specify entity types to filter down to.
+        // @example
+        // # Loops though the entities found in the player's chunk and narrates the name and location of it.
+        // - foreach <player.location.chunk.entities> as:entity:
+        //     - narrate "Found a <[entity].name> at <[entity].location.simple>!"
+        // @example
+        // # Loops though the axolotls found in the player's chunk and narrates the name and location of it.
+        // - foreach <player.location.chunk.entities[axolotl]> as:entity:
+        //     - narrate "Found an axolotl at <[entity].location.simple>!"
         // -->
         tagProcessor.registerTag(ListTag.class, "entities", (attribute, object) -> {
             ListTag entities = new ListTag();
@@ -504,6 +556,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a list of living entities in the chunk.
         // This includes Players, mobs, NPCs, etc., but excludes dropped items, experience orbs, etc.
+        // @example
+        // # Loops though the living entities found in the player's chunk and narrates the name and location of it.
+        // - foreach <player.location.chunk.living_entities> as:entity:
+        //     - narrate "Found a <[entity].name> at <[entity].location.simple>!"
         // -->
         tagProcessor.registerTag(ListTag.class, "living_entities", (attribute, object) -> {
             ListTag entities = new ListTag();
@@ -530,6 +586,11 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ListTag(PlayerTag)
         // @description
         // Returns a list of players in the chunk.
+        // @example
+        // # Narrates a list of players excluding the player in the chunk separated by a comma and a space.
+        // # For example, this can return: "steve, alex, john, jane".
+        // - define player_list <player.location.chunk.players.exclude[<player>].parse[name].separated_by[, ]>
+        // - narrate "Wow! Look at all these players in the same chunk as you: <[player_list]>!"
         // -->
         tagProcessor.registerTag(ListTag.class, "players", (attribute, object) -> {
             ListTag entities = new ListTag();
@@ -550,6 +611,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ListTag
         // @description
         // Returns a list of the height of each block in the chunk.
+        // @example
+        // # Narrates the height as a number of the highest block in the chunk.
+        // - narrate "The block with the tallest height has a height of <player.location.chunk.height_map.highest>!"
         // -->
         tagProcessor.registerTag(ListTag.class, "height_map", (attribute, object) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -569,6 +633,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ElementTag(Decimal)
         // @description
         // Returns the average height of the blocks in the chunk.
+        // @example
+        // # Narrates the average height of each block in the player's chunk rounded.
+        // - narrate "The average height of blocks in this chunks is <player.location.chunk.average_height.round>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "average_height", (attribute, object) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -590,6 +657,11 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Scans the heights of the blocks to check variance between them.
         // If no number is supplied, is_flat will return true if all the blocks are less than 2 blocks apart in height.
         // Specifying a number will modify the number criteria for determining if it is flat.
+        // @example
+        // - if <player.location.chunk.is_flat>:
+        //     - narrate "Wow that is a flat chunk!"
+        // - else:
+        //     - narrate "Watch out! This chunk has a more rugged terrain!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_flat", (attribute, object) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -616,6 +688,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ListTag(LocationTag)
         // @description
         // Returns a list of the highest non-air surface blocks in the chunk.
+        // @example
+        // # Spawns a creeper at a random surface block and adds 2 on the Y axis to prevent the creeper from suffocating.
+        // - spawn creeper <player.location.chunk.surface_blocks.random.add[0,2,0]>
         // -->
         tagProcessor.registerTag(ListTag.class, "surface_blocks", (attribute, object) -> {
             ListTag surface_blocks = new ListTag();
@@ -638,6 +713,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Gets a list of all block locations with a specified flag within the CuboidTag.
         // Searches the internal flag lists, rather than through all possible blocks.
+        // @example
+        // - foreach <player.location.chunk.blocks_flagged[my_flag]> as:block:
+        //     - narrate "Found block flagged 'my_flag' at <[block].simple>!"
         // -->
         tagProcessor.registerTag(ListTag.class, ElementTag.class, "blocks_flagged", (attribute, object, flagNameInput) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -657,6 +735,11 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ElementTag(Boolean)
         // @description
         // Returns whether the chunk is a specially located 'slime spawner' chunk.
+        // @example
+        // - if <player.location.chunk.spawn_slimes>:
+        //     - narrate "Watch out! Slimes can spawn here!"
+        // - else:
+        //     - narrate "No slimes can spawn here! You are safe for now!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "spawn_slimes", (attribute, object) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -673,6 +756,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the total time the chunk has been inhabited for.
         // This is a primary deciding factor in the "local difficulty" setting.
+        // @example
+        // # Narrates the time inhabited in the chunk by the player formatted into words.
+        // # For example: "You have been in this chunk for a total of 2 hours 26 minutes!"
+        // - narrate "You have been in this chunk for a total of <player.location.chunk.inhabited_time.formatted_words>!"
         // -->
         tagProcessor.registerTag(DurationTag.class, "inhabited_time", (attribute, object) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -706,6 +793,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // This is a primary deciding factor in the "local difficulty" setting.
         // @tags
         // <ChunkTag.inhabited_time>
+        // @example
+        // - adjust <player.location.chunk> inhabited_time:5d
         // -->
         if (mechanism.matches("inhabited_time") && mechanism.requireObject(DurationTag.class)) {
             getChunk().setInhabitedTime(mechanism.valueAsType(DurationTag.class).getTicks());
@@ -719,6 +808,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Removes a chunk from memory.
         // @tags
         // <ChunkTag.is_loaded>
+        // @example
+        // - adjust <player.location.chunk> unload
         // -->
         if (mechanism.matches("unload")) {
             getBukkitWorld().unloadChunk(getX(), getZ(), true);
@@ -732,6 +823,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Removes a chunk from memory without saving any recent changes.
         // @tags
         // <chunk.is_loaded>
+        // @example
+        // - adjust <player.location.chunk> unload_without_saving
         // -->
         if (mechanism.matches("unload_without_saving")) {
             getBukkitWorld().unloadChunk(getX(), getZ(), false);
@@ -746,6 +839,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Unless you have a specific reason to use this, prefer <@link command chunkload>.
         // @tags
         // <ChunkTag.force_loaded>
+        // @example
+        // - adjust <player.location.chunk> force_loaded:true
         // -->
         if (mechanism.matches("force_loaded") && mechanism.requireBoolean()) {
             getChunk().setForceLoaded(mechanism.getValue().asBoolean());
@@ -760,6 +855,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // This is usually a bad idea.
         // @tags
         // <ChunkTag.plugin_tickets>
+        // @example
+        // # Make sure you know what you are doing before using this mechanism.
+        // - adjust <player.location.chunk> clear_plugin_tickets
         // -->
         if (mechanism.matches("clear_plugin_tickets")) {
             for (Plugin plugin : new ArrayList<>(getChunk().getPluginChunkTickets())) {
@@ -775,6 +873,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Loads a chunk into memory.
         // @tags
         // <ChunkTag.is_loaded>
+        // @example
+        // - adjust <chunk[10,10]> load
         // -->
         if (mechanism.matches("load")) {
             getChunk().load(true);
@@ -787,6 +887,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Causes the chunk to be entirely deleted and reformed from the world's seed.
         // At time of writing this method only works as expected on Paper, and will error on Spigot.
+        // @example
+        // - adjust <player.location.chunk> regenerate
         // -->
         if (mechanism.matches("regenerate")) {
             getBukkitWorld().regenerateChunk(getX(), getZ());
@@ -798,6 +900,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @input None
         // @description
         // Refreshes the chunk, sending any changed properties to players.
+        // @example
+        // - adjust <player.location.chunk> refresh_chunk
         // -->
         if (mechanism.matches("refresh_chunk")) {
             final int chunkX = getX();
@@ -811,6 +915,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @input None
         // @description
         // Refreshes all 16x16x16 chunk sections within the chunk.
+        // @example
+        // - adjust <player.location.chunk> refresh_chunk_sections
         // -->
         if (mechanism.matches("refresh_chunk_sections")) {
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
@@ -827,6 +933,10 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @input BiomeTag
         // @description
         // Sets all biomes in the chunk to the given biome.
+        // @example
+        // - adjust <player.location.chunk> set_all_biomes:<biome[savanna]>
+        // # Allow players to see biome change:
+        // - adjust <player.location.chunk> refresh_chunk
         // -->
         if (mechanism.matches("set_all_biomes") && mechanism.requireObject(BiomeTag.class)) {
             NMSHandler.chunkHelper.setAllBiomes(getChunk(), mechanism.valueAsType(BiomeTag.class).getBiome());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -293,8 +293,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates added to it.
         // @example
-        // # Narrates "ch@10,10"
-        // - narrate <chunk[5,5,world].add[5,5]>
+        // # Notes the chunk with 10 added onto the X and Z axes of the chunk, making the coordinates "15,15,world".
+        // - note <chunk[5,5,world].add[10,10].cuboid> as:my_new_chunk_cuboid
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "add", (attribute, object, addCoords) -> {
             List<String> coords = CoreUtilities.split(addCoords.toString(), ',');
@@ -319,8 +319,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns the chunk with the specified coordinates subtracted from it.
         // @example
-        // # Narrates "ch@-5,-5,world"
-        // - narrate <chunk[5,5,world].sub[10,10]>
+        // # Notes the chunk with 5 subtracted onto the X and Z axes of the chunk, making the coordinates "-5,-5,world".
+        // - note <chunk[5,5,world].sub[10,10].cuboid> as:my_new_chunk_cuboid
         // -->
         tagProcessor.registerTag(ChunkTag.class, ElementTag.class, "sub", (attribute, object, subCoords) -> {
             List<String> coords = CoreUtilities.split(subCoords.toString(), ',');
@@ -345,6 +345,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns true if the chunk has already been generated.
         // @example
+        // # One way this can return "false" is if the player has been teleported to a location in the chunk while offline
+        // # to a chunk that has not been interacted or have not had a player nearby to generate it.
         // - if <player.location.chunk.is_generated>:
         //     - narrate "The chunk is generated! Woohoo!"
         // - else:
@@ -360,6 +362,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns true if the chunk is currently loaded into memory.
         // @example
+        // # One way this can return "false" is if the player is offline and no other players are nearby to keep the chunk loaded.
         // - if <player.location.chunk.is_loaded>:
         //     - narrate "The chunk is loaded! Yippee!"
         // - else:
@@ -397,9 +400,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Returns a list of plugins that are keeping this chunk loaded.
         // This is related to the <@link command chunkload> command.
         // @example
-        // # Narrates the list of plugin names keeping the player's chunk loaded separated by a comma and a space.
-        // # Example: "Plugins keeping your chunk loaded: Denizen, Citizens"
-        // - narrate "Plugins keeping your chunk loaded: <player.location.chunk.plugin_tickets.parse[name].separated_by[, ]>"
+        // # Narrates the list of plugin names keeping the player's chunk loaded formatted into readable format.
+        // # Example: "Plugins keeping your chunk loaded: Denizen and Citizens".
+        // - narrate "Plugins keeping your chunk loaded: <player.location.chunk.plugin_tickets.parse[name].formatted>"
         // -->
         tagProcessor.registerTag(ListTag.class, "plugin_tickets", (attribute, object) -> {
             if (!object.isLoadedSafe()) {
@@ -420,7 +423,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Returns the x coordinate of the chunk.
         // @example
         // # Narrates the player's chunk's X coordinate.
-        // # For example, if the player was in <chunk[5,10,world]>, the X coordinate would be "5"
+        // # For example, if the player was in <chunk[5,10,world]>, the X coordinate would be "5".
         // - narrate "Your current X chunk coordinate is: <player.location.chunk.x>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "x", (attribute, object) -> {
@@ -434,7 +437,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Returns the z coordinate of the chunk.
         // @example
         // # Narrates the player's chunk's Z coordinate.
-        // # For example, if the player was in <chunk[5,10,world]>, the Z coordinate would be "10"
+        // # For example, if the player was in <chunk[5,10,world]>, the Z coordinate would be "10".
         // - narrate "Your current Z chunk coordinate is: <player.location.chunk.z>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "z", (attribute, object) -> {
@@ -448,7 +451,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Returns the world associated with the chunk.
         // @example
         // # Narrates the name of the player's chunk's associated world.
-        // # For example, if the player was in <chunk[5,10,world]>, the world the chunk is in would be "world"
+        // # For example, if the player was in <chunk[5,10,world]>, the world the chunk is in would be "world".
         // - narrate "The world your chunk is in is: <player.location.chunk.world.name>!"
         // -->
         tagProcessor.registerTag(WorldTag.class, "world", (attribute, object) -> {
@@ -461,8 +464,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a cuboid of this chunk.
         // @example
-        // # Plays the "TOTEM" effect at the player's chunk as a cuboid outlined along the player's Y coordinate.
-        // - playeffect effect:TOTEM at:<player.location.chunk.cuboid.outline_2d[<player.location.y>]> offset:0.0 targets:<player>
+        // # Plays the "flame" effect at the player's chunk as a cuboid outlined along the player's Y coordinate.
+        // - playeffect effect:flame at:<player.location.chunk.cuboid.outline_2d[<player.location.y>]> offset:0.0
         // -->
         tagProcessor.registerTag(CuboidTag.class, "cuboid", (attribute, object) -> {
             int yMin = 0, yMax = 255;
@@ -483,9 +486,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a list of tile entity locations in the chunk.
         // @example
-        // # Loops though the tile entities found in the player's chunk and narrates the name and location of it.
-        // - foreach <player.location.chunk.tile_entities> as:tile_entity_location:
-        //     - narrate "Found a <[tile_entity_location].material.name> at <[tile_entity_location].simple>!"
+        // # Spawns a debugblock to highlight every tile entity in the chunk.
+        // - debugblock <player.location.chunk.tile_entities>
         // -->
         tagProcessor.registerTag(ListTag.class, "tile_entities", (attribute, object) -> {
             ListTag tiles = new ListTag();
@@ -587,10 +589,9 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a list of players in the chunk.
         // @example
-        // # Narrates a list of players excluding the player in the chunk separated by a comma and a space.
-        // # For example, this can return: "steve, alex, john, jane".
-        // - define player_list <player.location.chunk.players.exclude[<player>].parse[name].separated_by[, ]>
-        // - narrate "Wow! Look at all these players in the same chunk as you: <[player_list]>!"
+        // # Narrates a list of players excluding the original player in the chunk formatted into a readable format.
+        // # For example, this can return: "steve, alex, john, and jane".
+        // - narrate "Wow! Look at all these players in the same chunk as you: <player.location.chunk.players.exclude[<player>].parse[name].formatted>!"
         // -->
         tagProcessor.registerTag(ListTag.class, "players", (attribute, object) -> {
             ListTag entities = new ListTag();
@@ -635,7 +636,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Returns the average height of the blocks in the chunk.
         // @example
         // # Narrates the average height of each block in the player's chunk rounded.
-        // - narrate "The average height of blocks in this chunks is <player.location.chunk.average_height.round>!"
+        // - narrate "The average height of blocks in this chunk is <player.location.chunk.average_height.round>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "average_height", (attribute, object) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -659,9 +660,14 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Specifying a number will modify the number criteria for determining if it is flat.
         // @example
         // - if <player.location.chunk.is_flat>:
-        //     - narrate "Wow that is a flat chunk!"
+        //     - narrate "Wow! That is a flat chunk!"
         // - else:
         //     - narrate "Watch out! This chunk has a more rugged terrain!"
+        // @example
+        // - if <player.location.chunk.is_flat[4]>:
+        //     - narrate "Wow! This chunk's blocks are all less than 4 blocks apart in height!"
+        // - else:
+        //     - narrate "This chunk's blocks do not meet the criteria of being flat."
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_flat", (attribute, object) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -714,8 +720,8 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Gets a list of all block locations with a specified flag within the CuboidTag.
         // Searches the internal flag lists, rather than through all possible blocks.
         // @example
-        // - foreach <player.location.chunk.blocks_flagged[my_flag]> as:block:
-        //     - narrate "Found block flagged 'my_flag' at <[block].simple>!"
+        // # Spawns a debugblock to highlight every block in the chunk flagged "my_flag"
+        // - debugblock <player.location.chunk.blocks_flagged[my_flag]>
         // -->
         tagProcessor.registerTag(ListTag.class, ElementTag.class, "blocks_flagged", (attribute, object, flagNameInput) -> {
             Chunk chunk = object.getChunkForTag(attribute);
@@ -935,7 +941,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // Sets all biomes in the chunk to the given biome.
         // @example
         // - adjust <player.location.chunk> set_all_biomes:<biome[savanna]>
-        // # Allow players to see biome change:
+        // # Allow players to see the biome change:
         // - adjust <player.location.chunk> refresh_chunk
         // -->
         if (mechanism.matches("set_all_biomes") && mechanism.requireObject(BiomeTag.class)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
@@ -274,7 +274,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a hex code formatting of this color, like '#ff00ff'.
         // @example
-        // # Narrates "#ff00ff"
+        // # Narrates "#ff00ff".
         // - narrate <color[fuchsia].hex>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "hex", (attribute, object) -> {
@@ -294,7 +294,7 @@ public class ColorTag implements ObjectTag {
         // Highest order bits are red, then green, then lowest is blue.
         // This is a rare special case encoding usually avoided by most systems, but may be necessary for some obscure tools.
         // @example
-        // # Narrates "16711935"
+        // # Narrates "16711935".
         // - narrate <color[fuchsia].rgb_integer>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "rgb_integer", (attribute, object) -> {
@@ -309,7 +309,7 @@ public class ColorTag implements ObjectTag {
         // Highest order bits are alpha, then red, then green, then lowest is blue.
         // This is a rare special case encoding usually avoided by most systems, but may be necessary for some obscure tools.
         // @example
-        // # Narrates "4294902015"
+        // # Narrates "4294902015".
         // - narrate <color[fuchsia].argb_integer>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "argb_integer", (attribute, object) -> {
@@ -322,7 +322,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the red value of this color (0 to 255).
         // @example
-        // # Narrates "255"
+        // # Narrates "255".
         // - narrate <color[fuchsia].red>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "red", (attribute, object) -> {
@@ -335,7 +335,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the green value of this color (0 to 255).
         // @example
-        // # Narrates "0"
+        // # Narrates "0".
         // - narrate <color[fuchsia].green>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "green", (attribute, object) -> {
@@ -348,7 +348,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the blue value of this color (0 to 255).
         // @example
-        // # Narrates "255"
+        // # Narrates "255".
         // - narrate <color[fuchsia].blue>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "blue", (attribute, object) -> {
@@ -361,7 +361,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the alpha value of this color (0 to 255).
         // @example
-        // # Narrates "255"
+        // # Narrates "255".
         // - narrate <color[fuchsia].alpha>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "alpha", (attribute, object) -> {
@@ -375,7 +375,7 @@ public class ColorTag implements ObjectTag {
         // Returns the RGB value of this color.
         // EG, 255,0,255
         // @example
-        // # Narrates "255,0,255"
+        // # Narrates "255,0,255".
         // - narrate <color[fuchsia].rgb>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "rgb", (attribute, object) -> {
@@ -389,7 +389,7 @@ public class ColorTag implements ObjectTag {
         // Returns the RGBA value of this color.
         // EG, 255,0,255,255
         // @example
-        // # Narrates "255,0,255,255"
+        // # Narrates "255,0,255,255".
         // - narrate <color[fuchsia].rgba>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "rgba", (attribute, object) -> {
@@ -402,7 +402,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the hue value of this color (0 to 255).
         // @example
-        // # Narrates "213"
+        // # Narrates "213".
         // - narrate <color[fuchsia].hue>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "hue", (attribute, object) -> {
@@ -415,7 +415,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the saturation value of this color (0 to 255).
         // @example
-        // # Narrates "255"
+        // # Narrates "255".
         // - narrate <color[fuchsia].saturation>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "saturation", (attribute, object) -> {
@@ -428,7 +428,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the brightness value of this color (0 to 255).
         // @example
-        // # Narrates "255"
+        // # Narrates "255".
         // - narrate <color[fuchsia].brightness>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "brightness", (attribute, object) -> {
@@ -442,7 +442,7 @@ public class ColorTag implements ObjectTag {
         // Returns the HSV value of this color.
         // EG, 100,100,255
         // @example
-        // # Narrates "213,255,255"
+        // # Narrates "213,255,255".
         // - narrate <color[fuchsia].hsv>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "hsv", (attribute, object) -> {
@@ -456,8 +456,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different red value (0 to 255).
         // @example
-        // # Narrates "150,0,255"
-        // - narrate <color[fuchsia].with_red[150].rgb>
+        // # Colors the text with a rgb value of "150,0,255", which is a dark purple.
+        // - narrate "<&color[<color[fuchsia].with_red[150]>]>This is fuchsia with a different red value!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_red", (attribute, object) -> {
             return new ColorTag(attribute.getIntParam(), object.green, object.blue, object.alpha);
@@ -469,8 +469,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different green value (0 to 255).
         // @example
-        // # Narrates "255,150,255"
-        // - narrate <color[fuchsia].with_green[150].rgb>
+        // # Colors the text with a rgb value of "255,150,255", which is a light pink.
+        // - narrate "<&color[<color[fuchsia].with_green[150]>]>This is fuchsia with a different green value!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_green", (attribute, object) -> {
             return new ColorTag(object.red, attribute.getIntParam(), object.blue, object.alpha);
@@ -482,8 +482,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different blue value (0 to 255).
         // @example
-        // # Narrates "255,0,150"
-        // - narrate <color[fuchsia].with_blue[150].rgb>
+        // # Colors the text with a rgb value of "255,0,150", which is a hot pink.
+        // - narrate "<&color[<color[fuchsia].with_blue[150]>]>This is fuchsia with a different blue value!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_blue", (attribute, object) -> {
             return new ColorTag(object.red, object.green, attribute.getIntParam(), object.alpha);
@@ -495,8 +495,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different alpha value (0 to 255).
         // @example
-        // # Narrates "255,0,255,150"
-        // - narrate <color[fuchsia].with_alpha[150].rgba>
+        // # Colors the text with a rgb value of "255,0,255,150", which is fuchsia, but transparency does not show up in chat.
+        // - narrate "<&color[<color[fuchsia].with_alpha[150]>]>This is fuchsia with a different alpha value! It does not show in chat though!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_alpha", (attribute, object) -> {
             return new ColorTag(object.red, object.green, object.alpha, attribute.getIntParam());
@@ -508,8 +508,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different hue value (0 to 255).
         // @example
-        // # Narrates "150,255,255"
-        // - narrate <color[fuchsia].with_hue[150].hsv>
+        // # Colors the text with a rgb value of "0,120,255", which is a dark blue.
+        // - narrate "<&color[<color[fuchsia].with_hue[150]>]>This is fuchsia with a different hue!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_hue", (attribute, object) -> {
             int[] HSB = object.toHSB();
@@ -523,8 +523,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different saturation value (0 to 255).
         // @example
-        // # Narrates "213,150,255"
-        // - narrate <color[fuchsia].with_saturation[150].hsv>
+        // # Colors the text with a rgb value of "255,105,253", which is a light pink.
+        // - narrate "<&color[<color[fuchsia].with_saturation[150]>]>This is fuchsia with a different saturation!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_saturation", (attribute, object) -> {
             int[] HSB = object.toHSB();
@@ -538,8 +538,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different brightness value (0 to 255).
         // @example
-        // # Narrates "213,255,150"
-        // - narrate <color[fuchsia].with_brightness[150].hsv>
+        // # Colors the text with a rgb value of "150,0,148", which is a purple.
+        // - narrate "<&color[<color[fuchsia].with_brightness[150]>]>This is fuchsia with a different brightness!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_brightness", (attribute, object) -> {
             int[] HSB = object.toHSB();
@@ -553,10 +553,10 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the name of this color (or red,green,blue if none).
         // @example
-        // # Narrates "fuchsia"
+        // # Narrates "fuchsia".
         // - narrate <color[fuchsia].name>
         // @example
-        // # Narrates "255,105,184"
+        // # Narrates "255,105,184".
         // - narrate <color[#ff69b8].name>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "name", (attribute, object) -> {
@@ -569,7 +569,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the color that results if you mix this color with another.
         // @example
-        // # Narrates "127,127,255", which is a dark purple.
+        // # Narrates "127,127,255", a mix between fuchsia and aqua which appears as a dark purple.
         // - narrate <color[fuchsia].mix[aqua].rgb>
         // -->
         tagProcessor.registerTag(ColorTag.class, ColorTag.class, "mix", (attribute, object, mixWith) -> { // Temporarily non-static because the input could be 'random'

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
@@ -529,7 +529,7 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different brightness value (0 to 255).
         // @example
-        // # Colors the text with a rgb value of "150,0,148", which is a purple.
+        // # Colors the text with a rgb value of "150,0,148", which is a magenta.
         // - narrate "<&color[<color[fuchsia].with_brightness[150]>]>This is fuchsia with a different brightness!"
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_brightness", (attribute, object) -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
@@ -273,6 +273,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag
         // @description
         // Returns a hex code formatting of this color, like '#ff00ff'.
+        // @example
+        // # Narrates "#ff00ff"
+        // - narrate <color[fuchsia].hex>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "hex", (attribute, object) -> {
             if (object.alpha != 255) {
@@ -290,6 +293,9 @@ public class ColorTag implements ObjectTag {
         // Returns the Red, Green, and Blue values of this ColorTag as an integer number, equivalent to an integer reparse of <@link tag ColorTag.hex>.
         // Highest order bits are red, then green, then lowest is blue.
         // This is a rare special case encoding usually avoided by most systems, but may be necessary for some obscure tools.
+        // @example
+        // # Narrates "16711935"
+        // - narrate <color[fuchsia].rgb_integer>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "rgb_integer", (attribute, object) -> {
             return new ElementTag((object.red << 16) | (object.green << 8) | (object.blue));
@@ -302,6 +308,9 @@ public class ColorTag implements ObjectTag {
         // Returns the Alpha, Red, Green, and Blue values of this ColorTag as an integer number, equivalent to an integer reparse of <@link tag ColorTag.hex>.
         // Highest order bits are alpha, then red, then green, then lowest is blue.
         // This is a rare special case encoding usually avoided by most systems, but may be necessary for some obscure tools.
+        // @example
+        // # Narrates "4294902015"
+        // - narrate <color[fuchsia].argb_integer>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "argb_integer", (attribute, object) -> {
             return new ElementTag(((long) object.alpha << 24L) | ((long) object.red << 16L) | ((long) object.green << 8L) | ((long) object.blue));
@@ -312,6 +321,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag(Number)
         // @description
         // Returns the red value of this color (0 to 255).
+        // @example
+        // # Narrates "255"
+        // - narrate <color[fuchsia].red>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "red", (attribute, object) -> {
             return new ElementTag(object.red);
@@ -322,6 +334,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag(Number)
         // @description
         // Returns the green value of this color (0 to 255).
+        // @example
+        // # Narrates "0"
+        // - narrate <color[fuchsia].green>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "green", (attribute, object) -> {
             return new ElementTag(object.green);
@@ -332,6 +347,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag(Number)
         // @description
         // Returns the blue value of this color (0 to 255).
+        // @example
+        // # Narrates "255"
+        // - narrate <color[fuchsia].blue>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "blue", (attribute, object) -> {
             return new ElementTag(object.blue);
@@ -342,6 +360,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag(Number)
         // @description
         // Returns the alpha value of this color (0 to 255).
+        // @example
+        // # Narrates "255"
+        // - narrate <color[fuchsia].alpha>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "alpha", (attribute, object) -> {
             return new ElementTag(object.alpha);
@@ -353,6 +374,9 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the RGB value of this color.
         // EG, 255,0,255
+        // @example
+        // # Narrates "255,0,255"
+        // - narrate <color[fuchsia].rgb>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "rgb", (attribute, object) -> {
             return new ElementTag(object.red + "," + object.green + "," + object.blue);
@@ -364,6 +388,9 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the RGBA value of this color.
         // EG, 255,0,255,255
+        // @example
+        // # Narrates "255,0,255,255"
+        // - narrate <color[fuchsia].rgba>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "rgba", (attribute, object) -> {
             return new ElementTag(object.red + "," + object.green + "," + object.blue + "," + object.alpha);
@@ -374,6 +401,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag(Number)
         // @description
         // Returns the hue value of this color (0 to 255).
+        // @example
+        // # Narrates "213"
+        // - narrate <color[fuchsia].hue>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "hue", (attribute, object) -> {
             return new ElementTag(object.toHSB()[0]);
@@ -384,6 +414,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag(Number)
         // @description
         // Returns the saturation value of this color (0 to 255).
+        // @example
+        // # Narrates "255"
+        // - narrate <color[fuchsia].saturation>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "saturation", (attribute, object) -> {
             return new ElementTag(object.toHSB()[1]);
@@ -394,6 +427,9 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag(Number)
         // @description
         // Returns the brightness value of this color (0 to 255).
+        // @example
+        // # Narrates "255"
+        // - narrate <color[fuchsia].brightness>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "brightness", (attribute, object) -> {
             return new ElementTag(object.toHSB()[2]);
@@ -405,6 +441,9 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the HSV value of this color.
         // EG, 100,100,255
+        // @example
+        // # Narrates "213,255,255"
+        // - narrate <color[fuchsia].hsv>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "hsv", (attribute, object) -> {
             int[] HSV = object.toHSB();
@@ -416,6 +455,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns a copy of this color object with a different red value (0 to 255).
+        // @example
+        // # Narrates "150,0,255"
+        // - narrate <color[fuchsia].with_red[150].rgb>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_red", (attribute, object) -> {
             return new ColorTag(attribute.getIntParam(), object.green, object.blue, object.alpha);
@@ -426,6 +468,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns a copy of this color object with a different green value (0 to 255).
+        // @example
+        // # Narrates "255,150,255"
+        // - narrate <color[fuchsia].with_green[150].rgb>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_green", (attribute, object) -> {
             return new ColorTag(object.red, attribute.getIntParam(), object.blue, object.alpha);
@@ -436,6 +481,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns a copy of this color object with a different blue value (0 to 255).
+        // @example
+        // # Narrates "255,0,150"
+        // - narrate <color[fuchsia].with_blue[150].rgb>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_blue", (attribute, object) -> {
             return new ColorTag(object.red, object.green, attribute.getIntParam(), object.alpha);
@@ -446,6 +494,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns a copy of this color object with a different alpha value (0 to 255).
+        // @example
+        // # Narrates "255,0,255,150"
+        // - narrate <color[fuchsia].with_alpha[150].rgba>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_alpha", (attribute, object) -> {
             return new ColorTag(object.red, object.green, object.alpha, attribute.getIntParam());
@@ -456,6 +507,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns a copy of this color object with a different hue value (0 to 255).
+        // @example
+        // # Narrates "150,255,255"
+        // - narrate <color[fuchsia].with_hue[150].hsv>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_hue", (attribute, object) -> {
             int[] HSB = object.toHSB();
@@ -468,6 +522,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns a copy of this color object with a different saturation value (0 to 255).
+        // @example
+        // # Narrates "213,150,255"
+        // - narrate <color[fuchsia].with_saturation[150].hsv>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_saturation", (attribute, object) -> {
             int[] HSB = object.toHSB();
@@ -480,6 +537,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns a copy of this color object with a different brightness value (0 to 255).
+        // @example
+        // # Narrates "213,255,150"
+        // - narrate <color[fuchsia].with_brightness[150].hsv>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_brightness", (attribute, object) -> {
             int[] HSB = object.toHSB();
@@ -492,6 +552,12 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag
         // @description
         // Returns the name of this color (or red,green,blue if none).
+        // @example
+        // # Narrates "fuchsia"
+        // - narrate <color[fuchsia].name>
+        // @example
+        // # Narrates "255,105,184"
+        // - narrate <color[#ff69b8].name>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "name", (attribute, object) -> {
             return new ElementTag(object.identify().substring("co@".length()));
@@ -502,6 +568,9 @@ public class ColorTag implements ObjectTag {
         // @returns ColorTag
         // @description
         // Returns the color that results if you mix this color with another.
+        // @example
+        // # Narrates "127,127,255", which is a dark purple.
+        // - narrate <color[fuchsia].mix[aqua].rgb>
         // -->
         tagProcessor.registerTag(ColorTag.class, ColorTag.class, "mix", (attribute, object, mixWith) -> { // Temporarily non-static because the input could be 'random'
             return new ColorTag(object.mixWith(mixWith));
@@ -512,6 +581,9 @@ public class ColorTag implements ObjectTag {
         // @returns LocationTag
         // @description
         // Returns the color as a particle offset, for use with <@link command playeffect>.
+        // @example
+        // # Plays the "SPELL_MOB" effect above the player's head with the particle offset applied to color the particle.
+        // - playeffect at:<player.location.add[0,3,0]> effect:SPELL_MOB data:1 quantity:0 offset:<color[fuchsia].to_particle_offset>
         // -->
         tagProcessor.registerStaticTag(LocationTag.class, "to_particle_offset", (attribute, object) -> {
             if (object.red + object.green + object.blue == 0) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ColorTag.java
@@ -272,7 +272,7 @@ public class ColorTag implements ObjectTag {
         // @attribute <ColorTag.hex>
         // @returns ElementTag
         // @description
-        // Returns a hex code formatting of this color, like '#ff00ff'.
+        // Returns a hex code formatting of this color.
         // @example
         // # Narrates "#ff00ff".
         // - narrate <color[fuchsia].hex>
@@ -293,9 +293,6 @@ public class ColorTag implements ObjectTag {
         // Returns the Red, Green, and Blue values of this ColorTag as an integer number, equivalent to an integer reparse of <@link tag ColorTag.hex>.
         // Highest order bits are red, then green, then lowest is blue.
         // This is a rare special case encoding usually avoided by most systems, but may be necessary for some obscure tools.
-        // @example
-        // # Narrates "16711935".
-        // - narrate <color[fuchsia].rgb_integer>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "rgb_integer", (attribute, object) -> {
             return new ElementTag((object.red << 16) | (object.green << 8) | (object.blue));
@@ -308,9 +305,6 @@ public class ColorTag implements ObjectTag {
         // Returns the Alpha, Red, Green, and Blue values of this ColorTag as an integer number, equivalent to an integer reparse of <@link tag ColorTag.hex>.
         // Highest order bits are alpha, then red, then green, then lowest is blue.
         // This is a rare special case encoding usually avoided by most systems, but may be necessary for some obscure tools.
-        // @example
-        // # Narrates "4294902015".
-        // - narrate <color[fuchsia].argb_integer>
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "argb_integer", (attribute, object) -> {
             return new ElementTag(((long) object.alpha << 24L) | ((long) object.red << 16L) | ((long) object.green << 8L) | ((long) object.blue));
@@ -373,7 +367,6 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag
         // @description
         // Returns the RGB value of this color.
-        // EG, 255,0,255
         // @example
         // # Narrates "255,0,255".
         // - narrate <color[fuchsia].rgb>
@@ -387,7 +380,6 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag
         // @description
         // Returns the RGBA value of this color.
-        // EG, 255,0,255,255
         // @example
         // # Narrates "255,0,255,255".
         // - narrate <color[fuchsia].rgba>
@@ -440,7 +432,6 @@ public class ColorTag implements ObjectTag {
         // @returns ElementTag
         // @description
         // Returns the HSV value of this color.
-        // EG, 100,100,255
         // @example
         // # Narrates "213,255,255".
         // - narrate <color[fuchsia].hsv>
@@ -495,8 +486,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns a copy of this color object with a different alpha value (0 to 255).
         // @example
-        // # Colors the text with a rgb value of "255,0,255,150", which is fuchsia, but transparency does not show up in chat.
-        // - narrate "<&color[<color[fuchsia].with_alpha[150]>]>This is fuchsia with a different alpha value! It does not show in chat though!"
+        // # Narrates "213,255,255,150".
+        // - narrate <color[fuchsia].with_alpha[150].rgba>
         // -->
         tagProcessor.registerStaticTag(ColorTag.class, "with_alpha", (attribute, object) -> {
             return new ColorTag(object.red, object.green, object.alpha, attribute.getIntParam());
@@ -569,8 +560,8 @@ public class ColorTag implements ObjectTag {
         // @description
         // Returns the color that results if you mix this color with another.
         // @example
-        // # Narrates "127,127,255", a mix between fuchsia and aqua which appears as a dark purple.
-        // - narrate <color[fuchsia].mix[aqua].rgb>
+        // # Colors the text with a rgb value of "127,127,255", which is a a dark purple.
+        // - narrate "<&color[<color[fuchsia].mix[aqua]>]>This is fuchsia mixed with aqua!"
         // -->
         tagProcessor.registerTag(ColorTag.class, ColorTag.class, "mix", (attribute, object, mixWith) -> { // Temporarily non-static because the input could be 'random'
             return new ColorTag(object.mixWith(mixWith));


### PR DESCRIPTION
### Adds examples for `ChunkTag` tags and mechs and `ColorTag` tags.

Made sure to test all the examples and used past reviews to make sure it works well.

This is kinda a big PR so take your time 👍 

Minor explanations:
- For `ColorTag`, as you can't see the color in the meta website, I just narrated the `.rbg` value to avoid raw objects and to show the output as rgb
- `<ChunkTag.add>` and `<ChunkTag.sub>` use `<chunk[...]>` and not `<player.location.chunk>` to show how the `add` and `sub` tags work.
- `ChunkTag` mech `load` uses `<player.location.chunk.add[100,0]>` instead of `<player.location.chunk>` because if it uses the player's current chunk then it is probably already loaded.

###### 🎨🎨🎨