### PR TITLE
Fix player profile editor on `1.19.3`

### DIFF
--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
@@ -108,6 +108,9 @@ public class ReflectionMappingsInfo {
     public static String ClientboundLevelChunkPacketDataBlockEntityInfo_packedXZ = "a";
     public static String ClientboundLevelChunkPacketDataBlockEntityInfo_y = "b";
 
+    // net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
+    public static String ClientboundPlayerInfoUpdatePacket_entries = "b";
+
     // net.minecraft.world.entity.projectile.FishingHook
     public static String FishingHook_nibble = "ar";
     public static String FishingHook_timeUntilLured = "as";

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
@@ -108,9 +108,6 @@ public class ReflectionMappingsInfo {
     public static String ClientboundLevelChunkPacketDataBlockEntityInfo_packedXZ = "a";
     public static String ClientboundLevelChunkPacketDataBlockEntityInfo_y = "b";
 
-    // net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
-    public static String ClientboundPlayerInfoUpdatePacket_entries = "b";
-
     // net.minecraft.world.entity.projectile.FishingHook
     public static String FishingHook_nibble = "ar";
     public static String FishingHook_timeUntilLured = "as";

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
@@ -446,7 +446,7 @@ public class PacketHelperImpl implements PacketHelper {
         ((DenizenNetworkManagerImpl) ((CraftPlayer) player).getHandle().connection.connection).oldManager.channel.writeAndFlush(packet);
     }
 
-    public static void send(Player player, Packet packet) {
+    public static void send(Player player, Packet<?> packet) {
         ((CraftPlayer) player).getHandle().connection.send(packet);
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
@@ -24,6 +24,7 @@ import org.bukkit.craftbukkit.v1_19_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R2.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.lang.reflect.Field;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
@@ -99,9 +100,16 @@ public class ProfileEditorImpl extends ProfileEditor {
         }
     }
 
+    public static final Field ClientboundPlayerInfoUpdatePacket_entries = ReflectionHelper.getFields(ClientboundPlayerInfoUpdatePacket.class).getFirstOfType(List.class);
+
     public static ClientboundPlayerInfoUpdatePacket createInfoPacket(EnumSet<ClientboundPlayerInfoUpdatePacket.Action> actions, List<ClientboundPlayerInfoUpdatePacket.Entry> entries) {
         ClientboundPlayerInfoUpdatePacket playerInfoUpdatePacket = new ClientboundPlayerInfoUpdatePacket(actions, List.of());
-        ReflectionHelper.setFieldValue(ClientboundPlayerInfoUpdatePacket.class, ReflectionMappingsInfo.ClientboundPlayerInfoUpdatePacket_entries, playerInfoUpdatePacket, entries);
+        try {
+            ClientboundPlayerInfoUpdatePacket_entries.set(playerInfoUpdatePacket, entries);
+        }
+        catch (Throwable ex) {
+            Debug.echoError(ex);
+        }
         return playerInfoUpdatePacket;
     }
 

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
@@ -4,7 +4,6 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.v1_19.Handler;
-import com.denizenscript.denizen.nms.v1_19.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_19.helpers.PacketHelperImpl;
 import com.denizenscript.denizen.nms.v1_19.impl.network.handlers.DenizenNetworkManagerImpl;
 import com.denizenscript.denizen.scripts.commands.entity.RenameCommand;

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -49,7 +49,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.game.*;
-import net.minecraft.network.syncher.EntityDataSerializer;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerPlayer;
@@ -1142,9 +1141,8 @@ public class DenizenNetworkManagerImpl extends Connection {
     }
 
     public boolean processMirrorForPacket(Packet<?> packet) {
-        if (packet instanceof ClientboundPlayerInfoUpdatePacket) {
-            ClientboundPlayerInfoUpdatePacket playerInfo = (ClientboundPlayerInfoUpdatePacket) packet;
-            if (!ProfileEditorImpl.handleAlteredProfiles(playerInfo, this)) {
+        if (packet instanceof ClientboundPlayerInfoUpdatePacket playerInfoUpdatePacket) {
+            if (!ProfileEditorImpl.handleAlteredProfiles(playerInfoUpdatePacket, this)) {
                 return true;
             }
         }


### PR DESCRIPTION
## Explanation
I assume the previous player info packet just set it clientside, but now that the packets are split this is no longer the case - the client ignores the packet if it already has that player.
We could just use the update packet to update specific values, but since we want to update the player profile itself we will need to remove and re-add the player.

## Changes

- `PacketHelperImpl#send` now uses a wildcard generic for it's param - just to avoid the IDE warning / as a more proper practice.
- Cleaned up and changed some naming.
- `updatePlayer` now sends a remove packet and then a player initializing update packet instead of a single update packet, see explanation above.
- Add a `fakeProfiles.isEmpty()` requirement to `handleAlteredProfiles`'s first check. Looks like `fakeProfiles` used to be handled in a different method and was moved into `handleAlteredProfiles` without that check being added.
- Removed the null check on the packet's entries in `handleAlteredProfiles`, looking at the source code it's not possible for it to be null, and other places in Denizen code (and Mojang code, clientside) treat it as not nullable as well.
- Updated some code to modern java practices.
- `createInfoPacket` now constructs a packet with an empty entries list and uses reflection to set them. This is a lot cleaner then writing the data into a `ByteBuf` and having the packet read that imo, let me know if there is any specific reason it was done that way.
- Added a `break` to `handleAlteredProfiles`'s `any` checking loop.