### PR TITLE
Add paper-only PlayerPreparesGrindstoneCraftEvent

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -48,10 +48,10 @@ public class PaperModule {
             ScriptEvent.registerScriptEvent(PlayerInventorySlotChangeScriptEvent.class);
         }
         ScriptEvent.registerScriptEvent(PlayerJumpsScriptEventPaperImpl.class);
+        ScriptEvent.registerScriptEvent(PlayerPreparesGrindstoneCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerTradesWithMerchantScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerPreparesGrindstoneCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PreEntitySpawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(ProjectileCollideScriptEvent.class);
         ScriptEvent.registerScriptEvent(ServerListPingScriptEventPaperImpl.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -51,6 +51,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerTradesWithMerchantScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerPreparesGrindstoneCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PreEntitySpawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(ProjectileCollideScriptEvent.class);
         ScriptEvent.registerScriptEvent(ServerListPingScriptEventPaperImpl.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -22,6 +22,8 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     //
     // @Group Player
     //
+    // @Location true
+    //
     // @Triggers when a player prepares to grind an item.
     //
     // @Context
@@ -49,7 +51,10 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!item.tryAdvancedMatcher(path.eventArgLowerAt(3))) {
+        if (!item.tryAdvancedMatcher(path.eventArgLowerAt(4))) {
+            return false;
+        }
+        if (!runInCheck(path, inventory.getInventory().getLocation())) {
             return false;
         }
         return super.matches(path);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -18,7 +18,6 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
 
     // <--[event]
     // @Events
-    // player prepares grindstone craft item
     // player prepares grindstone craft <item>
     //
     // @Group Player

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -39,8 +39,8 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     //
     // @Warning The player doing the grinding is estimated and may be inaccurate.
     //
-    // @Examples
-    // This example removes also the cursed binding_curse enchantment from the item.
+    // @Example
+    // This example removes the usually not removable curse of binding enchantment.
     // on player prepares grindstone craft item:
     // - determine result:<context.result.with[remove_enchantments=binding_curse]>
     //

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -25,6 +25,8 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     //
     // @Location true
     //
+    // @Plugin Paper
+    //
     // @Triggers when a player prepares to grind an item.
     //
     // @Context
@@ -37,6 +39,11 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     // @Player Always.
     //
     // @Warning The player doing the grinding is estimated and may be inaccurate.
+    //
+    // @Examples
+    // This example removes also the cursed binding_curse enchantment from the item.
+    // on player prepares grindstone craft item:
+    // - determine result:<context.result.with[remove_enchantments=binding_curse]>
     //
     // -->
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -22,8 +22,6 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     //
     // @Group Player
     //
-    // @Location true
-    //
     // @Triggers when a player prepares to grind an item.
     //
     // @Context
@@ -52,9 +50,6 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     @Override
     public boolean matches(ScriptPath path) {
         if (!item.tryAdvancedMatcher(path.eventArgLowerAt(3))) {
-            return false;
-        }
-        if (!runInCheck(path, inventory.getLocation())) {
             return false;
         }
         return super.matches(path);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -40,7 +40,7 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     // @Warning The player doing the grinding is estimated and may be inaccurate.
     //
     // @Example
-    // This example removes the usually not removable curse of binding enchantment.
+    // # This example removes the usually not removable curse of binding enchantment.
     // on player prepares grindstone craft item:
     // - determine result:<context.result.with[remove_enchantments=binding_curse]>
     //

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -52,16 +52,14 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     }
 
     public PrepareResultEvent event;
-    public ItemTag item;
-    public Inventory inventory;
     public PlayerTag player;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!item.tryAdvancedMatcher(path.eventArgLowerAt(4))) {
+        if (!new ItemTag(event.getResult()).tryAdvancedMatcher(path.eventArgLowerAt(4))) {
             return false;
         }
-        if (!runInCheck(path, inventory.getLocation())) {
+        if (!runInCheck(path, event.getInventory().getLocation())) {
             return false;
         }
         return super.matches(path);
@@ -83,7 +81,7 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "inventory": return InventoryTag.mirrorBukkitInventory(inventory);
+            case "inventory": return InventoryTag.mirrorBukkitInventory(event.getInventory());
             case "result": return new ItemTag(event.getResult());
         }
         return super.getContext(name);
@@ -96,19 +94,17 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
 
     @EventHandler
     public void onPlayerPreparesGrindstoneCraft(PrepareResultEvent event) {
-        inventory = event.getInventory();
-        if (!(inventory instanceof GrindstoneInventory)) {
+        if (!(event.getInventory() instanceof GrindstoneInventory)) {
             return;
         }
-        if (inventory.getViewers().isEmpty()) {
+        if (event.getViewers().isEmpty()) {
             return;
         }
-        HumanEntity humanEntity = inventory.getViewers().get(0);
+        HumanEntity humanEntity = event.getViewers().get(0);
         if (EntityTag.isNPC(humanEntity)) {
             return;
         }
         player = EntityTag.getPlayerFrom(humanEntity);
-        item = new ItemTag(event.getResult());
         this.event = event;
         fire(event);
     }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -11,7 +11,8 @@ import com.destroystokyo.paper.event.inventory.PrepareResultEvent;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.GrindstoneInventory;
+import org.bukkit.inventory.Inventory;
 
 public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent implements Listener {
 
@@ -46,7 +47,7 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
 
     public PrepareResultEvent event;
     public ItemTag item;
-    public InventoryTag inventory;
+    public Inventory inventory;
     public PlayerTag player;
 
     @Override
@@ -54,7 +55,7 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
         if (!item.tryAdvancedMatcher(path.eventArgLowerAt(4))) {
             return false;
         }
-        if (!runInCheck(path, inventory.getInventory().getLocation())) {
+        if (!runInCheck(path, inventory.getLocation())) {
             return false;
         }
         return super.matches(path);
@@ -76,7 +77,7 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "inventory": return inventory;
+            case "inventory": return InventoryTag.mirrorBukkitInventory(inventory);
             case "result": return new ItemTag(event.getResult());
         }
         return super.getContext(name);
@@ -88,15 +89,15 @@ public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent 
     }
 
     @EventHandler
-    public void onPlayerPreparesGrindStoneCraft(PrepareResultEvent event) {
-        inventory = InventoryTag.mirrorBukkitInventory(event.getInventory());
-        if ((inventory.getInventoryType() != InventoryType.GRINDSTONE)) {
+    public void onPlayerPreparesGrindstoneCraft(PrepareResultEvent event) {
+        inventory = event.getInventory();
+        if (!(inventory instanceof GrindstoneInventory)) {
             return;
         }
-        if (event.getInventory().getViewers().isEmpty()) {
+        if (inventory.getViewers().isEmpty()) {
             return;
         }
-        HumanEntity humanEntity = inventory.getInventory().getViewers().get(0);
+        HumanEntity humanEntity = inventory.getViewers().get(0);
         if (EntityTag.isNPC(humanEntity)) {
             return;
         }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerPreparesGrindstoneCraftScriptEvent.java
@@ -1,0 +1,108 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.*;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.destroystokyo.paper.event.inventory.PrepareResultEvent;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryType;
+
+public class PlayerPreparesGrindstoneCraftScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player prepares grindstone craft item
+    // player prepares grindstone craft <item>
+    //
+    // @Group Player
+    //
+    // @Location true
+    //
+    // @Triggers when a player prepares to grind an item.
+    //
+    // @Context
+    // <context.inventory> returns the InventoryTag of the grindstone inventory.
+    // <context.result> returns the ItemTag to be crafted.
+    //
+    // @Determine
+    // "RESULT:" + ItemTag to change the item that is crafted.
+    //
+    // @Player Always.
+    //
+    // @Warning The player doing the grinding is estimated and may be inaccurate.
+    //
+    // -->
+
+
+    public PlayerPreparesGrindstoneCraftScriptEvent() {
+        registerCouldMatcher("player prepares grindstone craft <item>");
+    }
+
+    public PrepareResultEvent event;
+    public ItemTag item;
+    public InventoryTag inventory;
+    public PlayerTag player;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!item.tryAdvancedMatcher(path.eventArgLowerAt(3))) {
+            return false;
+        }
+        if (!runInCheck(path, inventory.getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        if (determinationObj instanceof ElementTag) {
+            String lower = CoreUtilities.toLowerCase(determinationObj.toString());
+            if (lower.startsWith("result:")) {
+                ItemTag result = ItemTag.valueOf(lower.substring("result:".length()), path.container);
+                event.setResult(result.getItemStack());
+                return true;
+            }
+        }
+        return super.applyDetermination(path, determinationObj);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "inventory": return inventory;
+            case "result": return new ItemTag(event.getResult());
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(player, null);
+    }
+
+    @EventHandler
+    public void onPlayerPreparesGrindStoneCraft(PrepareResultEvent event) {
+        inventory = InventoryTag.mirrorBukkitInventory(event.getInventory());
+        if ((inventory.getInventoryType() != InventoryType.GRINDSTONE)) {
+            return;
+        }
+        if (event.getInventory().getViewers().isEmpty()) {
+            return;
+        }
+        HumanEntity humanEntity = inventory.getInventory().getViewers().get(0);
+        if (EntityTag.isNPC(humanEntity)) {
+            return;
+        }
+        player = EntityTag.getPlayerFrom(humanEntity);
+        item = new ItemTag(event.getResult());
+        this.event = event;
+        fire(event);
+    }
+}


### PR DESCRIPTION
This PR add's the paper-only `PlayerPreparesGrindstoneCraftScriptEvent` build on Paper's `PreparesResultEvent`.

Additions:

- `player prepares grindstone craft <item>` event.
- `<context.inventory>` returns the InventoryTag of the grindstone inventory.
- `<context.result>` returns the ItemTag to be crafted.
- `RESULT + ItemTag` to change the item that is crafted.