### PR TITLE
Add `PlayerTag.last_death_location` tag/mech pair

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
@@ -419,8 +419,7 @@ public abstract class ImprovedOfflinePlayer {
         CompoundTag compoundTag = (CompoundTag) this.compound.getValue().get("LastDeathLocation");
         compoundTag = compoundTag.createBuilder()
                 .putIntArray("pos", new int[] {deathLoc.getBlockX(), deathLoc.getBlockY(), deathLoc.getBlockZ()})
-                .putString("dimension", deathLoc.getWorld().getKey().toString())
-                .build();
+                .putString("dimension", deathLoc.getWorld().getKey().toString()).build();
         this.compound = compound.createBuilder().put("LastDeathLocation", compoundTag).build();
         if (this.autosave) {
             savePlayerData();

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
@@ -414,4 +414,16 @@ public abstract class ImprovedOfflinePlayer {
             savePlayerData();
         }
     }
+
+    public void setLastDeathLocation(Location deathLoc) {
+        CompoundTag compoundTag = (CompoundTag) this.compound.getValue().get("LastDeathLocation");
+        compoundTag = compoundTag.createBuilder()
+                .putIntArray("pos", new int[] {deathLoc.getBlockX(), deathLoc.getBlockY(), deathLoc.getBlockZ()})
+                .putString("dimension", deathLoc.getWorld().getKey().toString())
+                .build();
+        this.compound = compound.createBuilder().put("LastDeathLocation", compoundTag).build();
+        if (this.autosave) {
+            savePlayerData();
+        }
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2529,6 +2529,36 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             }
             return result;
         });
+
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+
+            // <--[tag]
+            // @attribute <PlayerTag.last_death_location>
+            // @returns LocationTag
+            // @mechanism PlayerTag.last_death_location
+            // @description
+            // Returns the player's last death location, if any.
+            // Works with offline players.
+            // -->
+            tagProcessor.registerTag(LocationTag.class, "last_death_location", (attribute, object) -> {
+                Location deathLoc = object.getOfflinePlayer().getLastDeathLocation();
+                return deathLoc != null ? new LocationTag(deathLoc) : null;
+            });
+
+            // <--[mechanism]
+            // @object PlayerTag
+            // @name last_death_location
+            // @input LocationTag
+            // @description
+            // Sets the player's last death location.
+            // Note that this only updates clientside when the player respawns.
+            // @tags
+            // <PlayerTag.last_death_location>
+            // -->
+            registerOnlineOnlyMechanism("last_death_location", LocationTag.class, (object, mechanism, input) -> {
+                object.getPlayerEntity().setLastDeathLocation(input);
+            });
+        }
     }
 
     public static ObjectTagProcessor<PlayerTag> tagProcessor = new ObjectTagProcessor<>();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2609,6 +2609,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         tagProcessor.registerMechanism(name, false, paramType, (object, mechanism, input) -> {
             if (!object.isValid()) {
                 mechanism.echoError("Player is not considered valid in mechanism '" + name + "' for player: " + object.debuggable());
+                return;
             }
             runnable.run(object, mechanism, input);
         }, deprecatedVariants);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2537,7 +2537,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             // @returns LocationTag
             // @mechanism PlayerTag.last_death_location
             // @description
-            // Returns the player's last death location, if any.
+            // Returns the location where the player last died, if any.
             // Works with offline players.
             // -->
             registerOfflineTag(LocationTag.class, "last_death_location", (attribute, object) -> {
@@ -2550,8 +2550,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             // @name last_death_location
             // @input LocationTag
             // @description
-            // Sets the player's last death location.
-            // Note that this only updates clientside when the player respawns.
+            // Sets the player's last death location, note that this only updates clientside when the player respawns.
             // Works with offline players.
             // @tags
             // <PlayerTag.last_death_location>


### PR DESCRIPTION
## Additions

- `PlayerTag.last_death_location` 1.19+ tag/mech pair - controls the player's last death location.
- `PlayerTag#registerOfflineMechanism` - a mechanism equivalent of `PlayerTag#registerOfflineTag`.
- `ImprovedOfflinePlayer#setLastDeathLocation` - sets an offline player's last death location.