### PR TITLE
Add `context.original_damage` to `PlayerItemTakesDamage`

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -48,6 +48,7 @@ public class PaperModule {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             ScriptEvent.registerScriptEvent(PlayerInventorySlotChangeScriptEvent.class);
         }
+        ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerJumpsScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesGrindstoneCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSelectsStonecutterRecipeScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerItemTakesDamageScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerItemTakesDamageScriptEventPaperImpl.java
@@ -1,0 +1,18 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.player.PlayerItemTakesDamageScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+
+public class PlayerItemTakesDamageScriptEventPaperImpl extends PlayerItemTakesDamageScriptEvent {
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "original_damage": return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) ? new ElementTag(event.getOriginalDamage()) : null;
+        }
+        return super.getContext(name);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -192,7 +192,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerHearsSoundScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerHoldsItemEvent.class);
         ScriptEvent.registerScriptEvent(PlayerIncreasesExhaustionLevelScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEvent.class);
+        if (!Denizen.supportsPaper) {
+            ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerJoinsScriptEvent.class);
         if (!Denizen.supportsPaper) {
             ScriptEvent.registerScriptEvent(PlayerJumpScriptEvent.PlayerJumpsSpigotScriptEventImpl.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
@@ -34,7 +34,7 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
     //
     // @Context
     // <context.damage> returns the amount of damage the item has taken.
-    // <context.original_damage> returns the original amount of damage the item would have taken, before any modifications (such as the unbreaking enchantment).
+    // <context.original_damage> returns the original amount of damage the item would have taken, before any modifications such as the unbreaking enchantment (only on Paper).
     // <context.item> returns the item that has taken damage.
     // <context.slot> returns the slot of the item that has taken damage. This value is a bit of a hack and is not reliable.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerItemTakesDamageScriptEvent.java
@@ -1,14 +1,14 @@
 package com.denizenscript.denizen.events.player;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -34,6 +34,7 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
     //
     // @Context
     // <context.damage> returns the amount of damage the item has taken.
+    // <context.original_damage> returns the original amount of damage the item would have taken, before any modifications (such as the unbreaking enchantment).
     // <context.item> returns the item that has taken damage.
     // <context.slot> returns the slot of the item that has taken damage. This value is a bit of a hack and is not reliable.
     //
@@ -48,7 +49,7 @@ public class PlayerItemTakesDamageScriptEvent extends BukkitScriptEvent implemen
         registerCouldMatcher("player <item> takes damage");
     }
 
-    PlayerItemDamageEvent event;
+    public PlayerItemDamageEvent event;
     ItemTag item;
     LocationTag location;
 


### PR DESCRIPTION
## Additions

- `<context.original_damage>` - returns the original amount of damage the item would have taken before any modifications.
- `PlayerItemTakesDamageScriptEventPaperImpl` - a Paper impl of `PlayerItemTakesDamageScriptEvent`.

## Notes

- Tested on `1.19.3` Paper + Spigot, and `1.16.5` Paper