### PR TITLE
Add `PlayerTag.refresh_player` mechanism

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -109,4 +109,8 @@ public abstract class PlayerHelper {
     public void sendClimbableMaterials(Player player, List<Material> materials) {
         throw new UnsupportedOperationException();
     }
+
+    public void refreshPlayer(Player player) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2583,6 +2583,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             // @description
             // Sets the player's last death location, note that this only updates clientside when the player respawns.
             // Works with offline players.
+            // See also <@link mechanism PlayerTag.refresh_player>.
             // @tags
             // <PlayerTag.last_death_location>
             // -->
@@ -2595,6 +2596,16 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 }
             });
         }
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name refresh_player
+        // @description
+        // Refreshes the player's client, resending some internal data.
+        // -->
+        registerOnlineOnlyMechanism("refresh_player", (object, mechanism) -> {
+            NMSHandler.playerHelper.refreshPlayer(object.getPlayerEntity());
+        });
     }
 
     public static ObjectTagProcessor<PlayerTag> tagProcessor = new ObjectTagProcessor<>();

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
@@ -78,7 +78,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     public static final Field FLY_TICKS = ReflectionHelper.getFields(ServerGamePacketListenerImpl.class).get(ReflectionMappingsInfo.ServerGamePacketListenerImpl_aboveGroundTickCount, int.class);
     public static final Field VEHICLE_FLY_TICKS = ReflectionHelper.getFields(ServerGamePacketListenerImpl.class).get(ReflectionMappingsInfo.ServerGamePacketListenerImpl_aboveGroundVehicleTickCount, int.class);
     public static final MethodHandle PLAYER_RESPAWNFORCED_SETTER = ReflectionHelper.getFinalSetter(ServerPlayer.class, ReflectionMappingsInfo.ServerPlayer_respawnForced, boolean.class);
-    public static final MethodHandle SERVER_GAME_PACKET_LISTENER_IMPL_INTERNAL_TELEPORT = ReflectionHelper.getMethodHandle(ServerGamePacketListenerImpl.class, "internalTeleport", double.class, double.class, double.class, float.class, float.class, Set.class, boolean.class);
 
     public static final EntityDataAccessor<Byte> ENTITY_HUMAN_SKINLAYERS_DATAWATCHER;
 
@@ -437,14 +436,7 @@ public class PlayerHelperImpl extends PlayerHelper {
                 nmsWorld.isFlat(),
                 ClientboundRespawnPacket.KEEP_ALL_DATA,
                 nmsPlayer.getLastDeathLocation()));
-        try {
-            Location loc = player.getLocation();
-            SERVER_GAME_PACKET_LISTENER_IMPL_INTERNAL_TELEPORT.invoke(nmsPlayer.connection, loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), Set.of(), false);
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-            return;
-        }
+        nmsPlayer.connection.teleport(player.getLocation());
         if (nmsPlayer.isPassenger()) {
            nmsPlayer.connection.send(new ClientboundSetPassengersPacket(nmsPlayer.getVehicle()));
         }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
@@ -427,8 +427,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     public void refreshPlayer(Player player) {
         ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
         ServerLevel nmsWorld = (ServerLevel) nmsPlayer.level;
-        nmsPlayer.connection.send(new ClientboundPlayerInfoRemovePacket(List.of(nmsPlayer.getUUID())));
-        nmsPlayer.connection.send(ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(nmsPlayer)));
         nmsPlayer.connection.send(new ClientboundRespawnPacket(
                 nmsWorld.dimensionTypeId(),
                 nmsWorld.dimension(),

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
@@ -437,7 +437,6 @@ public class PlayerHelperImpl extends PlayerHelper {
                 nmsWorld.isFlat(),
                 ClientboundRespawnPacket.KEEP_ALL_DATA,
                 nmsPlayer.getLastDeathLocation()));
-        nmsPlayer.onUpdateAbilities();
         try {
             Location loc = player.getLocation();
             SERVER_GAME_PACKET_LISTENER_IMPL_INTERNAL_TELEPORT.invoke(nmsPlayer.connection, loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), Set.of(), false);
@@ -462,6 +461,7 @@ public class PlayerHelperImpl extends PlayerHelper {
                 nmsPlayer.connection.send(new ClientboundCooldownPacket(entry.getKey(), entry.getValue().endTime - tickCount));
             }
         }
+        nmsPlayer.onUpdateAbilities();
         nmsPlayer.server.getPlayerList().sendAllPlayerInfo(nmsPlayer);
         nmsPlayer.server.getPlayerList().sendPlayerPermissionLevel(nmsPlayer);
     }


### PR DESCRIPTION
## Additions

- `PlayerTag.refresh_player` mechanism - respawns the player entity client-side, resending some internal data.
- `PlayerHelper#refreshPlayer` method - used by the `PlayerTag.refresh_player` mechanism.
- Added a note about this mechanism to `PlayerTag.last_death_location`'s meta, as it can be used to update the player's last death location client-side.

## Notes

- The respawn packet recreates the Player entity client-side, which resets some data and is why all of that extra code is there - I am pretty sure I covered all of it.