### PR TITLE
Add paper-only 1.19+ `WardenChangesAngerLevelEvent`

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -65,6 +65,9 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(ServerResourcesReloadedScriptEvent.class);
         ScriptEvent.registerScriptEvent(TNTPrimesScriptEvent.class);
         ScriptEvent.registerScriptEvent(UnknownCommandScriptEvent.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            ScriptEvent.registerScriptEvent(WardenChangesAngerLevelScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(WorldGameRuleChangeScriptEvent.class);
 
         // Properties

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
@@ -1,0 +1,91 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import io.papermc.paper.event.entity.WardenAngerChangeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // warden changes anger level
+    //
+    // @Plugin Paper
+    //
+    // @Group Paper
+    //
+    // @Cancellable true
+    //
+    // @Location true
+    //
+    // @Triggers when a warden changes its anger level
+    //
+    // @Context
+    // <context.entity> returns the EntityTag of the warden, which changed the anger level.
+    // <context.new_anger> returns an ElementTag of the new anger level.
+    // <context.old_anger> returns an ElementTag of the old anger level.
+    // <context.target> returns the EntityTag who triggered the change (if any).
+    //
+    // @Determine
+    // "ANGER:" + ElementTag(Number) to set the value of the anger level.
+    //
+    // -->
+
+    public WardenChangesAngerLevelScriptEvent() {
+        registerCouldMatcher("warden changes anger level");
+    }
+
+    public WardenAngerChangeEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, event.getEntity().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "entity": return new EntityTag(event.getEntity());
+            case "new_anger": return new ElementTag(event.getNewAnger());
+            case "old_anger": return new ElementTag(event.getOldAnger());
+            case "target": return new EntityTag(event.getTarget());
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        if (determinationObj instanceof ElementTag) {
+            String lower = CoreUtilities.toLowerCase((determinationObj.toString()));
+            if (lower.startsWith("anger:")) {
+                ElementTag value = new ElementTag(lower.substring("anger:".length()));
+                if (value.isInt()) {
+                    event.setNewAnger(value.asInt());
+                    return true;
+                }
+            }
+        }
+        return super.applyDetermination(path, determinationObj);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getTarget() != null ? new EntityTag(event.getTarget()) : null);
+    }
+
+    @EventHandler
+    public void onWardenAngerChange(WardenAngerChangeEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
@@ -38,7 +38,7 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
     // <context.target> returns the EntityTag who triggered the change (if any).
     //
     // @Determine
-    // "ANGER:" + ElementTag(Number) to set the value of the anger level. Value must not exceed 150.
+    // "ANGER:" + ElementTag(Number) to set the value of the anger level. Value must be between 0 and 150.
     //
     // @Example
     // on warden changes anger level:

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
@@ -27,18 +27,18 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
     //
     // @Triggers when a warden changes its anger level.
     //
-    // @Player when the Entity who triggered the change is a player.
+    // @Player when the entity who triggered the change is a player.
     //
-    // @NPC when the Entity who triggered the change is a npc.
+    // @NPC when the entity who triggered the change is an npc.
     //
     // @Context
-    // <context.entity> returns the EntityTag of the warden, which changed the anger level.
+    // <context.entity> returns the EntityTag of the warden which changed its anger level.
     // <context.new_anger> returns an ElementTag of the new anger level.
     // <context.old_anger> returns an ElementTag of the old anger level.
     // <context.target> returns the EntityTag who triggered the change (if any).
     //
     // @Determine
-    // "ANGER:" + ElementTag(Number) to set the value of the anger level. Refer to <@link url https://jd.papermc.io/paper/1.19/org/bukkit/entity/Warden.AngerLevel.html>.
+    // "ANGER:" + ElementTag(Number) to set the value of the anger level. Value must not exceed 150.
     //
     // @Example
     // on warden changes anger level:

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
@@ -29,12 +29,12 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
     //
     // @Player when the entity who triggered the change is a player.
     //
-    // @NPC when the entity who triggered the change is an npc.
+    // @NPC when the entity who triggered the change is an NPC.
     //
     // @Context
     // <context.entity> returns the EntityTag of the warden which changed its anger level.
-    // <context.new_anger> returns an ElementTag of the new anger level.
-    // <context.old_anger> returns an ElementTag of the old anger level.
+    // <context.new_anger> returns an ElementTag(Number) of the new anger level.
+    // <context.old_anger> returns an ElementTag(Number) of the old anger level.
     // <context.target> returns the EntityTag who triggered the change (if any).
     //
     // @Determine
@@ -63,13 +63,13 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "entity": return new EntityTag(event.getEntity());
-            case "new_anger": return new ElementTag(event.getNewAnger());
-            case "old_anger": return new ElementTag(event.getOldAnger());
-            case "target": return event.getTarget() != null ? new EntityTag(event.getTarget()) : null;
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "entity" -> new EntityTag(event.getEntity());
+            case "new_anger" -> new ElementTag(event.getNewAnger());
+            case "old_anger" -> new ElementTag(event.getOldAnger());
+            case "target" -> event.getTarget() != null ? new EntityTag(event.getTarget()) : null;
+            default -> super.getContext(name);
+        };
     }
 
     @Override
@@ -89,7 +89,7 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
 
     @Override
     public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(event.getTarget() != null ? new EntityTag(event.getTarget()) : null);
+        return new BukkitScriptEntryData(event.getTarget());
     }
 
     @EventHandler

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
@@ -25,7 +25,11 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
     //
     // @Location true
     //
-    // @Triggers when a warden changes its anger level
+    // @Triggers when a warden changes its anger level.
+    //
+    // @Player when the Entity who triggered the change is a player.
+    //
+    // @NPC when the Entity who triggered the change is a npc.
     //
     // @Context
     // <context.entity> returns the EntityTag of the warden, which changed the anger level.
@@ -34,7 +38,12 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
     // <context.target> returns the EntityTag who triggered the change (if any).
     //
     // @Determine
-    // "ANGER:" + ElementTag(Number) to set the value of the anger level.
+    // "ANGER:" + ElementTag(Number) to set the value of the anger level. Refer to <@link url https://jd.papermc.io/paper/1.19/org/bukkit/entity/Warden.AngerLevel.html>.
+    //
+    // @Example
+    // on warden changes anger level:
+    // - if <context.new_anger> >= 40 && <context.new_anger> < 80:
+    //     - announce "Careful, the warden is agitated!"
     //
     // -->
 
@@ -58,7 +67,7 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
             case "entity": return new EntityTag(event.getEntity());
             case "new_anger": return new ElementTag(event.getNewAnger());
             case "old_anger": return new ElementTag(event.getOldAnger());
-            case "target": return new EntityTag(event.getTarget());
+            case "target": return event.getTarget() != null ? new EntityTag(event.getTarget()) : null;
         }
         return super.getContext(name);
     }


### PR DESCRIPTION
This PR adds the `WardenChangesAngerLevel` event.

Context:
`<context.entity>` returns the EntityTag of the warden, which changed the anger level.
`<context.new_anger>` returns an ElementTag of the new anger level.
`<context.old_anger>` returns an ElementTag of the old anger level.
`<context.target>` returns the EntityTag who triggered the change (if any).

Determinations:
`"ANGER:"` + ElementTag(Number) to set the value of the anger level.