### PR TITLE
Cleanup and improve `PlayerHoldsItemEvent`

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -51,7 +51,9 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerJumpsScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesGrindstoneCraftScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerRaiseLowerItemScriptEventPaperImpl.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+            ScriptEvent.registerScriptEvent(PlayerRaiseLowerItemScriptEventPaperImpl.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerSelectsStonecutterRecipeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -51,6 +51,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerJumpsScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesGrindstoneCraftScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerRaiseLowerItemScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PlayerSelectsStonecutterRecipeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerRaiseLowerItemScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerRaiseLowerItemScriptEventPaperImpl.java
@@ -1,0 +1,64 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.player.PlayerRaiseLowerItemScriptEvent;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public class PlayerRaiseLowerItemScriptEventPaperImpl extends PlayerRaiseLowerItemScriptEvent {
+
+    public DurationTag heldFor;
+    public ElementTag hand;
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "held_for" -> heldFor;
+            case "hand" -> hand;
+            case "item" -> item;
+            default -> super.getContext(name);
+        };
+    }
+
+    @Override
+    public void run(Player pl) {
+        cancelled = false;
+        player = new PlayerTag(pl);
+        item = new ItemTag(pl.getActiveItem());
+        heldFor = state ? null : new DurationTag((long) pl.getHandRaisedTime());
+        hand = new ElementTag(pl.getHandRaised());
+        fire();
+    }
+
+    @EventHandler
+    public void onStopUsingItem(PlayerStopUsingItemEvent event) {
+        signalDidLower(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerDropItem(PlayerDropItemEvent event) {
+        // You can only drop items from your main hand, so if the player's main hand isn't raised, ignore
+        if (event.getPlayer().isHandRaised() && event.getPlayer().getHandRaised() == EquipmentSlot.HAND && raisedItems.remove(event.getPlayer().getUniqueId())) {
+            cancelled = false;
+            state = false;
+            Player pl = event.getPlayer();
+            player = new PlayerTag(pl);
+            Debug.log("activeItem: " + pl.getActiveItem().getType());
+            // Work around Player#getActiveItem being air in the drop item event
+            ItemStack loweredItem = event.getItemDrop().getItemStack();
+            item = new ItemTag(loweredItem);
+            heldFor = new DurationTag((long) loweredItem.getMaxItemUseDuration() - pl.getItemUseRemainingTime());
+            hand = new ElementTag(pl.getHandRaised());
+            fire();
+        }
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerRaiseLowerItemScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerRaiseLowerItemScriptEventPaperImpl.java
@@ -6,7 +6,6 @@ import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -52,7 +51,6 @@ public class PlayerRaiseLowerItemScriptEventPaperImpl extends PlayerRaiseLowerIt
             state = false;
             Player pl = event.getPlayer();
             player = new PlayerTag(pl);
-            Debug.log("activeItem: " + pl.getActiveItem().getType());
             // Work around Player#getActiveItem being air in the drop item event
             ItemStack loweredItem = event.getItemDrop().getItemStack();
             item = new ItemTag(loweredItem);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerRaiseLowerItemScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerRaiseLowerItemScriptEventPaperImpl.java
@@ -10,6 +10,7 @@ import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
@@ -57,6 +58,13 @@ public class PlayerRaiseLowerItemScriptEventPaperImpl extends PlayerRaiseLowerIt
             heldFor = new DurationTag((long) loweredItem.getMaxItemUseDuration() - pl.getItemUseRemainingTime());
             hand = new ElementTag(pl.getHandRaised());
             fire();
+        }
+    }
+
+    @EventHandler
+    public void onPlayerChangeHeldItem(PlayerItemHeldEvent event) {
+        if (event.getPlayer().isHandRaised() && event.getPlayer().getHandRaised() == EquipmentSlot.HAND) {
+            signalDidLower(event.getPlayer());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -186,7 +186,6 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerFishesScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerFlyingScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerHearsSoundScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerHoldsItemEvent.class);
         ScriptEvent.registerScriptEvent(PlayerIncreasesExhaustionLevelScriptEvent.class);
         if (!Denizen.supportsPaper) {
             ScriptEvent.registerScriptEvent(PlayerItemTakesDamageScriptEvent.class);
@@ -210,6 +209,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerPreparesAnvilCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesEnchantScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerQuitsScriptEvent.class);
+        if (!Denizen.supportsPaper) {
+            ScriptEvent.registerScriptEvent(PlayerRaiseLowerItemScriptEvent.PlayerRaiseLowerItemScriptEventSpigotImpl.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerReceivesActionbarScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerReceivesCommandsScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerReceivesMessageScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -12,6 +12,8 @@ import com.denizenscript.denizen.events.player.*;
 import com.denizenscript.denizen.events.server.*;
 import com.denizenscript.denizen.events.vehicle.*;
 import com.denizenscript.denizen.events.world.*;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.events.ScriptEventCouldMatcher;
@@ -209,7 +211,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerPreparesAnvilCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesEnchantScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerQuitsScriptEvent.class);
-        if (!Denizen.supportsPaper) {
+        if (!Denizen.supportsPaper || NMSHandler.getVersion().isAtMost(NMSVersion.v1_17)) {
             ScriptEvent.registerScriptEvent(PlayerRaiseLowerItemScriptEvent.PlayerRaiseLowerItemScriptEventSpigotImpl.class);
         }
         ScriptEvent.registerScriptEvent(PlayerReceivesActionbarScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRaiseLowerItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRaiseLowerItemScriptEvent.java
@@ -38,9 +38,13 @@ public class PlayerRaiseLowerItemScriptEvent extends BukkitScriptEvent implement
     //
     // @Warning For 'lowers', the item may be tracked incorrectly. Prefer 'player lowers item' (the generic item form) for a 'lowers' event (similar for 'toggles').
     // Also be aware this event may misfire in some cases.
+    // This event and it's data are more accurate on Paper servers.
     //
     // @Context
-    // <context.state> returns an ElementTag(Boolean) with a value of "true" if the player is now holding up a raisable item and "false" otherwise.
+    // <context.state> returns an ElementTag(Boolean) of whether the player raised or lowered the item.
+    // <context.held_for> returns a DurationTag of how long the player held the item up for (only on Paper).
+    // <context.hand> returns an ElementTag of the hand that the player is raising or lowering (only on Paper).
+    // <context.item> returns an ItemTag of the item that the player is raising or lowering (only on Paper)
     //
     // @Player Always.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRaiseLowerItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRaiseLowerItemScriptEvent.java
@@ -16,6 +16,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -149,7 +150,7 @@ public class PlayerRaiseLowerItemScriptEvent extends BukkitScriptEvent implement
     }
 
     @EventHandler
-    public void onPlayerChangeItem(PlayerItemHeldEvent event) {
+    public void onPlayerSwapHandItems(PlayerSwapHandItemsEvent event) {
         signalDidLower(event.getPlayer());
     }
 
@@ -157,6 +158,11 @@ public class PlayerRaiseLowerItemScriptEvent extends BukkitScriptEvent implement
 
         @EventHandler
         public void onPlayerDropItem(PlayerDropItemEvent event) {
+            signalDidLower(event.getPlayer());
+        }
+
+        @EventHandler
+        public void onPlayerChangeHeldItem(PlayerItemHeldEvent event) {
             signalDidLower(event.getPlayer());
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRaiseLowerItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerRaiseLowerItemScriptEvent.java
@@ -50,7 +50,7 @@ public class PlayerRaiseLowerItemScriptEvent extends BukkitScriptEvent implement
     //
     // -->
 
-    public static EnumSet<Material> raisableItems = EnumSet.of(Material.SHIELD, Material.CROSSBOW, Material.BOW, Material.TRIDENT, Material.SPYGLASS);
+    public static final EnumSet<Material> raisableItems = EnumSet.of(Material.SHIELD, Material.CROSSBOW, Material.BOW, Material.TRIDENT, Material.SPYGLASS);
 
     public PlayerRaiseLowerItemScriptEvent() {
         registerCouldMatcher("player raises|lowers|toggles <item>");
@@ -113,8 +113,7 @@ public class PlayerRaiseLowerItemScriptEvent extends BukkitScriptEvent implement
     public void run(Player pl) {
         cancelled = false;
         player = new PlayerTag(pl);
-        if (raisableItems.contains(player.getHeldItem().getBukkitMaterial())
-                || !raisableItems.contains(player.getOffhandItem().getBukkitMaterial())) {
+        if (raisableItems.contains(player.getHeldItem().getBukkitMaterial()) || !raisableItems.contains(player.getOffhandItem().getBukkitMaterial())) {
             item = player.getHeldItem();
         }
         else {
@@ -155,6 +154,7 @@ public class PlayerRaiseLowerItemScriptEvent extends BukkitScriptEvent implement
     }
 
     public static class PlayerRaiseLowerItemScriptEventSpigotImpl extends PlayerRaiseLowerItemScriptEvent {
+
         @EventHandler
         public void onPlayerDropItem(PlayerDropItemEvent event) {
             signalDidLower(event.getPlayer());

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/packets/DenizenPacketHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/packets/DenizenPacketHandler.java
@@ -2,16 +2,18 @@ package com.denizenscript.denizen.utilities.packets;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.player.*;
-import com.denizenscript.denizen.nms.interfaces.packets.*;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.denizen.nms.interfaces.packets.PacketInResourcePackStatus;
+import com.denizenscript.denizen.nms.interfaces.packets.PacketInSteerVehicle;
+import com.denizenscript.denizen.nms.interfaces.packets.PacketOutChat;
+import com.denizenscript.denizen.nms.interfaces.packets.PacketOutEntityMetadata;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.scripts.commands.player.GlowCommand;
 import com.denizenscript.denizen.scripts.commands.server.ExecuteCommand;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
 import java.util.HashSet;

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/packets/DenizenPacketHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/packets/DenizenPacketHandler.java
@@ -67,39 +67,29 @@ public class DenizenPacketHandler {
         return false;
     }
 
-    public static HashSet<Material> raisableItems = new HashSet<>();
-
-    static {
-        raisableItems.add(Material.SHIELD);
-        raisableItems.add(Material.CROSSBOW);
-        raisableItems.add(Material.BOW);
-        raisableItems.add(Material.TRIDENT);
-        raisableItems.add(Material.SPYGLASS);
-    }
-
     public static boolean isHoldingRaisable(Player player) {
-        return raisableItems.contains(player.getEquipment().getItemInMainHand().getType())
-            || raisableItems.contains(player.getEquipment().getItemInOffHand().getType());
+        return PlayerRaiseLowerItemScriptEvent.raisableItems.contains(player.getEquipment().getItemInMainHand().getType())
+            || PlayerRaiseLowerItemScriptEvent.raisableItems.contains(player.getEquipment().getItemInOffHand().getType());
     }
 
     public void receivePlacePacket(final Player player) {
-        if (!PlayerHoldsItemEvent.instance.enabled) {
+        if (!PlayerRaiseLowerItemScriptEvent.instance.enabled) {
             return;
         }
         if (isHoldingRaisable(player)) {
             Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
-                PlayerHoldsItemEvent.signalDidRaise(player);
+                PlayerRaiseLowerItemScriptEvent.signalDidRaise(player);
             });
         }
     }
 
     public void receiveDigPacket(final Player player) {
-        if (!PlayerHoldsItemEvent.instance.enabled) {
+        if (Denizen.supportsPaper || !PlayerRaiseLowerItemScriptEvent.instance.enabled) {
             return;
         }
         if (isHoldingRaisable(player)) {
             Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
-                PlayerHoldsItemEvent.signalDidLower(player);
+                PlayerRaiseLowerItemScriptEvent.signalDidLower(player);
             });
         }
     }


### PR DESCRIPTION
## Changes

- Renamed it to `PlayerRaiseLowerItemScriptEvent` to better match the event line/what the event does and the `XScriptEvent` naming convention.
- `<context.held_for>` - returns a DurationTag of how long the item was held up for (only on Paper).
- `<context.hand>` - returns an ElementTag of the hand the player raised/lowered (only on Paper).
- `<context.item>` - returns an ItemTag of the item the player raised/lowered (only on Paper).
- The item being raised/lowered is now a lot more accurate on Paper, using their `Player#getActiveItem` API.
- Tracking using the `PlayerDropItemEvent` is now more accurate on Paper, as it can check whether the player has the item they're dropping raised.
- Tracking using the `PlayerItemHeldEvent` is now more accurate on Paper, as it can check whether the player has the item they're switching from raised.
- Moved the `raisableItems` set to the event class (makes more sense to have it there as it's specific to that event) and changed it into an `EnumSet`.
- Removed the `couldMatch` method - as far as I can see it was unnecessary and just wasn't removed when the `registerCouldMatcher` was added, lmk if there was any specific reason it was there.
- Improved some field/variable naming.
- Updated `getContext` to modern switch handling.
- Add `super` calls to `init` and `destroy` as they register the listeners (pretty sure none of that event's listeners worked since https://github.com/DenizenScript/Denizen/commit/a6f0f8544a39382ff339f640a3948b7993e20cac#diff-4feeebf123e826d7bdcea2c0ca8f1a9bbf1ba9c31b3ffa092fbc567da8306b48?).
- Switched the `contains` check in `signalDidRaise` to `add`, as it returns `true if this set did not already contain the specified element`.
- `lowers` will now trigger for the player switching their off and main hands, as that's how Minecraft does it (if you load a bow in your main hand then switch it to your off hand, it becomes completely unloaded and you have to restart)