### PR TITLE
Add `script` item advanced matcher

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -944,7 +944,8 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
         if (matcherLow.equals("potion") && CoreUtilities.toLowerCase(getBukkitMaterial().name()).contains("potion")) {
             return true;
         }
-        else if (matcherLow.equals("script") && isItemscript()) {
+        boolean isItemScript = isItemscript();
+        if (matcherLow.equals("script") && isItemScript) {
             return true;
         }
         if (matcher.contains("[") && matcher.endsWith("]")) {
@@ -954,7 +955,6 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
             }
             return helper.doesMatch(this);
         }
-        boolean isItemScript = isItemscript();
         if (isItemScript) {
             ScriptEvent.MatchHelper matchHelper = BukkitScriptEvent.createMatcher(matcher);
             if (matchHelper.doesMatch(getScriptName())) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -78,6 +78,7 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
     // @Matchable
     // ItemTag matchers, sometimes identified as "<item>", often seen as "with:<item>":
     // "potion": plaintext: matches if the item is any form of potion item.
+    // "script": plaintext: matches if the item is any form of script item.
     // "item_flagged:<flag>": A Flag Matcher for item flags.
     // "item_enchanted:<enchantment>": matches if the item is enchanted with the given enchantment name. Allows advanced matchers.
     // "raw_exact:<item>": matches based on exact raw item data comparison (almost always a bad idea to use).
@@ -941,6 +942,9 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
             }
         }
         if (matcherLow.equals("potion") && CoreUtilities.toLowerCase(getBukkitMaterial().name()).contains("potion")) {
+            return true;
+        }
+        else if (matcherLow.equals("script") && isItemscript()) {
             return true;
         }
         if (matcher.contains("[") && matcher.endsWith("]")) {


### PR DESCRIPTION
This PR adds the plaintext `script` item advanced matcher, that matches when the item is any form of script item.