### PR TITLE
New Paper-only event `entity steps on block`

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -37,6 +37,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(EntityLoadCrossbowScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityPathfindScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityRemoveFromWorldScriptEvent.class);
+        ScriptEvent.registerScriptEvent(EntityStepsOnScriptEvent.class);
         ScriptEvent.registerScriptEvent(ExperienceOrbMergeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerAbsorbsExperienceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerBeaconEffectScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityStepsOnScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityStepsOnScriptEvent.java
@@ -1,0 +1,108 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import io.papermc.paper.event.entity.EntityMoveEvent;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class EntityStepsOnScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // entity steps on block
+    // <entity> steps on <material>
+    //
+    // @Location true
+    //
+    // @Group Paper
+    //
+    // @Plugin Paper
+    //
+    // @Warning This event may fire very rapidly.
+    //
+    // @Cancellable true
+    //
+    // @Triggers when an entity steps onto a material.
+    //
+    // @Context
+    // <context.entity> returns an EntityTag of the entity stepping onto the block.
+    // <context.location> returns a LocationTag of the block the entity is stepping on.
+    // <context.previous_location> returns a LocationTag of where the entity was before stepping onto the block.
+    // <context.new_location> returns a LocationTag of where the entity is now.
+    //
+    // @Example
+    // # Announce the name of the entity stepping on the block and the material of block.
+    // on entity steps on block:
+    //     - announce "<context.entity.name> stepped on a <context.location.material.name>!"
+    //
+    // @Example
+    // # Announce the material of the block a sheep has stepped on.
+    // on sheep steps on block:
+    //     - announce "A sheep has stepped on a <context.location.material.name>!"
+    //
+    // @Example
+    // # Announce that a sheep has stepped on a diamond block.
+    // on sheep steps on diamond_block:
+    //     - announce "A sheep has stepped on a diamond block! Must be a wealthy sheep!"
+    // -->
+
+    public EntityStepsOnScriptEvent() {
+        registerCouldMatcher("<entity> steps on <material>");
+    }
+
+    public EntityTag entity;
+    public LocationTag location;
+    public LocationTag previousLocation;
+    public LocationTag newLocation;
+    public EntityMoveEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!entity.tryAdvancedMatcher(path.eventArgLowerAt(0))) {
+            return false;
+        }
+        MaterialTag material = new MaterialTag(location.getBlock());
+        if (!material.tryAdvancedMatcher(path.eventArgLowerAt(3))) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "entity" -> entity;
+            case "location" -> location;
+            case "previous_location" -> previousLocation;
+            case "new_location" -> newLocation;
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void entityStepsOnBlockEvent(EntityMoveEvent event) {
+        Location from = event.getFrom().clone().subtract(0, 0.05, 0);
+        Location to = event.getTo().clone().subtract(0, 0.05, 0);
+        if (LocationTag.isSameBlock(from, to)) {
+            return;
+        }
+        location = new LocationTag(to);
+        if (!Utilities.isLocationYSafe(location)) {
+            return;
+        }
+        entity = new EntityTag(event.getEntity());
+        previousLocation = new LocationTag(event.getFrom());
+        newLocation = new LocationTag(event.getTo());
+        this.event = event;
+        fire(event);
+    }
+}


### PR DESCRIPTION
#### Adds a new Paper-only event: `entity steps on block`

##### Event Lines
- `entity steps on block`
- `<entity> steps on <material>`

##### Contexts
- `<context.entity>`
- `<context.location>`
- `<context.previous_location>`
- `<context.new_location>`

Tested on versions **1.17.2**, **1.18.2**, and **1.19.3**.

Requested by Darwin on Discord :)

###### 🚶🚶🚶