### PR TITLE
`EnchantmentTag` and `PolygonTag` examples

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
@@ -200,7 +200,7 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // For vanilla enchantments, uses language translation keys.
         // @example
         // # Narrates "You don your Thorns III armor."
-        // # Note, that vanilla enchantments have a color applied to them, such as grey or red.
+        // # Note: vanilla enchantments have a color applied to them, such as grey or red.
         // - narrate "You don your <enchantment[thorns].full_name[3]><reset> armor."
         // -->
         tagProcessor.registerTag(ElementTag.class, "full_name", (attribute, object) -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
@@ -433,8 +433,8 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // Returns the damage bonus this enchantment applies against the given monster type.
         // The input is a MapTag with a level value and a monster type specified, where the type can be any of: ARTHROPOD, ILLAGER, WATER, UNDEAD, or UNDEFINED
         // @example
-        // # Narrates "With Bane of Arthropods 2, you get a damage bonus of 5!"
-        // - narrate "With Bane of Arthropods 2, you get a damage bonus of <enchantment[bane_of_arthropods].damage_bonus[level=2;type=arthropod]>!"
+        // # Narrates "With Bane of Arthropods 2, you get a damage bonus of 5 on arthropods!"
+        // - narrate "With Bane of Arthropods 2, you get a damage bonus of <enchantment[bane_of_arthropods].damage_bonus[level=2;type=arthropod]> on arthropods!"
         // -->
         tagProcessor.registerTag(ElementTag.class, MapTag.class, "damage_bonus", (attribute, object, map) -> {
             ElementTag level = map.getElement("level");
@@ -454,8 +454,8 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // The input is a MapTag with a level value and a damage type specified, where the damage type must be from <@link language Damage Cause>.
         // For entity damage causes, optionally specify the entity attacker.
         // @example
-        // # Narrates "With the Protection 3 enchantment, there is a damage protection of 3!"
-        // - narrate "With the Protection 3 enchantment, there is a damage protection of <enchantment[protection].damage_protection[level=3;type=fall]>!"
+        // # Narrates "With the Protection 3 enchantment, there is fall damage protection of 3!"
+        // - narrate "With the Protection 3 enchantment, there is fall damage protection of <enchantment[protection].damage_protection[level=3;type=fall]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, MapTag.class, "damage_protection", (attribute, object, map) -> {
             ElementTag level = map.getRequiredObjectAs("level", ElementTag.class, attribute);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
@@ -168,8 +168,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // For Denizen custom enchantments, returns the 'id' specified in the script.
         // For any other enchantments, returns the full key.
         // @example
-        // # Narrates "Wow, you have the protection enchantment!"
-        // - narrate "Wow, you have the <enchantment[protection].name> enchantment!"
+        // # This can narrate something like this:
+        // # "The item in your hand's first enchantment is sharpness!"
+        // - narrate "The item in your hand's first enchantment is <player.item_in_hand.enchantment_types.get[1].name||nothing>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
             return new ElementTag(object.getCleanName());
@@ -181,8 +182,8 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @description
         // Returns the full key for this enchantment, like "minecraft:sharpness".
         // @example
-        // # Narrates "The key for the protection enchantment is: minecraft:flame!"
-        // - narrate "The key for the protection enchantment is: <enchantment[flame].key>!"
+        // # Narrates "The key for the flame enchantment is: minecraft:flame!"
+        // - narrate "The key for the flame enchantment is: <enchantment[flame].key>!"
         // @example
         // # This example uses a custom Denizen enchantment.
         // # Narrates "The key for the my_enchantment enchantment is: denizen:my_enchantment!"
@@ -315,9 +316,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @description
         // Returns whether this enchantment is only considered to be a curse. Curses are removed at grindstones, and spread from crafting table repairs.
         // @example
-        // # In the case of the "loyalty" enchantment, this will narrate:
-        // # "Phew, this enchantment is not a curse!"
-        // - if <enchantment[loyalty].is_curse>:
+        // # In the case of the "vanishing_curse" enchantment, this will narrate:
+        // # "Watch out! This enchantment is a curse!"
+        // - if <enchantment[vanishing_curse].is_curse>:
         //     - narrate "Watch out! This enchantment is a curse!"
         // - else:
         //     - narrate "Phew, this enchantment is not a curse!"

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
@@ -167,6 +167,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // Gets the name of this enchantment. For vanilla enchantments, uses the vanilla name like 'sharpness'.
         // For Denizen custom enchantments, returns the 'id' specified in the script.
         // For any other enchantments, returns the full key.
+        // @example
+        // # Narrates "Wow, you have the protection enchantment!"
+        // - narrate "Wow, you have the <enchantment[protection].name> enchantment!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
             return new ElementTag(object.getCleanName());
@@ -177,6 +180,13 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag
         // @description
         // Returns the full key for this enchantment, like "minecraft:sharpness".
+        // @example
+        // # Narrates "The key for the protection enchantment is: minecraft:flame!"
+        // - narrate "The key for the protection enchantment is: <enchantment[flame].key>!"
+        // @example
+        // # This example uses a custom Denizen enchantment.
+        // # Narrates "The key for the my_enchantment enchantment is: denizen:my_enchantment!"
+        // - narrate "The key for the my_enchantment enchantment is: <enchantment[my_enchantment].key>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "key", (attribute, object) -> {
             return new ElementTag(object.enchantment.getKey().toString());
@@ -188,6 +198,10 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @description
         // Returns the full name for this enchantment for a given level, like "Sharpness V".
         // For vanilla enchantments, uses language translation keys.
+        // @example
+        // # Narrates "You don your Thorns III armor."
+        // # Note, that vanilla enchantments have a color applied to them, such as grey or red.
+        // - narrate "You don your <enchantment[thorns].full_name[3]><reset> armor."
         // -->
         tagProcessor.registerTag(ElementTag.class, "full_name", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -201,6 +215,10 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ScriptTag
         // @description
         // Returns the script that created this enchantment type, if any.
+        // @example
+        // # This can narrate something like this:
+        // # "The script used to create the my_enchantment enchantment is: my_enchantment_script"
+        // - narrate "The script used to create the my_enchantment enchantment is: <enchantment[my_enchantment].script.name>"
         // -->
         tagProcessor.registerTag(ScriptTag.class, "script", (attribute, object) -> {
             if (!object.enchantment.getKey().getNamespace().equals("denizen")) {
@@ -218,6 +236,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Number)
         // @description
         // Returns the minimum level of this enchantment. Usually '1'.
+        // @example
+        // # Narrates "The minimum enchantment level that you can get for Feather Falling is: 1!"
+        // - narrate "The minimum enchantment level that you can get for Feather Falling is: <enchantment[feather_falling].min_level>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "min_level", (attribute, object) -> {
             return new ElementTag(object.enchantment.getStartLevel());
@@ -228,6 +249,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Number)
         // @description
         // Returns the maximum level of this enchantment. Usually between 1 and 5.
+        // @example
+        // # Narrates "The maximum enchantment level that you can get for Feather Falling is: 4!"
+        // - narrate "The maximum enchantment level that you can get for Feather Falling is: <enchantment[feather_falling].max_level>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "max_level", (attribute, object) -> {
             return new ElementTag(object.enchantment.getMaxLevel());
@@ -238,6 +262,13 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Boolean)
         // @description
         // Returns whether this enchantment is only for spawning as treasure.
+        // @example
+        // # In the case of the "loyalty" enchantment, this will narrate:
+        // # "You cannot find this enchantment as treasure!"
+        // - if <enchantment[loyalty].treasure_only>:
+        //     - narrate "You can only find this enchantment as treasure!"
+        // - else:
+        //     - narrate "You cannot find this enchantment as treasure!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "treasure_only", (attribute, object) -> {
             return new ElementTag(object.enchantment.isTreasure());
@@ -248,6 +279,13 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Boolean)
         // @description
         // Returns whether this enchantment is only considered to be tradable. Villagers won't trade this enchantment if set to false.
+        // @example
+        // # In the case of the "loyalty" enchantment, this will narrate:
+        // # "Let's do some haggling to get this enchantment!"
+        // - if <enchantment[loyalty].is_tradable>:
+        //     - narrate "Let's do some haggling to get this enchantment!"
+        // - else:
+        //     - narrate "Villagers don't seem to want to trade this enchantment!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_tradable", (attribute, object) -> {
             return new ElementTag(NMSHandler.enchantmentHelper.isTradable(object.enchantment));
@@ -259,6 +297,13 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @description
         // Returns whether this enchantment is only considered to be discoverable.
         // If true, this will spawn from vanilla sources like the enchanting table. If false, it can only be given directly by script.
+        // @example
+        // # In the case of the "loyalty" enchantment, this will narrate:
+        // # "Time to do some discovering!"
+        // - if <enchantment[loyalty].is_discoverable>:
+        //     - narrate "Time to do some discovering!"
+        // - else:
+        //     - narrate "You'll have to be given this enchantment through a script!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_discoverable", (attribute, object) -> {
             return new ElementTag(NMSHandler.enchantmentHelper.isDiscoverable(object.enchantment));
@@ -269,6 +314,13 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Boolean)
         // @description
         // Returns whether this enchantment is only considered to be a curse. Curses are removed at grindstones, and spread from crafting table repairs.
+        // @example
+        // # In the case of the "loyalty" enchantment, this will narrate:
+        // # "Phew, this enchantment is not a curse!"
+        // - if <enchantment[loyalty].is_curse>:
+        //     - narrate "Watch out! This enchantment is a curse!"
+        // - else:
+        //     - narrate "Phew, this enchantment is not a curse!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_curse", (attribute, object) -> {
             return new ElementTag(NMSHandler.enchantmentHelper.isCurse(object.enchantment));
@@ -280,6 +332,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @description
         // Returns the category of this enchantment. Can be any of: ARMOR, ARMOR_FEET, ARMOR_LEGS, ARMOR_CHEST, ARMOR_HEAD,
         // WEAPON, DIGGER, FISHING_ROD, TRIDENT, BREAKABLE, BOW, WEARABLE, CROSSBOW, VANISHABLE
+        // @example
+        // # This narrates "The bane_of_arthropods enchantment is in the WEAPON category!"
+        // - narrate "The bane_of_arthropods enchantment is in the <enchantment[bane_of_arthropods].category> category!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "category", (attribute, object) -> {
             return new ElementTag(object.enchantment.getItemTarget());
@@ -290,6 +345,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag
         // @description
         // Returns the rarity of this enchantment. Can be any of: COMMON, UNCOMMON, RARE, VERY_RARE
+        // @example
+        // # This narrates "The infinity enchantment is VERY_RARE!"
+        // - narrate "The infinity enchantment is <enchantment[infinity].rarity>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "rarity", (attribute, object) -> {
             return new ElementTag(NMSHandler.enchantmentHelper.getRarity(object.enchantment));
@@ -301,6 +359,13 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @description
         // Returns whether this enchantment can enchant the given ItemTag (based on material mainly).
         // This is internally based on multiple factors, such as the enchantment's category and its own specific compatibility checks.
+        // @example
+        // # In the case of the "knockback" enchantment, this narrates
+        // # "You can apply the knockback enchantment in a diamond sword!"
+        // - if <enchantment[knockback].can_enchant[diamond_sword]>:
+        //     - narrate "You can apply the knockback enchantment in a diamond sword!"
+        // - else:
+        //     - narrate "You cannot apply the knockback enchantment in a diamond sword!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "can_enchant", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -314,6 +379,13 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Boolean)
         // @description
         // Returns whether this enchantment is compatible with another given enchantment.
+        // @example
+        // # In the case of the "silk_touch" and "mending" enchantments, this narrates
+        // # "These enchantments are compatible together!"
+        // - if <enchantment[silk_touch].is_compatible[mending]>:
+        //     - narrate "These enchantments are compatible together!"
+        // - else:
+        //     - narrate "These enchantments are not compatible with each other!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_compatible", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -327,6 +399,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Decimal)
         // @description
         // Returns the minimum cost for this enchantment for the given level.
+        // @example
+        // # This narrates "The minimum cost for the efficiency 3 enchantment is: 21!"
+        // - narrate "The minimum cost for the efficiency 3 enchantment is: <enchantment[efficiency].min_cost[3]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "min_cost", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -340,6 +415,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @returns ElementTag(Decimal)
         // @description
         // Returns the maximum cost for this enchantment for the given level.
+        // @example
+        // # This narrates "The maximum cost for the efficiency 3 enchantment is: 81!"
+        // - narrate "The maximum cost for the efficiency 3 enchantment is: <enchantment[efficiency].max_cost[3]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "max_cost", (attribute, object) -> {
             if (!attribute.hasParam()) {
@@ -354,7 +432,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // @description
         // Returns the damage bonus this enchantment applies against the given monster type.
         // The input is a MapTag with a level value and a monster type specified, where the type can be any of: ARTHROPOD, ILLAGER, WATER, UNDEAD, or UNDEFINED
-        // For example, <[my_enchantment].damage_bonus[level=3;type=undead]>
+        // @example
+        // # Narrates "With Bane of Arthropods 2, you get a damage bonus of 5!"
+        // - narrate "With Bane of Arthropods 2, you get a damage bonus of <enchantment[bane_of_arthropods].damage_bonus[level=2;type=arthropod]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, MapTag.class, "damage_bonus", (attribute, object, map) -> {
             ElementTag level = map.getElement("level");
@@ -373,7 +453,9 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
         // Returns the damage protection this enchantment applies against the given damage cause and optional attacker.
         // The input is a MapTag with a level value and a damage type specified, where the damage type must be from <@link language Damage Cause>.
         // For entity damage causes, optionally specify the entity attacker.
-        // For example, <[my_enchantment].damage_protection[level=3;type=undead]>
+        // @example
+        // # Narrates "With the Protection 3 enchantment, there is a damage protection of 3!"
+        // - narrate "With the Protection 3 enchantment, there is a damage protection of <enchantment[protection].damage_protection[level=3;type=fall]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, MapTag.class, "damage_protection", (attribute, object, map) -> {
             ElementTag level = map.getRequiredObjectAs("level", ElementTag.class, attribute);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PolygonTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PolygonTag.java
@@ -621,6 +621,10 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns ElementTag(Decimal)
         // @description
         // Returns the maximum Y level for this polygon.
+        // @example
+        // # For example, this might return something like:
+        // # "The maximum Y level for the polygon, 'my_polygon', is 73!"
+        // - narrate "The maximum Y level for the polygon, 'my_polygon', is <polygon[my_polygon].max_y>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "max_y", (attribute, polygon) -> {
             return new ElementTag(polygon.yMax);
@@ -631,6 +635,10 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns ElementTag(Decimal)
         // @description
         // Returns the minimum Y level for this polygon.
+        // @example
+        // # For example, this might return something like:
+        // # "The minimum Y level for the polygon, 'my_polygon', is 62!"
+        // - narrate "The minimum Y level for the polygon, 'my_polygon', is <polygon[my_polygon].min_y>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "min_y", (attribute, polygon) -> {
             return new ElementTag(polygon.yMin);
@@ -641,6 +649,10 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns ElementTag
         // @description
         // Gets the name of a noted PolygonTag. If the polygon isn't noted, this is null.
+        // @example
+        // # For example, this might return something like:
+        // # "The polygon you are currently in is noted as: my_polygon!"
+        // - narrate "The polygon you are currently in is noted as: <player.location.areas[polygons].first.note_name.if_null[null! You aren't in a polygon]>!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "note_name", (attribute, polygon) -> {
             String noteName = NoteManager.getSavedId(polygon);
@@ -655,6 +667,9 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns ListTag(LocationTag)
         // @description
         // Returns a list of the polygon's corners, as locations with Y coordinate set to the y-min value.
+        // @example
+        // # Displays a debugblock at each corner of the polygon "my_polygon".
+        // - debugblock <polygon[my_polygon].corners>
         // -->
         tagProcessor.registerTag(ListTag.class, "corners", (attribute, polygon) -> {
             ListTag list = new ListTag();
@@ -669,6 +684,9 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns PolygonTag
         // @description
         // Returns a copy of the polygon, with all coordinates shifted by the given location-vector.
+        // @example
+        // # Notes the polygon "my_polygon" as "my_shifted_polygon" but shifted over by 25,25,25.
+        // - note <polygon[my_polygon].shift[25,25,25]> as:my_shifted_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "shift", (attribute, polygon) -> {
             if (!attribute.hasParam()) {
@@ -696,6 +714,11 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @mechanism PolygonTag.add_corner
         // @description
         // Returns a copy of the polygon, with the specified corner added to the end of the corner list.
+        // @example
+        // # Notes a new polygon with a new corner added. If the new corner has a location of "10,66,-2",
+        // # and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon"
+        // # will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0"
+        // - note <polygon[my_polygon].with_corner[10,66,-2]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "with_corner", (attribute, polygon) -> {
             if (!attribute.hasParam()) {
@@ -715,6 +738,11 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns PolygonTag
         // @description
         // Returns a copy of the polygon, with the specified minimum-Y value.
+        // @example
+        // # Notes a new polygon from "my_polygon" with the minimum-Y value being 10.
+        // # For example, if "my_polygon" had a maximum-Y of 50 and a minimum-Y of 30, then
+        // # "my_new_polygon" will have a maximum-Y of 50 and a minimum-Y of 10.
+        // - note <polygon[my_polygon].with_y_min[10]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "with_y_min", (attribute, polygon) -> {
             if (!attribute.hasParam()) {
@@ -731,6 +759,11 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns PolygonTag
         // @description
         // Returns a copy of the polygon, with the specified maximum-Y value.
+        // @example
+        // # Notes a new polygon from "my_polygon" with the maximum-Y value being 10.
+        // # For example, if "my_polygon" had a maximum-Y of 50 and a minimum-Y of 30, then
+        // # "my_new_polygon" will have a maximum-Y of 70 and a minimum-Y of 30.
+        // - note <polygon[my_polygon].with_y_max[70]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "with_y_max", (attribute, polygon) -> {
             if (!attribute.hasParam()) {
@@ -747,6 +780,12 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns PolygonTag
         // @description
         // Returns a copy of the polygon, with the specified Y value included as part of the Y range (expanding the Y-min or Y-max as needed).
+        // @example
+        // # Notes "my_polygon" as "my_new_polygon" but with the player's Y location included in the Y range.
+        // # For example, if "my_polygon" has a maximum-Y of 80 and a minimum-Y of 60 and the player's Y location was 95,
+        // # then "my_new_polygon" will have a maximum-Y of 95 and a minimum-Y of 60. However, if the player's Y location
+        // # was 50, then the maximum-Y value would stay the same because that Y location is already included within the Y range.
+        // - note <polygon[my_polygon].include_y[<player.location.y>]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "include_y", (attribute, polygon) -> {
             if (!attribute.hasParam()) {
@@ -765,6 +804,9 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns ListTag(LocationTag)
         // @description
         // Returns a list of locations along the 2D outline of this polygon, at the specified Y level (roughly a block-width of separation between each).
+        // @example
+        // # Plays the "flame" effect along the 2D outline of the polygon, "my_polygon" at the player's Y location.
+        // - playeffect effect:flame at:<polygon[my_polygon].outline_2d[<player.location.y>]> offset:0.0
         // -->
         tagProcessor.registerTag(ListTag.class, "outline_2d", (attribute, polygon) -> {
             if (!attribute.hasParam()) {
@@ -782,6 +824,9 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @returns ListTag(LocationTag)
         // @description
         // Returns a list of locations along the 3D outline of this polygon (roughly a block-width of separation between each).
+        // @example
+        // # Plays the "flame" effect along the outline of the polygon, "my_polygon".
+        // - playeffect effect:flame at:<polygon[my_polygon].outline> offset:0.0
         // -->
         tagProcessor.registerTag(ListTag.class, "outline", (attribute, polygon) -> {
             return polygon.getOutline();
@@ -795,6 +840,11 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // Adds a corner to the end of the polygon's corner list.
         // @tags
         // <PolygonTag.with_corner[<location>]>
+        // @example
+        // # Adjusts the polygon to have a new corner added. If the new corner has a location of "10,66,-2",
+        // # and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon"
+        // # will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0"
+        // - adjust <polygon[my_polygon]> add_corner:10,66,-2
         // -->
         tagProcessor.registerMechanism("add_corner", false, LocationTag.class, (object, mechanism, location) -> {
             if (object.noteName != null) {
@@ -814,6 +864,11 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @description
         // Returns a boolean indicating whether the specified location is inside this polygon.
         // Uses block-inclusive containment: contains a wider section of blocks along the edge (this mode is equivalent to WorldEdit's block selection).
+        // @example
+        // - if <polygon[my_polygon].contains_inclusive[<player.location>]>:
+        //     - narrate "The player's location is contained within the polygon!"
+        // - else:
+        //     - narrate "The player's location is not contained within the polygon!"
         // -->
         tagProcessor.registerTag(ElementTag.class, LocationTag.class, "contains_inclusive", (attribute, polygon, loc) -> {
             return new ElementTag(polygon.containsInclusive(loc));
@@ -826,6 +881,9 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // Returns each block location within the polygon.
         // Optionally, specify a material matcher to only return locations with that block type.
         // Uses block-inclusive containment: contains a wider section of blocks along the edge (this mode is equivalent to WorldEdit's block selection).
+        // @example
+        // # Displays a debugblock at each block of wool contained within the polygon "my_polygon".
+        // - debugblock <polygon[my_polygon].blocks_inclusive[*wool]>
         // -->
         tagProcessor.registerTag(ListTag.class, "blocks_inclusive", (attribute, polygon) -> {
             if (attribute.hasParam()) {
@@ -848,6 +906,9 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @description
         // Returns each block location on the 3D outer shell of the polygon.
         // Uses block-inclusive containment: contains a wider section of blocks along the edge (this mode is equivalent to WorldEdit's block selection).
+        // @example
+        // # Plays the "flame" effect at the outer 3D shell of the polygon "my_polygon".
+        // - playeffect effect:flame at:<polygon[my_polygon].shell_inclusive> offset:0.0
         // -->
         tagProcessor.registerTag(ListTag.class, "shell_inclusive", (attribute, polygon) -> {
             return polygon.getShellInternal(true);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PolygonTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PolygonTag.java
@@ -715,9 +715,7 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @description
         // Returns a copy of the polygon, with the specified corner added to the end of the corner list.
         // @example
-        // # Notes a new polygon with a new corner added. If the new corner has a location of "10,66,-2",
-        // # and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon"
-        // # will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0"
+        // # Notes a new polygon with a new corner added. If the new corner has a location of "10,66,-2", and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon" will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0".
         // - note <polygon[my_polygon].with_corner[10,66,-2]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "with_corner", (attribute, polygon) -> {
@@ -740,8 +738,7 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // Returns a copy of the polygon, with the specified minimum-Y value.
         // @example
         // # Notes a new polygon from "my_polygon" with the minimum-Y value being 10.
-        // # For example, if "my_polygon" had a maximum-Y of 50 and a minimum-Y of 30, then
-        // # "my_new_polygon" will have a maximum-Y of 50 and a minimum-Y of 10.
+        // # For example, if "my_polygon" had a maximum-Y of 50 and a minimum-Y of 30, then "my_new_polygon" will have a maximum-Y of 50 and a minimum-Y of 10.
         // - note <polygon[my_polygon].with_y_min[10]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "with_y_min", (attribute, polygon) -> {
@@ -761,8 +758,7 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // Returns a copy of the polygon, with the specified maximum-Y value.
         // @example
         // # Notes a new polygon from "my_polygon" with the maximum-Y value being 10.
-        // # For example, if "my_polygon" had a maximum-Y of 50 and a minimum-Y of 30, then
-        // # "my_new_polygon" will have a maximum-Y of 70 and a minimum-Y of 30.
+        // # For example, if "my_polygon" had a maximum-Y of 50 and a minimum-Y of 30, then "my_new_polygon" will have a maximum-Y of 70 and a minimum-Y of 30.
         // - note <polygon[my_polygon].with_y_max[70]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "with_y_max", (attribute, polygon) -> {
@@ -782,9 +778,8 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // Returns a copy of the polygon, with the specified Y value included as part of the Y range (expanding the Y-min or Y-max as needed).
         // @example
         // # Notes "my_polygon" as "my_new_polygon" but with the player's Y location included in the Y range.
-        // # For example, if "my_polygon" has a maximum-Y of 80 and a minimum-Y of 60 and the player's Y location was 95,
-        // # then "my_new_polygon" will have a maximum-Y of 95 and a minimum-Y of 60. However, if the player's Y location
-        // # was 50, then the maximum-Y value would stay the same because that Y location is already included within the Y range.
+        // # For example, if "my_polygon" has a maximum-Y of 80 and a minimum-Y of 60 and the player's Y location was 95, then "my_new_polygon" will have a maximum-Y of 95 and a minimum-Y of 60.
+        // # However, if the player's Y location was 50, then the maximum-Y value would stay the same and the minimum-Y value would change to 50 instead.
         // - note <polygon[my_polygon].include_y[<player.location.y>]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "include_y", (attribute, polygon) -> {
@@ -841,9 +836,8 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @tags
         // <PolygonTag.with_corner[<location>]>
         // @example
-        // # Adjusts the polygon to have a new corner added. If the new corner has a location of "10,66,-2",
-        // # and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon"
-        // # will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0"
+        // # Adjusts the polygon to have a new corner added.
+        // # If the new corner has a location of "10,66,-2", and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon" will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0".
         // - adjust <polygon[my_polygon]> add_corner:10,66,-2
         // -->
         tagProcessor.registerMechanism("add_corner", false, LocationTag.class, (object, mechanism, location) -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PolygonTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PolygonTag.java
@@ -715,7 +715,8 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // @description
         // Returns a copy of the polygon, with the specified corner added to the end of the corner list.
         // @example
-        // # Notes a new polygon with a new corner added. If the new corner has a location of "10,66,-2", and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon" will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0".
+        // # Notes a new polygon with a new corner added. If the new corner has a location of "10,66,-2", and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0",
+        // # then "my_new_polygon" will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0".
         // - note <polygon[my_polygon].with_corner[10,66,-2]> as:my_new_polygon
         // -->
         tagProcessor.registerTag(PolygonTag.class, "with_corner", (attribute, polygon) -> {
@@ -778,7 +779,8 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // Returns a copy of the polygon, with the specified Y value included as part of the Y range (expanding the Y-min or Y-max as needed).
         // @example
         // # Notes "my_polygon" as "my_new_polygon" but with the player's Y location included in the Y range.
-        // # For example, if "my_polygon" has a maximum-Y of 80 and a minimum-Y of 60 and the player's Y location was 95, then "my_new_polygon" will have a maximum-Y of 95 and a minimum-Y of 60.
+        // # For example, if "my_polygon" has a maximum-Y of 80 and a minimum-Y of 60,
+        // # and the player's Y location was 95, then "my_new_polygon" will have a maximum-Y of 95 and a minimum-Y of 60.
         // # However, if the player's Y location was 50, then the maximum-Y value would stay the same and the minimum-Y value would change to 50 instead.
         // - note <polygon[my_polygon].include_y[<player.location.y>]> as:my_new_polygon
         // -->
@@ -837,7 +839,8 @@ public class PolygonTag implements ObjectTag, Cloneable, Notable, Adjustable, Ar
         // <PolygonTag.with_corner[<location>]>
         // @example
         // # Adjusts the polygon to have a new corner added.
-        // # If the new corner has a location of "10,66,-2", and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0", then "my_new_polygon" will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0".
+        // # If the new corner has a location of "10,66,-2", and "my_polygon" has corners "0.0,0.0", "7.0,7.0", and "-5.0,6.0",
+        // # then "my_new_polygon" will have corners  "0.0,0.0", "7.0,7.0", "-5.0,6.0", and "10.0,-2.0".
         // - adjust <polygon[my_polygon]> add_corner:10,66,-2
         // -->
         tagProcessor.registerMechanism("add_corner", false, LocationTag.class, (object, mechanism, location) -> {


### PR DESCRIPTION
### Adds tag and mechanism examples for `EnchantmentTag` and `PolygonTag`.

Note: Jumps all the way to `PolygonTag` because it was getting lonely being the only `AreaObject` related tag to not have examples yet.