### PR TITLE
Fix `sendEntityMetadataFlagsUpdate` on 1.19.3

### DIFF
--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
@@ -340,9 +340,10 @@ public class PacketHelperImpl implements PacketHelper {
 
     @Override
     public void sendEntityMetadataFlagsUpdate(Player player, Entity entity) {
-        SynchedEntityData dw = new SynchedEntityData(null);
-        dw.define(ENTITY_DATA_WATCHER_FLAGS, ((CraftEntity) entity).getHandle().getEntityData().get(ENTITY_DATA_WATCHER_FLAGS));
-        send(player, new ClientboundSetEntityDataPacket(entity.getEntityId(), dw.packDirty()));
+        byte flags = ((CraftEntity) entity).getHandle().getEntityData().get(ENTITY_DATA_WATCHER_FLAGS);
+        List<SynchedEntityData.DataValue<?>> data = new ArrayList<>();
+        data.add(SynchedEntityData.DataValue.create(ENTITY_DATA_WATCHER_FLAGS, flags));
+        send(player, new ClientboundSetEntityDataPacket(entity.getEntityId(), data));
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
@@ -340,8 +340,8 @@ public class PacketHelperImpl implements PacketHelper {
 
     @Override
     public void sendEntityMetadataFlagsUpdate(Player player, Entity entity) {
-        byte flags = ((CraftEntity) entity).getHandle().getEntityData().get(ENTITY_DATA_WATCHER_FLAGS);
         List<SynchedEntityData.DataValue<?>> data = new ArrayList<>();
+        byte flags = ((CraftEntity) entity).getHandle().getEntityData().get(ENTITY_DATA_WATCHER_FLAGS);
         data.add(SynchedEntityData.DataValue.create(ENTITY_DATA_WATCHER_FLAGS, flags));
         send(player, new ClientboundSetEntityDataPacket(entity.getEntityId(), data));
     }


### PR DESCRIPTION
## Explanation
Previously, it added the entity's metadata flags into a new `SynchedEntityData`, then used a `ClientboundSetEntityDataPacket` constructor which took a boolean (that determined whether the packet should send all data or just data marked as dirty) with `true` (I.e. all data was sent).
On 1.19.3 that system had a few modifications, including changing the packet constructor to take the data directly instead of taking a `SynchedEntityData`. The code was then updated to use `SynchedEntityData#packDirty`, which returns a list of all data marked as dirty, or `null` if none is - as the data wasn't marked as dirty, packets with null lists were sent.

## Changes

- Now skips the `SynchedEntityData` entirely, and just gets the data from the entity, constructs a new list with it, and sends the packet with that, which should be identical to the old behavior.