### PR TITLE
Support brewing recipes in tags

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -5,12 +5,12 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.IntArrayTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.inventory.BrewingRecipe;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
 
 import java.util.List;
@@ -75,18 +75,6 @@ public abstract class ItemHelper {
     }
 
     public abstract boolean isValidMix(ItemStack input, ItemStack ingredient);
-
-    public static class BrewingRecipe {
-        public RecipeChoice input;
-        public RecipeChoice ingredient;
-        public ItemStack result;
-
-        public BrewingRecipe(RecipeChoice ingredient, RecipeChoice input, ItemStack result) {
-            this.ingredient = ingredient;
-            this.input = input;
-            this.result = result;
-        }
-    }
 
     public Map<NamespacedKey, BrewingRecipe> getCustomBrewingRecipes() {
         throw new UnsupportedOperationException();

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -10,9 +10,12 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public abstract class ItemHelper {
@@ -72,4 +75,28 @@ public abstract class ItemHelper {
     }
 
     public abstract boolean isValidMix(ItemStack input, ItemStack ingredient);
+
+    public static class BrewingRecipe {
+        public RecipeChoice input;
+        public RecipeChoice ingredient;
+        public ItemStack result;
+
+        public BrewingRecipe(RecipeChoice ingredient, RecipeChoice input, ItemStack result) {
+            this.ingredient = ingredient;
+            this.input = input;
+            this.result = result;
+        }
+    }
+
+    public Map<NamespacedKey, BrewingRecipe> getCustomBrewingRecipes() {
+        throw new UnsupportedOperationException();
+    }
+
+    public Set<NamespacedKey> getCustomBrewingRecipeIDs() {
+        throw new UnsupportedOperationException();
+    }
+
+    public BrewingRecipe getCustomBrewingRecipe(NamespacedKey recipeKey) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -4,7 +4,6 @@ import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
-import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.jnbt.StringTag;
 import com.denizenscript.denizen.objects.properties.item.*;
 import com.denizenscript.denizen.scripts.containers.core.BookScriptContainer;
@@ -12,6 +11,7 @@ import com.denizenscript.denizen.scripts.containers.core.ItemScriptContainer;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
 import com.denizenscript.denizen.tags.BukkitTagContext;
 import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.inventory.BrewingRecipe;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
@@ -716,7 +716,7 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
                 }
             }
             if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) && (type == null || type.equals("brewing"))) {
-                for (Map.Entry<NamespacedKey, ItemHelper.BrewingRecipe> entry : NMSHandler.itemHelper.getCustomBrewingRecipes().entrySet()) {
+                for (Map.Entry<NamespacedKey, BrewingRecipe> entry : NMSHandler.itemHelper.getCustomBrewingRecipes().entrySet()) {
                     ItemStack result = entry.getValue().result;
                     if (object.getBukkitMaterial() == result.getType() && (object.getItemStack().getDurability() == -1 || object.getItemStack().getDurability() == result.getDurability())) {
                         addRecipe.accept(entry.getKey());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -708,8 +708,8 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
             };
             if (type == null || !type.equals("brewing")) {
                 for (Recipe recipe : Bukkit.getRecipesFor(object.getItemStack())) {
-                    if (recipe instanceof Keyed keyed && Utilities.isRecipeOfType(recipe, type)) {
-                        addRecipe.accept(keyed.getKey());
+                    if (recipe instanceof Keyed keyedRecipe && Utilities.isRecipeOfType(recipe, type)) {
+                        addRecipe.accept(keyedRecipe.getKey());
                     }
                 }
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -707,10 +707,7 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
             };
             if (type == null || !type.equals("brewing")) {
                 for (Recipe recipe : Bukkit.getRecipesFor(object.getItemStack())) {
-                    if (!Utilities.isRecipeOfType(recipe, type)) {
-                        continue;
-                    }
-                    if (recipe instanceof Keyed) {
+                    if (recipe instanceof Keyed && Utilities.isRecipeOfType(recipe, type)) {
                         addRecipe.accept(((Keyed) recipe).getKey());
                     }
                 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -687,14 +687,15 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
         // If the item is a scripted item, returns a list of all recipe IDs created by the item script.
         // Others, returns a list of all recipe IDs that the server lists as capable of crafting the item.
         // Returns a list in the Namespace:Key format, for example "minecraft:gold_nugget".
-        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, STONECUTTING, BREWING)
+        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, STONECUTTING, BREWING (only on Paper))
         // to limit to just recipes of that type.
+        // For Brewing recipes, only custom ones are available.
         // -->
         tagProcessor.registerTag(ListTag.class, "recipe_ids", (attribute, object) -> {
             String type = attribute.hasParam() ? CoreUtilities.toLowerCase(attribute.getParam()) : null;
             ItemScriptContainer container = ItemScriptHelper.getItemScriptContainer(object.getItemStack());
             ListTag list = new ListTag();
-            Consumer<NamespacedKey> addRecipe = recipe -> {
+            Consumer<NamespacedKey> addRecipe = (recipe) -> {
                 if (CoreUtilities.equalsIgnoreCase(recipe.getNamespace(), "denizen")) {
                     if (container != ItemScriptHelper.recipeIdToItemScript.get(recipe.toString())) {
                         return;
@@ -707,8 +708,8 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
             };
             if (type == null || !type.equals("brewing")) {
                 for (Recipe recipe : Bukkit.getRecipesFor(object.getItemStack())) {
-                    if (recipe instanceof Keyed && Utilities.isRecipeOfType(recipe, type)) {
-                        addRecipe.accept(((Keyed) recipe).getKey());
+                    if (recipe instanceof Keyed keyed && Utilities.isRecipeOfType(recipe, type)) {
+                        addRecipe.accept(keyed.getKey());
                     }
                 }
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -687,9 +687,9 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
         // If the item is a scripted item, returns a list of all recipe IDs created by the item script.
         // Others, returns a list of all recipe IDs that the server lists as capable of crafting the item.
         // Returns a list in the Namespace:Key format, for example "minecraft:gold_nugget".
-        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, STONECUTTING, BREWING (only on Paper))
+        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, STONECUTTING, BREWING)
         // to limit to just recipes of that type.
-        // For Brewing recipes, only custom ones are available.
+        // Brewing recipes are only supported on Paper, and only custom ones are available.
         // -->
         tagProcessor.registerTag(ListTag.class, "recipe_ids", (attribute, object) -> {
             String type = attribute.hasParam() ? CoreUtilities.toLowerCase(attribute.getParam()) : null;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -1,31 +1,34 @@
 package com.denizenscript.denizen.objects;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizen.nms.interfaces.ItemHelper;
+import com.denizenscript.denizen.nms.util.jnbt.StringTag;
 import com.denizenscript.denizen.objects.properties.item.*;
 import com.denizenscript.denizen.scripts.containers.core.BookScriptContainer;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptContainer;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
+import com.denizenscript.denizen.tags.BukkitTagContext;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.flags.MapTagFlagTracker;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.utilities.CoreConfiguration;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.util.jnbt.StringTag;
-import com.denizenscript.denizen.tags.BukkitTagContext;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.scripts.ScriptRegistry;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.debugging.Debuggable;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
@@ -34,7 +37,8 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.*;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -43,6 +47,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
@@ -682,28 +687,40 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
         // If the item is a scripted item, returns a list of all recipe IDs created by the item script.
         // Others, returns a list of all recipe IDs that the server lists as capable of crafting the item.
         // Returns a list in the Namespace:Key format, for example "minecraft:gold_nugget".
-        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, STONECUTTING)
+        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, STONECUTTING, BREWING)
         // to limit to just recipes of that type.
         // -->
         tagProcessor.registerTag(ListTag.class, "recipe_ids", (attribute, object) -> {
             String type = attribute.hasParam() ? CoreUtilities.toLowerCase(attribute.getParam()) : null;
             ItemScriptContainer container = ItemScriptHelper.getItemScriptContainer(object.getItemStack());
             ListTag list = new ListTag();
-            for (Recipe recipe : Bukkit.getRecipesFor(object.getItemStack())) {
-                if (!Utilities.isRecipeOfType(recipe, type)) {
-                    continue;
-                }
-                if (recipe instanceof Keyed) {
-                    NamespacedKey key = ((Keyed) recipe).getKey();
-                    if (key.getNamespace().equalsIgnoreCase("denizen")) {
-                        if (container != ItemScriptHelper.recipeIdToItemScript.get(key.toString())) {
-                            continue;
-                        }
+            Consumer<NamespacedKey> addRecipe = recipe -> {
+                if (CoreUtilities.equalsIgnoreCase(recipe.getNamespace(), "denizen")) {
+                    if (container != ItemScriptHelper.recipeIdToItemScript.get(recipe.toString())) {
+                        return;
                     }
-                    else if (container != null) {
+                }
+                else if (container != null) {
+                    return;
+                }
+                list.add(recipe.toString());
+            };
+            if (type == null || !type.equals("brewing")) {
+                for (Recipe recipe : Bukkit.getRecipesFor(object.getItemStack())) {
+                    if (!Utilities.isRecipeOfType(recipe, type)) {
                         continue;
                     }
-                    list.add(key.toString());
+                    if (recipe instanceof Keyed) {
+                        addRecipe.accept(((Keyed) recipe).getKey());
+                    }
+                }
+            }
+            if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) && (type == null || type.equals("brewing"))) {
+                for (Map.Entry<NamespacedKey, ItemHelper.BrewingRecipe> entry : NMSHandler.itemHelper.getCustomBrewingRecipes().entrySet()) {
+                    ItemStack result = entry.getValue().result;
+                    if (object.getBukkitMaterial() == result.getType() && (object.getItemStack().getDurability() == -1 || object.getItemStack().getDurability() == result.getDurability())) {
+                        addRecipe.accept(entry.getKey());
+                    }
                 }
             }
             return list;

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -226,8 +226,8 @@ public class ServerTagBase {
                 }
             }
             if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) && (type == null || type.equals("brewing"))) {
-                for (NamespacedKey recipe : NMSHandler.itemHelper.getCustomBrewingRecipeIDs()) {
-                    list.add(recipe.toString());
+                for (NamespacedKey brewingRecipe : NMSHandler.itemHelper.getCustomBrewingRecipeIDs()) {
+                    list.add(brewingRecipe.toString());
                 }
             }
             event.setReplacedObject(list.getObjectAttribute(attribute.fulfill(1)));

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -4,7 +4,6 @@ import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
-import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.npc.traits.AssignmentTrait;
 import com.denizenscript.denizen.objects.*;
 import com.denizenscript.denizen.scripts.commands.server.BossBarCommand;
@@ -12,6 +11,7 @@ import com.denizenscript.denizen.scripts.containers.core.AssignmentScriptContain
 import com.denizenscript.denizen.scripts.containers.core.CommandScriptHelper;
 import com.denizenscript.denizen.utilities.*;
 import com.denizenscript.denizen.utilities.depends.Depends;
+import com.denizenscript.denizen.utilities.inventory.BrewingRecipe;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.events.ScriptEvent;
@@ -246,7 +246,7 @@ public class ServerTagBase {
         if (attribute.startsWith("recipe_items") && attribute.hasParam()) {
             NamespacedKey recipeKey = Utilities.parseNamespacedKey(attribute.getParam());
             Recipe recipe = Bukkit.getRecipe(recipeKey);
-            ItemHelper.BrewingRecipe brewingRecipe = Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) ? NMSHandler.itemHelper.getCustomBrewingRecipe(recipeKey) : null;
+            BrewingRecipe brewingRecipe = Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) ? NMSHandler.itemHelper.getCustomBrewingRecipe(recipeKey) : null;
             if (recipe == null && brewingRecipe == null) {
                 return;
             }
@@ -334,7 +334,7 @@ public class ServerTagBase {
             Recipe recipe = Bukkit.getRecipe(recipeKey);
             if (recipe == null) {
                 if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
-                    ItemHelper.BrewingRecipe brewingRecipe = NMSHandler.itemHelper.getCustomBrewingRecipe(recipeKey);
+                    BrewingRecipe brewingRecipe = NMSHandler.itemHelper.getCustomBrewingRecipe(recipeKey);
                     if (brewingRecipe != null) {
                         event.setReplacedObject(new ItemTag(brewingRecipe.result).getObjectAttribute(attribute.fulfill(1)));
                     }

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -1,34 +1,38 @@
 package com.denizenscript.denizen.tags.core;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizen.nms.interfaces.ItemHelper;
+import com.denizenscript.denizen.npc.traits.AssignmentTrait;
 import com.denizenscript.denizen.objects.*;
 import com.denizenscript.denizen.scripts.commands.server.BossBarCommand;
 import com.denizenscript.denizen.scripts.containers.core.AssignmentScriptContainer;
 import com.denizenscript.denizen.scripts.containers.core.CommandScriptHelper;
 import com.denizenscript.denizen.utilities.*;
-import com.denizenscript.denizencore.objects.notable.NoteManager;
-import com.denizenscript.denizencore.tags.core.UtilTagBase;
-import com.denizenscript.denizencore.utilities.CoreConfiguration;
-import com.denizenscript.denizencore.utilities.Deprecations;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
-import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizen.Denizen;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.npc.traits.AssignmentTrait;
-import com.denizenscript.denizencore.objects.core.*;
-import com.denizenscript.denizencore.scripts.commands.core.SQLCommand;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectFetcher;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.*;
 import com.denizenscript.denizencore.objects.notable.Notable;
+import com.denizenscript.denizencore.objects.notable.NoteManager;
 import com.denizenscript.denizencore.scripts.ScriptRegistry;
+import com.denizenscript.denizencore.scripts.commands.core.SQLCommand;
 import com.denizenscript.denizencore.scripts.containers.ScriptContainer;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ReplaceableTagEvent;
 import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.denizencore.tags.TagRunnable;
+import com.denizenscript.denizencore.tags.core.UtilTagBase;
+import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.Deprecations;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.citizensnpcs.Citizens;
@@ -203,7 +207,7 @@ public class ServerTagBase {
         // @description
         // Returns a list of all recipe IDs on the server.
         // Returns a list in the Namespace:Key format, for example "minecraft:gold_nugget".
-        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, CAMPFIRE, STONECUTTING)
+        // Optionally, specify a recipe type (CRAFTING, FURNACE, COOKING, BLASTING, SHAPED, SHAPELESS, SMOKING, CAMPFIRE, STONECUTTING, BREWING)
         // to limit to just recipes of that type.
         // Note: this will produce an error if all recipes of any one type have been removed from the server, due to an error in Spigot.
         // -->
@@ -211,11 +215,18 @@ public class ServerTagBase {
             listDeprecateWarn(attribute);
             String type = attribute.hasParam() ? CoreUtilities.toLowerCase(attribute.getParam()) : null;
             ListTag list = new ListTag();
-            Iterator<Recipe> recipeIterator = Bukkit.recipeIterator();
-            while (recipeIterator.hasNext()) {
-                Recipe recipe = recipeIterator.next();
-                if (Utilities.isRecipeOfType(recipe, type) && recipe instanceof Keyed) {
-                    list.add(((Keyed) recipe).getKey().toString());
+            if (type == null || !type.equals("brewing")) {
+                Iterator<Recipe> recipeIterator = Bukkit.recipeIterator();
+                while (recipeIterator.hasNext()) {
+                    Recipe recipe = recipeIterator.next();
+                    if (Utilities.isRecipeOfType(recipe, type) && recipe instanceof Keyed) {
+                        list.add(((Keyed) recipe).getKey().toString());
+                    }
+                }
+            }
+            if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) && (type == null || type.equals("brewing"))) {
+                for (NamespacedKey recipe : NMSHandler.itemHelper.getCustomBrewingRecipeIDs()) {
+                    list.add(recipe.toString());
                 }
             }
             event.setReplacedObject(list.getObjectAttribute(attribute.fulfill(1)));
@@ -233,8 +244,10 @@ public class ServerTagBase {
         // For shaped recipes, this will include 'air' for slots that are part of the shape but don't require an item.
         // -->
         if (attribute.startsWith("recipe_items") && attribute.hasParam()) {
-            Recipe recipe = Bukkit.getRecipe(Utilities.parseNamespacedKey(attribute.getParam()));
-            if (recipe == null) {
+            NamespacedKey recipeKey = Utilities.parseNamespacedKey(attribute.getParam());
+            Recipe recipe = Bukkit.getRecipe(recipeKey);
+            ItemHelper.BrewingRecipe brewingRecipe = Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) ? NMSHandler.itemHelper.getCustomBrewingRecipe(recipeKey) : null;
+            if (recipe == null && brewingRecipe == null) {
                 return;
             }
             ListTag result = new ListTag();
@@ -266,6 +279,10 @@ public class ServerTagBase {
             else if (recipe instanceof CookingRecipe<?>) {
                 addChoice.accept(((CookingRecipe) recipe).getInputChoice());
             }
+            else if (brewingRecipe != null) {
+                addChoice.accept(brewingRecipe.ingredient);
+                addChoice.accept(brewingRecipe.input);
+            }
             event.setReplacedObject(result.getObjectAttribute(attribute.fulfill(1)));
             return;
         }
@@ -291,11 +308,15 @@ public class ServerTagBase {
         // @returns ElementTag
         // @description
         // Returns the type of recipe that the given recipe ID is.
-        // Will be one of FURNACE, BLASTING, SHAPED, SHAPELESS, SMOKING, CAMPFIRE, STONECUTTING, SMITHING.
+        // Will be one of FURNACE, BLASTING, SHAPED, SHAPELESS, SMOKING, CAMPFIRE, STONECUTTING, SMITHING, BREWING.
         // -->
         if (attribute.startsWith("recipe_type") && attribute.hasParam()) {
-            Recipe recipe = Bukkit.getRecipe(Utilities.parseNamespacedKey(attribute.getParam()));
+            NamespacedKey recipeKey = Utilities.parseNamespacedKey(attribute.getParam());
+            Recipe recipe = Bukkit.getRecipe(recipeKey);
             if (recipe == null) {
+                if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18) && NMSHandler.itemHelper.getCustomBrewingRecipeIDs().contains(recipeKey)) {
+                    event.setReplacedObject(new ElementTag("brewing").getObjectAttribute(attribute.fulfill(1)));
+                }
                 return;
             }
             event.setReplacedObject(new ElementTag(Utilities.getRecipeType(recipe)).getObjectAttribute(attribute.fulfill(1)));
@@ -309,8 +330,15 @@ public class ServerTagBase {
         // Returns the item that a recipe will create when crafted.
         // -->
         if (attribute.startsWith("recipe_result") && attribute.hasParam()) {
-            Recipe recipe = Bukkit.getRecipe(Utilities.parseNamespacedKey(attribute.getParam()));
+            NamespacedKey recipeKey = Utilities.parseNamespacedKey(attribute.getParam());
+            Recipe recipe = Bukkit.getRecipe(recipeKey);
             if (recipe == null) {
+                if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+                    ItemHelper.BrewingRecipe brewingRecipe = NMSHandler.itemHelper.getCustomBrewingRecipe(recipeKey);
+                    if (brewingRecipe != null) {
+                        event.setReplacedObject(new ItemTag(brewingRecipe.result).getObjectAttribute(attribute.fulfill(1)));
+                    }
+                }
                 return;
             }
             event.setReplacedObject(new ItemTag(recipe.getResult()).getObjectAttribute(attribute.fulfill(1)));

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -220,8 +220,8 @@ public class ServerTagBase {
                 Iterator<Recipe> recipeIterator = Bukkit.recipeIterator();
                 while (recipeIterator.hasNext()) {
                     Recipe recipe = recipeIterator.next();
-                    if (Utilities.isRecipeOfType(recipe, type) && recipe instanceof Keyed keyed) {
-                        list.add(keyed.getKey().toString());
+                    if (Utilities.isRecipeOfType(recipe, type) && recipe instanceof Keyed keyedRecipe) {
+                        list.add(keyedRecipe.getKey().toString());
                     }
                 }
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/BrewingRecipe.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/BrewingRecipe.java
@@ -4,6 +4,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 
 public class BrewingRecipe {
+
     public RecipeChoice input;
     public RecipeChoice ingredient;
     public ItemStack result;

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/BrewingRecipe.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/BrewingRecipe.java
@@ -1,0 +1,16 @@
+package com.denizenscript.denizen.utilities.inventory;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+
+public class BrewingRecipe {
+    public RecipeChoice input;
+    public RecipeChoice ingredient;
+    public ItemStack result;
+
+    public BrewingRecipe(RecipeChoice ingredient, RecipeChoice input, ItemStack result) {
+        this.ingredient = ingredient;
+        this.input = input;
+        this.result = result;
+    }
+}

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
@@ -521,7 +521,7 @@ public class ItemHelperImpl extends ItemHelper {
     public boolean isValidMix(ItemStack input, ItemStack ingredient) {
         net.minecraft.world.item.ItemStack nmsInput = CraftItemStack.asNMSCopy(input);
         net.minecraft.world.item.ItemStack nmsIngredient = CraftItemStack.asNMSCopy(ingredient);
-        return net.minecraft.world.item.alchemy.PotionBrewing.hasMix(nmsInput, nmsIngredient);
+        return PotionBrewing.hasMix(nmsInput, nmsIngredient);
     }
 
     public static Class<?> PaperPotionMix_CLASS = null;

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
@@ -1,17 +1,24 @@
 package com.denizenscript.denizen.nms.v1_18.helpers;
 
-import com.denizenscript.denizen.nms.v1_18.ReflectionMappingsInfo;
-import com.denizenscript.denizen.objects.ItemTag;
-import com.denizenscript.denizen.utilities.FormattedTextHelper;
-import com.denizenscript.denizencore.utilities.ReflectionHelper;
-import com.denizenscript.denizen.nms.util.jnbt.*;
-import com.denizenscript.denizen.nms.v1_18.impl.jnbt.CompoundTagImpl;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.google.common.collect.*;
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
+import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
+import com.denizenscript.denizen.nms.util.jnbt.IntArrayTag;
+import com.denizenscript.denizen.nms.util.jnbt.Tag;
+import com.denizenscript.denizen.nms.v1_18.ReflectionMappingsInfo;
+import com.denizenscript.denizen.nms.v1_18.impl.jnbt.CompoundTagImpl;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.FormattedTextHelper;
+import com.denizenscript.denizen.utilities.inventory.BrewingRecipe;
+import com.denizenscript.denizencore.utilities.ReflectionHelper;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedHashMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Multisets;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -24,6 +31,7 @@ import net.minecraft.nbt.NbtUtils;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.alchemy.PotionBrewing;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -38,19 +46,19 @@ import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftRecipe;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftNamespacedKey;
-import org.bukkit.inventory.RecipeChoice;
-import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -514,5 +522,44 @@ public class ItemHelperImpl extends ItemHelper {
         net.minecraft.world.item.ItemStack nmsInput = CraftItemStack.asNMSCopy(input);
         net.minecraft.world.item.ItemStack nmsIngredient = CraftItemStack.asNMSCopy(ingredient);
         return net.minecraft.world.item.alchemy.PotionBrewing.hasMix(nmsInput, nmsIngredient);
+    }
+
+    public static Class<?> PaperPotionMix_CLASS = null;
+
+    @Override
+    public Map<NamespacedKey, BrewingRecipe> getCustomBrewingRecipes() {
+        Map<NamespacedKey, ?> nmsCustomRecipes = getNMSCustomBrewingRecipes();
+        Map<NamespacedKey, BrewingRecipe> brewingRecipes = new HashMap<>(nmsCustomRecipes.size());
+        for (Map.Entry<NamespacedKey, ?> entry : nmsCustomRecipes.entrySet()) {
+            brewingRecipes.put(entry.getKey(), paperMixToRecipe(entry.getValue()));
+        }
+        return brewingRecipes;
+    }
+
+    @Override
+    public Set<NamespacedKey> getCustomBrewingRecipeIDs() {
+        return getNMSCustomBrewingRecipes().keySet();
+    }
+
+    @Override
+    public BrewingRecipe getCustomBrewingRecipe(NamespacedKey recipeKey) {
+        return paperMixToRecipe(getNMSCustomBrewingRecipes().get(recipeKey));
+    }
+
+    public Map<NamespacedKey, ?> getNMSCustomBrewingRecipes() {
+        return ReflectionHelper.getFieldValue(PotionBrewing.class, "CUSTOM_MIXES", null);
+    }
+
+    public BrewingRecipe paperMixToRecipe(Object paperMix) {
+        if (paperMix == null) {
+            return null;
+        }
+        if (PaperPotionMix_CLASS == null) {
+            PaperPotionMix_CLASS = paperMix.getClass();
+        }
+        RecipeChoice ingredient = CraftRecipe.toBukkit(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "ingredient", paperMix));
+        RecipeChoice input = CraftRecipe.toBukkit(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "input", paperMix));
+        ItemStack result = CraftItemStack.asBukkitCopy(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "result", paperMix));
+        return new BrewingRecipe(ingredient, input, result);
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
@@ -525,7 +525,7 @@ public class ItemHelperImpl extends ItemHelper {
     public boolean isValidMix(ItemStack input, ItemStack ingredient) {
         net.minecraft.world.item.ItemStack nmsInput = CraftItemStack.asNMSCopy(input);
         net.minecraft.world.item.ItemStack nmsIngredient = CraftItemStack.asNMSCopy(ingredient);
-        return net.minecraft.world.item.alchemy.PotionBrewing.hasMix(nmsInput, nmsIngredient);
+        return PotionBrewing.hasMix(nmsInput, nmsIngredient);
     }
 
     public static Class<?> PaperPotionMix_CLASS = null;
@@ -550,11 +550,11 @@ public class ItemHelperImpl extends ItemHelper {
         return paperMixToRecipe(getNMSCustomBrewingRecipes().get(recipeKey));
     }
 
-    public Map<NamespacedKey, ?> getNMSCustomBrewingRecipes() {
+    public static Map<NamespacedKey, ?> getNMSCustomBrewingRecipes() {
         return ReflectionHelper.getFieldValue(PotionBrewing.class, "CUSTOM_MIXES", null);
     }
 
-    public BrewingRecipe paperMixToRecipe(Object paperMix) {
+    public static BrewingRecipe paperMixToRecipe(Object paperMix) {
         if (paperMix == null) {
             return null;
         }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
@@ -9,6 +9,7 @@ import com.denizenscript.denizen.nms.v1_19.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_19.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
+import com.denizenscript.denizen.utilities.inventory.BrewingRecipe;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;


### PR DESCRIPTION
## Additions

- `BrewingRecipe` class - a temporary class to hold an input, ingredient, and result of a brewing recipe. Can be replaced by Paper's one once Spigot support is dropped.
- `ItemHelper#getCustomBrewingRecipes` - returns a Map of keys to brewing recipes.
- `ItemHelper#getCustomBrewingRecipeIDs` - returns a Set of all brewing recipe keys.
- `ItemHelper#getCustomBrewingRecipe` - returns a brewing recipe by ID.
- `ItemHelperImpl#getNMSCustomBrewingRecipes` - returns the internal custom brewing recipe map
- `ItemHelperImpl#paperMixToRecipe` - converts paper's `PaperPotionMix` into a `BrewingRecipe`.

## Changes

- `ItemTag.recipe_ids`, `server.recipe_ids`, `server.recipe_items`, `server.recipe_type`, and `server.recipe_result` now support custom brewing recipes on Paper servers.
- Updated some code to modern java.
- Cleaned up imports.

## Notes

- The code is slightly messy currently because we can't access Paper's object directly, but I tried setting it up in a way that would make it easy to clean up later once we go Paper-Only.
- The reason for the separate methods is to avoid going over the entire map converting to `BrewingRecipe`'s with reflection for simple things such as getting the IDs. We could maybe remove them once we go Paper-only and that code is cleaned up - Let me know if these methods should be merged already.