### PR TITLE
`EntityTag.charged` - Guardian laser support

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCharged.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityCharged.java
@@ -74,10 +74,10 @@ public class EntityCharged implements Property {
         // @name charged
         // @input ElementTag(Boolean)
         // @description
-        // If the entity is wither_skull, changes whether the skull is charged. Charged skulls are blue.
-        // If the entity is a vex, changes whether the vex is charging. Charging vexes have red lines.
+        // If the entity is wither_skull, sets whether the skull is charged. Charged skulls are blue.
+        // If the entity is a vex, sets whether the vex is charging. Charging vexes have red lines.
         // This is a visual effect, and does not cause the vex to actually charge at anyone.
-        // If the entity is a guardian, returns whether the guardian's laser is active.
+        // If the entity is a guardian, sets whether the guardian's laser is active.
         // Note that guardians require a target to use their laser, see <@link command attack>.
         // @tags
         // <EntityTag.charged>


### PR DESCRIPTION
## Changes

- `EntityTag.charged` now supports setting whether a guardian's laser is active.
- Updated `EntityCharged` to modern mechanism registration.