### PR TITLE
Command Switch for Tab Complete

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.events.server;
 
-import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
@@ -12,7 +11,6 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerAnimationType;
 import org.bukkit.event.server.TabCompleteEvent;
 
 public class TabCompleteScriptEvent extends BukkitScriptEvent implements Listener {
@@ -52,14 +50,8 @@ public class TabCompleteScriptEvent extends BukkitScriptEvent implements Listene
 
     @Override
     public boolean matches(ScriptPath path) {
-        /*if (!path.tryObjectSwitch("command", new ElementTag(getCommand()))) { //getCommand being a helper function already in the event
+        if (!path.tryObjectSwitch("command", new ElementTag(getCommand()))) {
             return false;
-        }*/
-        String command = path.switches.get("command");
-        if (command != null) {
-            if (!new ElementTag(getCommand()).tryAdvancedMatcher(command)) {
-                return false;
-            }
         }
         return super.matches(path);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
@@ -45,6 +45,14 @@ public class TabCompleteScriptEvent extends BukkitScriptEvent implements Listene
 
     public TabCompleteEvent event;
 
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!path.tryObjectSwitch("command", new ElementTag(getCommand()))) { //getCommand being a helper function already in the event
+            return false;
+        }
+        return super.matches(path);
+    }
+
     public String getCommand() {
         String[] args = event.getBuffer().trim().split(" ");
         String cmd = args.length > 0 ? args[0] : "";

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.events.server;
 
+import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
@@ -11,6 +12,7 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerAnimationType;
 import org.bukkit.event.server.TabCompleteEvent;
 
 public class TabCompleteScriptEvent extends BukkitScriptEvent implements Listener {
@@ -43,14 +45,21 @@ public class TabCompleteScriptEvent extends BukkitScriptEvent implements Listene
 
     public TabCompleteScriptEvent() {
         registerCouldMatcher("tab complete");
+        registerSwitches("command");
     }
 
     public TabCompleteEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryObjectSwitch("command", new ElementTag(getCommand()))) { //getCommand being a helper function already in the event
+        /*if (!path.tryObjectSwitch("command", new ElementTag(getCommand()))) { //getCommand being a helper function already in the event
             return false;
+        }*/
+        String command = path.switches.get("command");
+        if (command != null) {
+            if (!new ElementTag(getCommand()).tryAdvancedMatcher(command)) {
+                return false;
+            }
         }
         return super.matches(path);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
@@ -50,7 +50,7 @@ public class TabCompleteScriptEvent extends BukkitScriptEvent implements Listene
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryObjectSwitch("command", new ElementTag(getCommand()))) {
+        if (!runGenericSwitchCheck(path, "command", getCommand())) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/TabCompleteScriptEvent.java
@@ -21,6 +21,8 @@ public class TabCompleteScriptEvent extends BukkitScriptEvent implements Listene
     //
     // @Group Server
     //
+    // @Switch command:<command_name> to only process the event if the command matches the input name.
+    //
     // @Cancellable true
     //
     // @Triggers when a player or the console is sent a list of available tab completions.


### PR DESCRIPTION
Adds a command switch to Tab Complete

This uses the same logic as `<context.command>` in this event - putting it in line with `on <command_name> command` in function.

I have tested this and it works as intended.