### PR TITLE
Deprecate the `EntityTag.skeleton_arms_raised` mechanism

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -3757,12 +3757,15 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @object EntityTag
         // @name skeleton_arms_raised
         // @input ElementTag(Boolean)
+        // @deprecated use 'EntityTag.aggressive'.
         // @description
-        // Sets whether the skeleton entity should raise its arms.
+        // Deprecated in favor of <@link mechanism EntityTag.aggressive>.
         // -->
         if (mechanism.matches("skeleton_arms_raised") && mechanism.requireBoolean()) {
-            EntityAnimation entityAnimation = NMSHandler.animationHelper.getEntityAnimation(mechanism.getValue().asBoolean() ? "SKELETON_START_SWING_ARM" : "SKELETON_STOP_SWING_ARM");
-            entityAnimation.play(entity);
+            BukkitImplDeprecations.entitySkeletonArmsRaised.warn(mechanism.context);
+            if (getBukkitEntityType() == EntityType.SKELETON) {
+                NMSHandler.entityHelper.setAggressive((Mob) getBukkitEntity(), mechanism.getValue().asBoolean());
+            }
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -174,7 +174,7 @@ public class BukkitImplDeprecations {
     public static Warning skeletonSwingArm = new SlowWarning("skeletonSwingArm", "The 'SKELETON_START/STOP_SWING_ARM' animations are deprecated in favor of the 'EntityTag.aggressive' property.");
     public static Warning entityArmsRaised = new SlowWarning("entityArmsRaised", "The 'EntityTag.arms_raised' property is deprecated in favor of 'EntityTag.aggressive'.");
 
-    // Added 2022/12/15
+    // Added 2022/12/16
     public static Warning entitySkeletonArmsRaised = new SlowWarning("entitySkeletonArmsRaised", "The 'EntityTag.skeleton_arms_raised' mechanism is deprecated in favor of 'EntityTag.aggressive'.");
 
     // ==================== VERY SLOW deprecations ====================

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -174,6 +174,9 @@ public class BukkitImplDeprecations {
     public static Warning skeletonSwingArm = new SlowWarning("skeletonSwingArm", "The 'SKELETON_START/STOP_SWING_ARM' animations are deprecated in favor of the 'EntityTag.aggressive' property.");
     public static Warning entityArmsRaised = new SlowWarning("entityArmsRaised", "The 'EntityTag.arms_raised' property is deprecated in favor of 'EntityTag.aggressive'.");
 
+    // Added 2022/12/15
+    public static Warning entitySkeletonArmsRaised = new SlowWarning("entitySkeletonArmsRaised", "The 'EntityTag.skeleton_arms_raised' mechanism is deprecated in favor of 'EntityTag.aggressive'.");
+
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.
 


### PR DESCRIPTION
## Changes

- Deprecates `EntityTag.skeleton_arms_raised`, a mechanism mirror of the deprecated `SKELETON_START/STOP_SWING_ARM` animations (see #2386), in favor of `EntityTag.aggressive`.
- The mechanism's code was modified to use `setAggressive` directly instead of the animations to avoid double deprecation warnings.

## Additions

- `BukkitImplDeprecations.entitySkeletonArmsRaised` - a deprecation warning for the `EntityTag.skeleton_arms_raised` mechanism.