### PR TITLE
Update NPC Metadata usage

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SittingTrait.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SittingTrait.java
@@ -258,8 +258,8 @@ public class SittingTrait extends Trait implements Listener {
         trait.setSmall(true);
         trait.setMarker(true);
         trait.setVisible(false);
-        holder.data().set(NPC.NAMEPLATE_VISIBLE_METADATA, false);
-        holder.data().set(NPC.DEFAULT_PROTECTED_METADATA, true);
+        holder.data().set(NPC.Metadata.NAMEPLATE_VISIBLE, false);
+        holder.data().set(NPC.Metadata.DEFAULT_PROTECTED, true);
         boolean spawned = holder.spawn(location);
         if (!spawned || !holder.isSpawned()) {
             if (retryCount >= 4) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -1959,7 +1959,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // -->
         registerSpawnedOnlyTag(ElementTag.class, "is_collidable", (attribute, object) -> {
             if (object.isCitizensNPC()) {
-                return new ElementTag(object.getDenizenNPC().getCitizen().data().get(NPC.COLLIDABLE_METADATA, true));
+                return new ElementTag(object.getDenizenNPC().getCitizen().data().get(NPC.Metadata.COLLIDABLE, true));
             }
             return new ElementTag(object.getLivingEntity().isCollidable());
         });
@@ -3387,7 +3387,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // -->
         if (mechanism.matches("collidable") && mechanism.requireBoolean()) {
             if (isCitizensNPC()) {
-                getDenizenNPC().getCitizen().data().setPersistent(NPC.COLLIDABLE_METADATA, mechanism.getValue().asBoolean());
+                getDenizenNPC().getCitizen().data().setPersistent(NPC.Metadata.COLLIDABLE, mechanism.getValue().asBoolean());
             }
             else {
                 getLivingEntity().setCollidable(mechanism.getValue().asBoolean());
@@ -3547,7 +3547,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         if (mechanism.matches("glowing") && mechanism.requireBoolean()) {
             getBukkitEntity().setGlowing(mechanism.getValue().asBoolean());
             if (Depends.citizens != null && CitizensAPI.getNPCRegistry().isNPC(getLivingEntity())) {
-                CitizensAPI.getNPCRegistry().getNPC(getLivingEntity()).data().setPersistent(NPC.GLOWING_METADATA, mechanism.getValue().asBoolean());
+                CitizensAPI.getNPCRegistry().getNPC(getLivingEntity()).data().setPersistent(NPC.Metadata.GLOWING, mechanism.getValue().asBoolean());
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
@@ -800,7 +800,7 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // See <@link command vulnerable>
         // -->
         tagProcessor.registerTag(ElementTag.class, "invulnerable", (attribute, object) -> {
-            return new ElementTag(object.getCitizen().data().get(NPC.DEFAULT_PROTECTED_METADATA, true));
+            return new ElementTag(object.getCitizen().data().get(NPC.Metadata.DEFAULT_PROTECTED, true));
         }, "vulnerable");
 
         // <--[tag]
@@ -980,7 +980,7 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // Returns whether the NPC is targetable.
         // -->
         tagProcessor.registerTag(ElementTag.class, "targetable", (attribute, object) -> {
-            boolean targetable = object.getCitizen().data().get(NPC.TARGETABLE_METADATA, object.getCitizen().data().get(NPC.DEFAULT_PROTECTED_METADATA, true));
+            boolean targetable = object.getCitizen().data().get(NPC.Metadata.TARGETABLE, object.getCitizen().data().get(NPC.Metadata.DEFAULT_PROTECTED, true));
             return new ElementTag(targetable);
         });
 
@@ -1577,8 +1577,8 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
                     ((ItemFrame) getEntity()).getItem().setType(mat);
                     break;
                 case FALLING_BLOCK:
-                    getCitizen().data().setPersistent(NPC.ITEM_ID_METADATA, mat.name());
-                    getCitizen().data().setPersistent(NPC.ITEM_DATA_METADATA, 0);
+                    getCitizen().data().setPersistent(NPC.Metadata.ITEM_ID, mat.name());
+                    getCitizen().data().setPersistent(NPC.Metadata.ITEM_DATA, 0);
                     break;
                 default:
                     Debug.echoError("NPC is the not an item type!");
@@ -1715,7 +1715,7 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // <NPCTag.targetable>
         // -->
         if (mechanism.matches("targetable") && mechanism.requireBoolean()) {
-            getCitizen().data().setPersistent(NPC.TARGETABLE_METADATA, mechanism.getValue().asBoolean());
+            getCitizen().data().setPersistent(NPC.Metadata.TARGETABLE, mechanism.getValue().asBoolean());
         }
 
         // <--[mechanism]
@@ -1807,7 +1807,7 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // TODO
         // -->
         if (mechanism.matches("name_visible")) {
-            getCitizen().data().setPersistent(NPC.NAMEPLATE_VISIBLE_METADATA, mechanism.getValue().asString());
+            getCitizen().data().setPersistent(NPC.Metadata.NAMEPLATE_VISIBLE, mechanism.getValue().asString());
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
@@ -163,7 +163,7 @@ public class EntityItem implements Property {
         if (mechanism.matches("item") && mechanism.requireObject(ItemTag.class)) {
             ItemStack itemStack = mechanism.valueAsType(ItemTag.class).getItemStack();
             if (item.isCitizensNPC()) {
-                item.getDenizenNPC().getCitizen().data().setPersistent(NPC.ITEM_ID_METADATA, itemStack.getType().name());
+                item.getDenizenNPC().getCitizen().data().setPersistent(NPC.Metadata.ITEM_ID, itemStack.getType().name());
             }
             if (isDroppedItem()) {
                 getDroppedItem().setItemStack(itemStack);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/GlowCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/GlowCommand.java
@@ -102,7 +102,7 @@ public class GlowCommand extends AbstractCommand {
         final UUID puuid = Utilities.getEntryPlayer(scriptEntry).getUUID();
         for (EntityTag ent : entities) {
             if (Depends.citizens != null && CitizensAPI.getNPCRegistry().isNPC(ent.getLivingEntity())) {
-                CitizensAPI.getNPCRegistry().getNPC(ent.getLivingEntity()).data().setPersistent(NPC.GLOWING_METADATA, shouldGlow);
+                CitizensAPI.getNPCRegistry().getNPC(ent.getLivingEntity()).data().setPersistent(NPC.Metadata.GLOWING, shouldGlow);
             }
             if (shouldGlow) {
                 HashSet<UUID> players = glowViewers.computeIfAbsent(ent.getLivingEntity().getEntityId(), k -> new HashSet<>());


### PR DESCRIPTION
## Explanation
See https://github.com/CitizensDev/CitizensAPI/commit/f8f3d101c1078e4d7774d3c805061ffc79ca3593#diff-011b9d18b3e9f51f2389cd606b104527fc5c2fb229278bba62d2546a732ad02cL577-L695, and the matching https://github.com/CitizensDev/Citizens2/commit/b8e79b20cffe5e601ceeecad7e11875767014481.

## Changes

- Replaces old Citizens metadata strings with the `Metadata` enum.