### PR TITLE
Fix disguise entity data handling on 1.19.3

### DIFF
--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -644,23 +644,23 @@ public class DenizenNetworkManagerImpl extends Connection {
         }
         try {
             int entityID = -1;
-            if (packet instanceof ClientboundSetEntityDataPacket) {
-                entityID = ((ClientboundSetEntityDataPacket) packet).id();
+            if (packet instanceof ClientboundSetEntityDataPacket entityDataPacket) {
+                entityID = entityDataPacket.id();
             }
-            if (packet instanceof ClientboundUpdateAttributesPacket) {
-                entityID = ((ClientboundUpdateAttributesPacket) packet).getEntityId();
+            if (packet instanceof ClientboundUpdateAttributesPacket updateAttributesPacket) {
+                entityID = updateAttributesPacket.getEntityId();
             }
-            if (packet instanceof ClientboundAddPlayerPacket) {
-                entityID = ((ClientboundAddPlayerPacket) packet).getEntityId();
+            if (packet instanceof ClientboundAddPlayerPacket addPlayerPacket) {
+                entityID = addPlayerPacket.getEntityId();
             }
-            else if (packet instanceof ClientboundAddEntityPacket) {
-                entityID = ((ClientboundAddEntityPacket) packet).getId();
+            else if (packet instanceof ClientboundAddEntityPacket addEntityPacket) {
+                entityID = addEntityPacket.getId();
             }
-            else if (packet instanceof ClientboundTeleportEntityPacket) {
-                entityID = ((ClientboundTeleportEntityPacket) packet).getId();
+            else if (packet instanceof ClientboundTeleportEntityPacket teleportEntityPacket) {
+                entityID = teleportEntityPacket.getId();
             }
-            else if (packet instanceof ClientboundMoveEntityPacket) {
-                Entity e = ((ClientboundMoveEntityPacket) packet).getEntity(player.level);
+            else if (packet instanceof ClientboundMoveEntityPacket moveEntityPacket) {
+                Entity e = moveEntityPacket.getEntity(player.level);
                 if (e != null) {
                     entityID = e.getId();
                 }
@@ -760,7 +760,7 @@ public class DenizenNetworkManagerImpl extends Connection {
                 }
             }
             antiDuplicate = true;
-            disguise.sendTo(Collections.singletonList(new PlayerTag(player.getBukkitEntity())));
+            disguise.sendTo(List.of(new PlayerTag(player.getUUID())));
             antiDuplicate = false;
             return true;
         }


### PR DESCRIPTION
## Explanation
See https://github.com/DenizenScript/Denizen/pull/2415 and https://github.com/DenizenScript/Denizen/pull/2417.
During the 1.19.3 update disguise handling for entity data packets was changed to use `SynchedEntityData#packDirty`, which could return null if no data was marked as dirty.

## Changes

- Changed disguise entity data packet handling to use `SynchedEntityData#getNonDefaultValues`, which will now only send the disguise's non-default entity data values, or not at all if there are none.
- Updated the code to modern Java practices.
- Made some variable names clearer.
- Replaced the `entityID != -1` that wrapped the entire code with an early return.
- Other minor cleanups.

## Notes

- Here's [A diff](https://github.com/DenizenScript/Denizen/compare/dev...tal5:7b05bbf9d8fced7bd50efb674419b82c13de11d5) without the indention change which is a lot more readable.