### PR TITLE
PlayerTag.flying_fall_damage tag/mec addition

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
@@ -127,6 +127,9 @@ public class PaperPlayerExtensions {
             // @Plugin Paper
             // @description
             // Sets whether the player will take fall damage while <@link mechanism PlayerTag.can_fly> is true.
+            // @tags
+            // <PlayerTag.flying_fall_damage>
+            // <PlayerTag.can_fly>
             // -->
             PlayerTag.registerOnlineOnlyMechanism("flying_fall_damage", ElementTag.class, (object, mechanism, input) -> {
                 if (mechanism.requireBoolean()) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
+import net.kyori.adventure.util.TriState;
 import org.bukkit.Material;
 
 public class PaperPlayerExtensions {
@@ -81,6 +82,19 @@ public class PaperPlayerExtensions {
 
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
 
+            // <--[tag]
+            // @attribute <PlayerTag.flying_fall_damage>
+            // @returns ElementTag(Boolean)
+            // @mechanism PlayerTag.flying_fall_damage
+            // @group properties
+            // @Plugin Paper
+            // @description
+            // Returns whether the player will take fall damage while <@link tag PlayerTag.can_fly> is true.
+            // -->
+            PlayerTag.registerOnlineOnlyTag(ElementTag.class, "flying_fall_damage", (attribute, object) -> {
+                return new ElementTag(object.getPlayerEntity().hasFlyingFallDamage().toBooleanOrElse(false));
+            });
+
             // <--[mechanism]
             // @object PlayerTag
             // @name add_tab_completions
@@ -104,6 +118,20 @@ public class PaperPlayerExtensions {
             // -->
             PlayerTag.registerOnlineOnlyMechanism("remove_tab_completions", ListTag.class, (object, mechanism, input) -> {
                 object.getPlayerEntity().removeAdditionalChatCompletions(input);
+            });
+
+            // <--[mechanism]
+            // @object PlayerTag
+            // @name flying_fall_damage
+            // @input ElementTag(Boolean)
+            // @Plugin Paper
+            // @description
+            // Sets whether the player will take fall damage while <@link mechanism PlayerTag.can_fly> is true.
+            // -->
+            PlayerTag.registerOnlineOnlyMechanism("flying_fall_damage", ElementTag.class, (object, mechanism, input) -> {
+                if (mechanism.requireBoolean()) {
+                    object.getPlayerEntity().setFlyingFallDamage(TriState.byBoolean(input.asBoolean()));
+                }
             });
         }
     }


### PR DESCRIPTION
This is a handy tool for any sort of functionality that would require someone to jump twice in quick succession - normally things like a double jump. With this addition, you can leave can_fly enabled on the player and they will take fall damage normally instead of cycling can_fly on and off in various hacky ways.

Tested with an example script:
```yaml
double_jump_example:
  type: world
  events:
    on player joins:
    - adjust <player> can_fly:true
    - adjust <player> flying_fall_damage:true
    on player starts flying:
    - adjust <player> velocity:0,0.5,0
    - adjust <player> fall_distance:0
    - determine cancelled
```