### PR TITLE
`CuboidTag` and `EllipsoidTag` examples

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/CuboidTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/CuboidTag.java
@@ -725,6 +725,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @description
         // Returns a random block location within the cuboid.
         // (Note: random selection will not be fairly weighted for multi-member cuboids).
+        // @example
+        // # Spawns a debugblock at a random block in the cuboid "my_cuboid".
+        // - debugblock <cuboid[my_cuboid].random>
         // -->
         tagProcessor.registerTag(LocationTag.class, "random", (attribute, cuboid) -> {
             LocationPair pair = cuboid.pairs.get(CoreUtilities.getRandom().nextInt(cuboid.pairs.size()));
@@ -742,6 +745,10 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ElementTag(Number)
         // @description
         // Returns the number of cuboids defined in the CuboidTag.
+        // @example
+        // # Narrates the amount of cuboids are defined in "my_cuboid".
+        // # For example, if there are 3 cuboids defined in "my_cuboid", this will return "3".
+        // - narrate "The cuboid, 'my_cuboid', has <cuboid[my_cuboid].members_size> members!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "members_size", (attribute, cuboid) -> {
             return new ElementTag(cuboid.pairs.size());
@@ -752,6 +759,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ListTag(LocationTag)
         // @description
         // Returns each block location on the outline of the CuboidTag.
+        // @example
+        // # Plays the "flame" effect at the outline of the cuboid.
+        // - playeffect effect:flame at:<cuboid[my_cuboid].outline> offset:0.0
         // -->
         tagProcessor.registerTag(ListTag.class, "outline", (attribute, cuboid) -> {
             return cuboid.getOutline();
@@ -762,6 +772,8 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ListTag(LocationTag)
         // @description
         // Returns a list of block locations along the 2D outline of this CuboidTag, at the specified Y level.
+        // # Plays the "flame" effect at the 2D outline of the cuboid on the player's Y level.
+        // - playeffect effect:flame at:<cuboid[my_cuboid].outline_2d[<player.location.y>]> offset:0.0
         // -->
         tagProcessor.registerTag(ListTag.class, "outline_2d", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -777,6 +789,12 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ElementTag(Boolean)
         // @description
         // Returns whether this cuboid and another intersect.
+        // @example
+        // # Checks if the cuboid, "my_cuboid", intersects "my_second_cuboid".
+        // - if <cuboid[my_cuboid].intersects[my_second_cuboid]>:
+        //     - narrate "Both cuboids intersect each other!"
+        // - else:
+        //     - narrate "These cuboids do NOT intersect each other!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "intersects", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -813,6 +831,10 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ListTag(CuboidTag)
         // @description
         // Returns a list of all sub-cuboids in this CuboidTag (for cuboids that contain multiple sub-cuboids).
+        // @example
+        // # Loops through the members of the cuboid and plays a "flame" effect at their outlines.
+        // - foreach <cuboid[my_cuboid].list_members> as:member:
+        //     - playeffect effect:flame at:<[member].outline> offset:0.0
         // -->
         tagProcessor.registerTag(ListTag.class, "list_members", (attribute, cuboid) -> {
             List<LocationPair> pairs = cuboid.pairs;
@@ -828,6 +850,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns CuboidTag
         // @description
         // Returns a cuboid representing the one component of this cuboid (for cuboids that contain multiple sub-cuboids).
+        // @example
+        // # Displays a debugblock at the corners of the second member of "my_cuboid".
+        // - debugblock <cuboid[my_cuboid].get[2].corners>
         // -->
         tagProcessor.registerTag(CuboidTag.class, "get", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -890,6 +915,11 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @mechanism CuboidTag.add_member
         // @description
         // Returns a modified copy of this cuboid, with the input cuboid(s) added at the end.
+        // @example
+        // # Adds "my_second_cuboid" as a member of "my_cuboid".
+        // # If "my_cuboid" has two members, then "my_second_cuboid" will become the third member.
+        // # You can also use the "add_member" mechanism.
+        // - note <cuboid[my_cuboid].add_member[my_second_cuboid]> as:my_third_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "add_member", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -906,6 +936,10 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
             // @mechanism CuboidTag.add_member
             // @description
             // Returns a modified copy of this cuboid, with the input cuboid(s) added at the specified index.
+            // @example
+            // # Adds "my_second_cuboid" as a member of "my_cuboid" at an index of 3.
+            // # You can also use the "add_member" mechanism.
+            // - note <cuboid[my_cuboid].add_member[my_second_cuboid].at[3]> as:my_third_cuboid
             // -->
             if (attribute.startsWith("at", 2)) {
                 if (!attribute.hasContext(2)) {
@@ -942,6 +976,10 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @mechanism CuboidTag.remove_member
         // @description
         // Returns a modified copy of this cuboid, with member at the input index removed.
+        // @example
+        // # Removes the third member in the cuboid "my_cuboid" and notes it as "my_new_cuboid".
+        // # You can also use the "remove_member" mechanism.
+        // - note <cuboid[my_cuboid].remove_member[3]> as:my_new_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "remove_member", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -969,6 +1007,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @description
         // Returns the location of the exact center of the cuboid.
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # Displays a debugblock at the center of the cuboid.
+        // - debugblock <cuboid[my_cuboid].center>
         // -->
         tagProcessor.registerTag(LocationTag.class, "center", (attribute, cuboid) -> {
             LocationPair pair;
@@ -999,6 +1040,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Returns the volume of the cuboid.
         // Effectively equivalent to: (size.x * size.y * size.z).
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # For example, a cuboid with a size of "6,7,8" will have a volume of "336". 6 * 7 * 8 = 336.
+        // - narrate "The volume of the cuboid 'my_cuboid' is: <cuboid[my_cuboid].volume>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "volume", (attribute, cuboid) -> {
             LocationPair pair = cuboid.pairs.get(0);
@@ -1013,6 +1057,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Returns the size of the cuboid.
         // Effectively equivalent to: (max - min) + (1,1,1)
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # For example, this can return "6,7,8", meaning the cuboid is 6 blocks wide, 7 blocks high, and 8 blocks deep.
+        // - narrate "The size of the cuboid 'my_cuboid' is: <cuboid[my_cuboid].volume.xyz>!"
         // -->
         tagProcessor.registerTag(LocationTag.class, "size", (attribute, cuboid) -> {
             LocationPair pair;
@@ -1039,6 +1086,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @description
         // Returns the highest-numbered (maximum) corner location.
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # Displays a glowstone "block_marker" effect at maximum corner location of the cuboid.
+        // - playeffect effect:block_marker special_data:glowstone at:<cuboid[my_cuboid].max> offset:0.0
         // -->
         tagProcessor.registerTag(LocationTag.class, "max", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1062,6 +1112,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @description
         // Returns the lowest-numbered (minimum) corner location.
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # Displays a glowstone "block_marker" effect at minimum corner location of the cuboid.
+        // - playeffect effect:block_marker special_data:glowstone at:<cuboid[my_cuboid].min> offset:0.0
         // -->
         tagProcessor.registerTag(LocationTag.class, "min", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1087,6 +1140,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // The 4 low corners, then the 4 high corners.
         // In order X-Z-, X+Z-, X-Z+, X+Z+
         // If the object is a multi-member cuboid, returns corners for all members in sequence.
+        // @example
+        // # Displays a glowstone block marker effect at each corner of the cuboid.
+        // - playeffect effect:block_marker special_data:glowstone at:<cuboid[my_cuboid].corners> offset:0.0
         // -->
         tagProcessor.registerTag(ListTag.class, "corners", (attribute, cuboid) -> {
             ListTag output = new ListTag();
@@ -1109,6 +1165,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @description
         // Returns a copy of this cuboid, with all members shifted by the given vector LocationTag.
         // For example, a cuboid from 5,5,5 to 10,10,10, shifted 100,0,100, would return a cuboid from 105,5,105 to 110,10,110.
+        // @example
+        // # Notes the cuboid "my_cuboid" as "my_shifted_cuboid" but shifted over by 25,25,25.
+        // - note <cuboid[my_cuboid].shift[25,25,25]> as:my_shifted_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "shift", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1127,6 +1186,12 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns CuboidTag
         // @description
         // Expands the first member of the CuboidTag to contain the given location (or entire cuboid), and returns the expanded cuboid.
+        // @example
+        // # Expands the cuboid to contain the player's location and notes it as "my_new_cuboid".
+        // - note <cuboid[my_cuboid].include[<player.location>]> as:my_new_cuboid
+        // @example
+        // # Expands the cuboid to contain the cuboid "my_second_cuboid" and notes it as "my_new_cuboid".
+        // - note <cuboid[my_cuboid].include[my_second_cuboid]> as:my_new_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "include", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1149,6 +1214,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns CuboidTag
         // @description
         // Expands the first member of the CuboidTag to contain the given X value, and returns the expanded cuboid.
+        // @example
+        // # Expands the cuboid to include a block with an X location of 25 and notes it as "my_expanded_cuboid".
+        // - note <cuboid[my_cuboid].include_x[25]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "include_x", (attribute, cuboid) -> {
             cuboid = cuboid.clone();
@@ -1171,6 +1239,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns CuboidTag
         // @description
         // Expands the first member of the CuboidTag to contain the given Y value, and returns the expanded cuboid.
+        // @example
+        // # Expands the cuboid to include a block with a Y location of 25 and notes it as "my_expanded_cuboid".
+        // - note <cuboid[my_cuboid].include_y[25]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "include_y", (attribute, cuboid) -> {
             cuboid = cuboid.clone();
@@ -1193,6 +1264,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns CuboidTag
         // @description
         // Expands the first member of the CuboidTag to contain the given Z value, and returns the expanded cuboid.
+        // @example
+        // # Expands the cuboid to include a block with a Z location of 25 and notes it as "my_expanded_cuboid".
+        // - note <cuboid[my_cuboid].include_z[25]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "include_z", (attribute, cuboid) -> {
             cuboid = cuboid.clone();
@@ -1219,6 +1293,11 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // and the output min will contain the old max values.
         // Note that this is equivalent to constructing a cuboid with the input value and the original cuboids max value.
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # Notes a new cuboid with the player's location as the new minimum location of the cuboid.
+        // # For example: if "my_cuboid" spans from 10,10,10 (max) to 5,5,5 (min) and the player had a location of -5,5,-5,
+        // # then "my_new_cuboid" will have a minimum location of -5,5,-5.
+        // - note <cuboid[my_cuboid].with_min[<player.location>]> as:my_new_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "with_min", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1238,6 +1317,11 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // and the output max will contain the old min values.
         // Note that this is equivalent to constructing a cuboid with the input value and the original cuboids min value.
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # Notes a new cuboid with the player's location as the new maximum location of the cuboid.
+        // # For example: if "my_cuboid" spans from 10,10,10 (max) to 5,5,5 (min) and the player had a location of 15,10,15,
+        // # then "my_new_cuboid" will have a minimum location of 15,10,15.
+        // - note <cuboid[my_cuboid].with_max[<player.location>]> as:my_new_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "with_max", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1257,6 +1341,14 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Supplying a negative input will therefore contract the cuboid.
         // Note that you can also specify a single number to expand all coordinates by the same amount (equivalent to specifying a location that is that value on X, Y, and Z).
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # If "my_cuboid" spans from 10,10,10 to 5,5,5 and gets expanded by 15 (15,15,15),
+        // # "my_expanded_cuboid" will span -10,-10,-10 to 25,25,25
+        // - note <cuboid[my_cuboid].expand[15]> as:my_expanded_cuboid
+        // @example
+        // # If "my_cuboid" spans from 10,10,10 to 5,5,5 and gets expanded by 15,15,15,
+        // # "my_expanded_cuboid" will span -10,-10,-10 to 25,25,25
+        // - note <cuboid[my_cuboid].expand[15,15,15]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "expand", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1284,6 +1376,12 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Note that you can also specify a single number to expand all coordinates by the same amount (equivalent to specifying a location that is that value on X, Y, and Z).
         // Inverted by <@link tag CuboidTag.shrink_one_side>
         // Not valid for multi-member CuboidTags.
+        // @example
+        // # Expands the high value of the cuboid "my_cuboid" by 15 (15,15,15) on one side and notes it as "my_expanded_cuboid".
+        // - note <cuboid[my_cuboid].expand_one_side[15]> as:my_expanded_cuboid
+        // @example
+        // # Expands the low value of the cuboid "my_cuboid" by -15 (-15,-15,-15) on one side and notes it as "my_expanded_cuboid".
+        // - note <cuboid[my_cuboid].expand_one_side[-15]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "expand_one_side", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1332,6 +1430,12 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Inverted by <@link tag CuboidTag.expand_one_side>
         // Not valid for multi-member CuboidTags.
         // If you shrink past the limits of the cuboid's size, the cuboid will flip and start expanding the opposite direction.
+        // @example
+        // # Shrinks the high value of the cuboid "my_cuboid" by 15 (15,15,15) on one side and notes it as "my_expanded_cuboid".
+        // - note <cuboid[my_cuboid].expand_one_side[15]> as:my_expanded_cuboid
+        // @example
+        // # Shrinks the low value of the cuboid "my_cuboid" by -15 (-15,-15,-15) on one side and notes it as "my_expanded_cuboid".
+        // - note <cuboid[my_cuboid].expand_one_side[-15]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "shrink_one_side", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1375,6 +1479,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ListTag(ChunkTag)
         // @description
         // Gets a list of all chunks entirely within the CuboidTag (ignoring the Y axis).
+        // @example
+        // # Loads the chunks that are fully within the cuboid "my_cuboid".
+        // - chunkload <cuboid[my_cuboid].chunks>
         // -->
         tagProcessor.registerTag(ListTag.class, "chunks", (attribute, cuboid) -> {
             ListTag chunks = new ListTag();
@@ -1408,6 +1515,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ListTag(ChunkTag)
         // @description
         // Gets a list of all chunks partially or entirely within the CuboidTag.
+        // @example
+        // # Loads the chunks that are within the cuboid "my_cuboid", even if they are partially within the cuboid.
+        // - chunkload <cuboid[my_cuboid].partial_chunks>
         // -->
         tagProcessor.registerTag(ListTag.class, "partial_chunks", (attribute, cuboid) -> {
             ListTag chunks = new ListTag();
@@ -1547,6 +1657,12 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // <CuboidTag.get>
         // <CuboidTag.add_member[<cuboid>]>
         // <CuboidTag.add_member[<cuboid>].at[<#>]>
+        // @example
+        // # Adds "my_second_cuboid" as a member to "my_cuboid".
+        // - adjust <cuboid[my_cuboid]> add_member:my_second_cuboid
+        // @example
+        // # Adds "my_second_cuboid" as a member to "my_cuboid" at an index of 2.
+        // - adjust <cuboid[my_cuboid]> add_member:2,my_second_cuboid
         // -->
         if (mechanism.matches("add_member")) {
             if (noteName != null) {
@@ -1581,6 +1697,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Remove a sub-member from the cuboid at the specified index.
         // @tags
         // <CuboidTag.remove_member[<#>]>
+        // @example
+        // # Removes the second member from the cuboid "my_cuboid".
+        // - adjust <cuboid[my_cuboid]> remove_member:2
         // -->
         if (mechanism.matches("remove_member") && mechanism.requireInteger()) {
             if (pairs.size() == 1) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/CuboidTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/CuboidTag.java
@@ -1538,6 +1538,10 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @returns ElementTag
         // @description
         // Gets the name of a noted CuboidTag. If the cuboid isn't noted, this is null.
+        // @example
+        // # For example, this might return something like:
+        // # "The cuboid you are currently in is noted as: my_cuboid!"
+        // - narrate "The cuboid you are currently in is noted as: <player.location.areas[cuboid].first.note_name.if_null[null! You aren't in a cuboid]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "note_name", (attribute, cuboid) -> {
             String noteName = NoteManager.getSavedId(cuboid);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/CuboidTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/CuboidTag.java
@@ -916,8 +916,7 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @description
         // Returns a modified copy of this cuboid, with the input cuboid(s) added at the end.
         // @example
-        // # Adds "my_second_cuboid" as a member of "my_cuboid".
-        // # If "my_cuboid" has two members, then "my_second_cuboid" will become the third member.
+        // # Creates a new cuboid named "my_third_cuboid" and adds "my_cuboid" and "my_second_cuboid" as members.
         // # You can also use the "add_member" mechanism.
         // - note <cuboid[my_cuboid].add_member[my_second_cuboid]> as:my_third_cuboid
         // -->
@@ -1320,7 +1319,7 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @example
         // # Notes a new cuboid with the player's location as the new maximum location of the cuboid.
         // # For example: if "my_cuboid" spans from 10,10,10 (max) to 5,5,5 (min) and the player had a location of 15,10,15,
-        // # then "my_new_cuboid" will have a minimum location of 15,10,15.
+        // # then "my_new_cuboid" will span from 15,10,15 (max) to 5,5,5 (min).
         // - note <cuboid[my_cuboid].with_max[<player.location>]> as:my_new_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "with_max", (attribute, cuboid) -> {
@@ -1343,12 +1342,12 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Not valid for multi-member CuboidTags.
         // @example
         // # If "my_cuboid" spans from 10,10,10 to 5,5,5 and gets expanded by 15 (15,15,15),
-        // # "my_expanded_cuboid" will span -10,-10,-10 to 25,25,25
+        // # then "my_expanded_cuboid" will span -10,-10,-10 (min) to 25,25,25 (max).
         // - note <cuboid[my_cuboid].expand[15]> as:my_expanded_cuboid
         // @example
-        // # If "my_cuboid" spans from 10,10,10 to 5,5,5 and gets expanded by 15,15,15,
-        // # "my_expanded_cuboid" will span -10,-10,-10 to 25,25,25
-        // - note <cuboid[my_cuboid].expand[15,15,15]> as:my_expanded_cuboid
+        // # If "my_cuboid" spans from 10,10,10 to 5,5,5 and gets expanded by 15,20,25,
+        // # then "my_expanded_cuboid" will span -10,-15,-20 (min) to 25,30,35 (max).
+        // - note <cuboid[my_cuboid].expand[15,20,25]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "expand", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1377,10 +1376,14 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Inverted by <@link tag CuboidTag.shrink_one_side>
         // Not valid for multi-member CuboidTags.
         // @example
-        // # Expands the high value of the cuboid "my_cuboid" by 15 (15,15,15) on one side and notes it as "my_expanded_cuboid".
-        // - note <cuboid[my_cuboid].expand_one_side[15]> as:my_expanded_cuboid
+        // # Expands the high value of the cuboid "my_cuboid" by 15,16,17 on one side and notes it as "my_expanded_cuboid".
+        // # If "my_cuboid" spans from 10,10,10 (max) to 5,5,5 (min), then expanding it by 15,16,17 will make "my_expanded_cuboid"
+        // # span from 25,26,27 (max) to 5,5,5 (min).
+        // - note <cuboid[my_cuboid].expand_one_side[15,16,17]> as:my_expanded_cuboid
         // @example
         // # Expands the low value of the cuboid "my_cuboid" by -15 (-15,-15,-15) on one side and notes it as "my_expanded_cuboid".
+        // # If "my_cuboid" spans from 10,10,10 (max) to 5,5,5 (min), then shrinking it by -15 will make "my_expanded_cuboid"
+        // # span from 10,10,10 (max) to -10,-10,-10 (min).
         // - note <cuboid[my_cuboid].expand_one_side[-15]> as:my_expanded_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "expand_one_side", (attribute, cuboid) -> {
@@ -1431,11 +1434,15 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Not valid for multi-member CuboidTags.
         // If you shrink past the limits of the cuboid's size, the cuboid will flip and start expanding the opposite direction.
         // @example
-        // # Shrinks the high value of the cuboid "my_cuboid" by 15 (15,15,15) on one side and notes it as "my_expanded_cuboid".
-        // - note <cuboid[my_cuboid].expand_one_side[15]> as:my_expanded_cuboid
+        // # Shrinks the high value of the cuboid "my_cuboid" by 15,16,17 on one side and notes it as "my_smaller_cuboid".
+        // # If "my_cuboid" spans from 10,10,10 (max) to 5,5,5 (min), then shrinking it by 15,16,17 will make "my_smaller_cuboid"
+        // # span from 5,5,5 (max) to -5,-6,-7 (min).
+        // - note <cuboid[my_cuboid].shrink_one_side[15,16,17]> as:my_smaller_cuboid
         // @example
-        // # Shrinks the low value of the cuboid "my_cuboid" by -15 (-15,-15,-15) on one side and notes it as "my_expanded_cuboid".
-        // - note <cuboid[my_cuboid].expand_one_side[-15]> as:my_expanded_cuboid
+        // # Shrinks the low value of the cuboid "my_cuboid" by -15 (-15,-15,-15) on one side and notes it as "my_smaller_cuboid".
+        // # If "my_cuboid" spans from 10,10,10 (max) to 5,5,5 (min), then shrinking it by -15 will make "my_smaller_cuboid"
+        // # span from 20,20,20 (max) to 10,10,10 (min).
+        // - note <cuboid[my_cuboid].shrink_one_side[-15]> as:my_smaller_cuboid
         // -->
         tagProcessor.registerTag(CuboidTag.class, "shrink_one_side", (attribute, cuboid) -> {
             if (!attribute.hasParam()) {
@@ -1481,6 +1488,9 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Gets a list of all chunks entirely within the CuboidTag (ignoring the Y axis).
         // @example
         // # Loads the chunks that are fully within the cuboid "my_cuboid".
+        // # If "my_cuboid" spans from "15,50,15" (max) to "7,64,5" (min), then this will return an empty list and not load any chunks
+        // # because no chunks are fully enclosed within it. But, for example, if it spans from "21,70,21" (max) to "-10,64,-9" (min),
+        // # then this will return a list with chunk 0,0 and load it because the cuboid surrounds that chunk.
         // - chunkload <cuboid[my_cuboid].chunks>
         // -->
         tagProcessor.registerTag(ListTag.class, "chunks", (attribute, cuboid) -> {
@@ -1517,6 +1527,8 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // Gets a list of all chunks partially or entirely within the CuboidTag.
         // @example
         // # Loads the chunks that are within the cuboid "my_cuboid", even if they are partially within the cuboid.
+        // # If "my_cuboid" spans from "15,50,15" (max) to "7,64,5" (min), then this will return a list with chunk 0,0
+        // # in it, because the chunk is partially contained by the cuboid.
         // - chunkload <cuboid[my_cuboid].partial_chunks>
         // -->
         tagProcessor.registerTag(ListTag.class, "partial_chunks", (attribute, cuboid) -> {
@@ -1662,10 +1674,13 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // <CuboidTag.add_member[<cuboid>]>
         // <CuboidTag.add_member[<cuboid>].at[<#>]>
         // @example
-        // # Adds "my_second_cuboid" as a member to "my_cuboid".
+        // # Adds "my_second_cuboid" as a member to "my_cuboid" and narrates a formatted list of members.
+        // # For example, if "my_cuboid" is "world,5,5,5,10,10,10" and "my_second_cuboid" is "world,12,12,12,22,22,22",
+        // # then this will narrate "world,5,5,5,10,10,10 and world,12,12,12,22,22,22".
         // - adjust <cuboid[my_cuboid]> add_member:my_second_cuboid
+        // - narrate <cuboid[my_cuboid].list_members.formatted>
         // @example
-        // # Adds "my_second_cuboid" as a member to "my_cuboid" at an index of 2.
+        // # Adds "my_second_cuboid" as a member to "my_cuboid" at the second index.
         // - adjust <cuboid[my_cuboid]> add_member:2,my_second_cuboid
         // -->
         if (mechanism.matches("add_member")) {
@@ -1702,8 +1717,11 @@ public class CuboidTag implements ObjectTag, Cloneable, Notable, Adjustable, Are
         // @tags
         // <CuboidTag.remove_member[<#>]>
         // @example
-        // # Removes the second member from the cuboid "my_cuboid".
+        // # Removes the second member from "my_cuboid" and narrates a formatted list of members.
+        // # For example, if "my_cuboid" is "world,5,5,5,10,10,10" and it's second member is "world,12,12,12,22,22,22",
+        // # after the member is removed then this will narrate "world,5,5,5,10,10,10".
         // - adjust <cuboid[my_cuboid]> remove_member:2
+        // - narrate <cuboid[my_cuboid].list_members.formatted>
         // -->
         if (mechanism.matches("remove_member") && mechanism.requireInteger()) {
             if (pairs.size() == 1) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EllipsoidTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EllipsoidTag.java
@@ -422,6 +422,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @description
         // Returns a random decimal location within the ellipsoid.
         // Note that distribution of results will not be completely even.
+        // @example
+        // # Displays a debugblock at a random location within the ellipsoid "my_ellipsoid".
+        // - debugblock <ellipsoid[my_ellipsoid].random>
         // -->
         tagProcessor.registerTag(LocationTag.class, "random", (attribute, object) -> {
             // This is an awkward hack to try to weight towards the center a bit (to counteract the weight-away-from-center that would otherwise happen).
@@ -444,6 +447,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns LocationTag
         // @description
         // Returns the center location of the ellipsoid.
+        // @example
+        // # Displays a debugblock at center location of the ellipsoid "my_ellipsoid".
+        // - debugblock <ellipsoid[my_ellipsoid].location>
         // -->
         tagProcessor.registerTag(LocationTag.class, "location", (attribute, object) -> {
             return object.center;
@@ -454,6 +460,8 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns LocationTag
         // @description
         // Returns the size of the ellipsoid.
+        // @example
+        // - narrate "The size of the ellipsoid 'my_ellipsoid' is: <ellipsoid[my_ellipsoid].size.xyz>!"
         // -->
         tagProcessor.registerTag(LocationTag.class, "size", (attribute, object) -> {
             return object.size;
@@ -464,6 +472,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns EllipsoidTag
         // @description
         // Returns a copy of this ellipsoid, shifted by the input location.
+        // @example
+        // # Shifts the ellipsoid by 10,10,10 and notes it as "my_shifted_ellipsoid".
+        // - note <ellipsoid[my_ellipsoid].add[10,10,10]> as:my_shifted_ellipsoid
         // -->
         tagProcessor.registerTag(EllipsoidTag.class, "add", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -478,6 +489,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns EllipsoidTag
         // @description
         // Returns a copy of this ellipsoid, with the size value adapted to include the specified world location.
+        // @example
+        // # Expands "my_ellipsoid" to include the player's location and notes it as "my_new_ellipsoid".
+        // - note <ellipsoid[my_ellipsoid].include[<player.location>]> as:my_new_ellipsoid
         // -->
         tagProcessor.registerTag(EllipsoidTag.class, "include", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -528,6 +542,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns EllipsoidTag
         // @description
         // Returns a copy of this ellipsoid, set to the specified location.
+        // @example
+        // # Sets the location of "my_ellipsoid" to be the player's location.
+        // - note <ellipsoid[my_ellipsoid].with_location[<player.location>]> as:my_new_ellipsoid
         // -->
         tagProcessor.registerTag(EllipsoidTag.class, "with_location", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -542,6 +559,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns EllipsoidTag
         // @description
         // Returns a copy of this ellipsoid, set to the specified size.
+        // @example
+        // # Changes the size of "my_ellipsoid" to be 20,20,20 and notes it as "my_new_ellipsoid".
+        // - note <ellipsoid[my_ellipsoid].with_size[20,20,20]> as:my_new_ellipsoid
         // -->
         tagProcessor.registerTag(EllipsoidTag.class, "with_size", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -556,6 +576,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns ListTag(ChunkTag)
         // @description
         // Returns a list of all chunks that this ellipsoid touches at all (note that no valid ellipsoid tag can ever totally contain a chunk, due to vertical limits and roundness).
+        // @example
+        // # Loads the chunks that are fully within the ellipsoid "my_ellipsoid".
+        // - chunkload <ellipsoid[my_ellipsoid].chunks>
         // -->
         tagProcessor.registerTag(ListTag.class, "chunks", (attribute, object) -> {
             ListTag chunks = new ListTag();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EllipsoidTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EllipsoidTag.java
@@ -608,6 +608,10 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @returns ElementTag
         // @description
         // Gets the name of a noted EllipsoidTag. If the ellipsoid isn't noted, this is null.
+        // @example
+        // # For example, this might return something like:
+        // # "The ellipsoid you are currently in is noted as: my_ellipsoid!"
+        // - narrate "The ellipsoid you are currently in is noted as: <player.location.areas[ellipsoid].first.note_name.if_null[null! You aren't in an ellipsoid]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "note_name", (attribute, ellipsoid) -> {
             String noteName = NoteManager.getSavedId(ellipsoid);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EllipsoidTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EllipsoidTag.java
@@ -461,6 +461,7 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @description
         // Returns the size of the ellipsoid.
         // @example
+        // # For example, this can return: "The size of the ellipsoid 'my_ellipsoid' is: 10,10,10!"
         // - narrate "The size of the ellipsoid 'my_ellipsoid' is: <ellipsoid[my_ellipsoid].size.xyz>!"
         // -->
         tagProcessor.registerTag(LocationTag.class, "size", (attribute, object) -> {
@@ -474,6 +475,8 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // Returns a copy of this ellipsoid, shifted by the input location.
         // @example
         // # Shifts the ellipsoid by 10,10,10 and notes it as "my_shifted_ellipsoid".
+        // # For example, if "my_ellipsoid" has a location of "5,5,5", and it's added by "10,10,10",
+        // # "my_shifted_cuboid" will have a location of "15,15,15".
         // - note <ellipsoid[my_ellipsoid].add[10,10,10]> as:my_shifted_ellipsoid
         // -->
         tagProcessor.registerTag(EllipsoidTag.class, "add", (attribute, object) -> {
@@ -491,6 +494,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // Returns a copy of this ellipsoid, with the size value adapted to include the specified world location.
         // @example
         // # Expands "my_ellipsoid" to include the player's location and notes it as "my_new_ellipsoid".
+        // # For example, if "my_ellipsoid" has a location of "5,5,5" and a size of "8,8,8",
+        // # and the player had a location of 20,22,24, then "my_new_ellipsoid" will have a location of
+        // # "5,5,5" and a size of "26,29,33" (rounded).
         // - note <ellipsoid[my_ellipsoid].include[<player.location>]> as:my_new_ellipsoid
         // -->
         tagProcessor.registerTag(EllipsoidTag.class, "include", (attribute, object) -> {
@@ -544,6 +550,7 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // Returns a copy of this ellipsoid, set to the specified location.
         // @example
         // # Sets the location of "my_ellipsoid" to be the player's location.
+        // # For example, if the player's location is 10,15,20, then "my_new_ellipsoid" will have a location of 10,15,20.
         // - note <ellipsoid[my_ellipsoid].with_location[<player.location>]> as:my_new_ellipsoid
         // -->
         tagProcessor.registerTag(EllipsoidTag.class, "with_location", (attribute, object) -> {
@@ -577,7 +584,9 @@ public class EllipsoidTag implements ObjectTag, Notable, Cloneable, AreaContainm
         // @description
         // Returns a list of all chunks that this ellipsoid touches at all (note that no valid ellipsoid tag can ever totally contain a chunk, due to vertical limits and roundness).
         // @example
-        // # Loads the chunks that are fully within the ellipsoid "my_ellipsoid".
+        // # Loads the chunks that touch the ellipsoid "my_ellipsoid".
+        // # For example, if "my_ellipsoid" had a size of "9,4,6" and a location of "-10,70,-9",
+        // # this will return a list containing chunks -2,-1 and -1,-1.
         // - chunkload <ellipsoid[my_ellipsoid].chunks>
         // -->
         tagProcessor.registerTag(ListTag.class, "chunks", (attribute, object) -> {


### PR DESCRIPTION
#### Adds examples to `CuboidTag` and `EllipsoidTag` tags and mechs

Notes:
- The tag `<CuboitTag.set[].at[]>` and the mechanism `set` was ignored due to me not being really sure what they did and how to use them lol. I might do more testing later and add examples in a future PR.