### PR TITLE
`player stops damaging block` event

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -232,6 +232,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerStatisticIncrementsScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSteersEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStepsOnScriptEvent.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+            ScriptEvent.registerScriptEvent(PlayerStopsDamagingBlockScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerSwapsItemsScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerTakesFromFurnaceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerTakesFromLecternScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.events.player;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
@@ -24,17 +25,19 @@ public class PlayerStopsDamagingBlockScriptEvent extends BukkitScriptEvent imple
     //
     // @Triggers when a block stops being damaged by a player.
     //
+    // @Switch with:<item> to only process the event when the player stops hitting the block with a specified item.
+    //
     // @Context
     // <context.location> returns the LocationTag the block no longer being damaged.
     // <context.material> returns the MaterialTag of the block no longer being damaged.
     //
     // @Player Always.
     //
-    // @Usage
+    // @Example
     // on player stops damaging block:
     // - narrate "You were so close to breaking that block! You got this!"
     //
-    // @Usage
+    // @Example
     // on player stops damaging infested*:
     // - narrate "It's Silverfish time!"
     // - spawn silverfish|silverfish|silverfish|silverfish|silverfish <context.location> persistent
@@ -46,6 +49,7 @@ public class PlayerStopsDamagingBlockScriptEvent extends BukkitScriptEvent imple
 
     public PlayerStopsDamagingBlockScriptEvent() {
         registerCouldMatcher("player stops damaging <block>");
+        registerSwitches("with");
     }
 
     @Override
@@ -54,6 +58,9 @@ public class PlayerStopsDamagingBlockScriptEvent extends BukkitScriptEvent imple
             return false;
         }
         if (!path.tryArgObject(3, material)) {
+            return false;
+        }
+        if (!runWithCheck(path, new ItemTag(event.getPlayer().getEquipment().getItemInMainHand()))) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
@@ -1,0 +1,86 @@
+package com.denizenscript.denizen.events.player;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDamageAbortEvent;
+
+public class PlayerStopsDamagingBlockScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player stops damaging block
+    // player stops damaging <material>
+    //
+    // @Group Player
+    //
+    // @Location true
+    //
+    // @Triggers when a block stops being damaged by a player.
+    //
+    // @Context
+    // <context.location> returns the LocationTag the block no longer being damaged.
+    // <context.material> returns the MaterialTag of the block no longer being damaged.
+    //
+    // @Player Always.
+    //
+    // @Usage
+    // on player stops damaging block:
+    // - narrate "You were so close to breaking that block! You got this!"
+    //
+    // @Usage
+    // on player stops damaging infested*:
+    // - narrate "NO! IT'S SILVERFISH TIME!"
+    // - spawn silverfish|silverfish|silverfish|silverfish|silverfish <context.location> persistent
+    // -->
+
+    LocationTag location;
+    MaterialTag material;
+    BlockDamageAbortEvent event;
+
+    public PlayerStopsDamagingBlockScriptEvent() {
+        registerCouldMatcher("player stops damaging <block>");
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!path.tryArgObject(3, material)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "location" -> location;
+            case "material" -> material;
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void playerStopsDamagingBlockEvent(BlockDamageAbortEvent event) {
+        if (EntityTag.isNPC(event.getPlayer())) {
+            return;
+        }
+        location = new LocationTag(event.getBlock().getLocation());
+        material = new MaterialTag(event.getBlock());
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
@@ -60,7 +60,7 @@ public class PlayerStopsDamagingBlockScriptEvent extends BukkitScriptEvent imple
         if (!path.tryArgObject(3, material)) {
             return false;
         }
-        if (!runWithCheck(path, new ItemTag(event.getPlayer().getEquipment().getItemInMainHand()))) {
+        if (!runWithCheck(path, new ItemTag(event.getItemInHand()))) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerStopsDamagingBlockScriptEvent.java
@@ -36,7 +36,7 @@ public class PlayerStopsDamagingBlockScriptEvent extends BukkitScriptEvent imple
     //
     // @Usage
     // on player stops damaging infested*:
-    // - narrate "NO! IT'S SILVERFISH TIME!"
+    // - narrate "It's Silverfish time!"
     // - spawn silverfish|silverfish|silverfish|silverfish|silverfish <context.location> persistent
     // -->
 


### PR DESCRIPTION
## `player stops damaging block` event

### Event Lines:
- `player stops damaging block`
- `player stops damaging <material>`

### Contexts:
- `<context.location>` - the location of the block
- `<context.material>` - the material of the block

Works on 1.18.2 and 1.19.3

#### Note:
I think `player stops breaking block` sounds good too. Either works though in my opinion. ¯\\\_(ツ)_/¯ Let me know if you want it changed ;)

Requested by Stewe on discord 🌀