### PR TITLE
Paper-only event `player tracks|untracks <entity>`

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -64,6 +64,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerSelectsStonecutterRecipeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerTracksEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerTradesWithMerchantScriptEvent.class);
         ScriptEvent.registerScriptEvent(PreEntitySpawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(ProjectileCollideScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -64,7 +64,9 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerSelectsStonecutterRecipeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerTracksEntityScriptEvent.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            ScriptEvent.registerScriptEvent(PlayerTracksEntityScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerTradesWithMerchantScriptEvent.class);
         ScriptEvent.registerScriptEvent(PreEntitySpawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(ProjectileCollideScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
@@ -1,0 +1,101 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import io.papermc.paper.event.player.PlayerTrackEntityEvent;
+import io.papermc.paper.event.player.PlayerUntrackEntityEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player tracks|untracks <entity>
+    //
+    // @Location true
+    //
+    // @Group Paper
+    //
+    // @Plugin Paper
+    //
+    // @Warning This event may fire very rapidly.
+    //
+    // @Triggers when a player starts or stop tracking an entity.
+    //
+    // @Context
+    // <context.entity> returns an EntityTag of the entity being tracked.
+    // <context.location> returns a LocationTag of the entity.
+    //
+    // @Player Always.
+    //
+    // @Example
+    // # Narrate when the player tracks all entities except for item frames.
+    // on player tracks !item_frame:
+    // - narrate "You are now tracking <context.entity.name> at <context.location.simple>"
+    //
+    // @Example
+    // on player untracks chicken:
+    // - narrate "CHICKEN: No! Come back! :("
+    // -->
+
+    public PlayerTracksEntityScriptEvent() {
+        registerCouldMatcher("player tracks|untracks <entity>");
+    }
+
+    public String type;
+    public Player player;
+    public EntityTag entity;
+    public LocationTag location;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!path.eventArgLowerAt(1).equals(type)) {
+            return false;
+        }
+        if (!path.tryArgObject(2, entity)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(player);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "entity" -> entity;
+            case "location" -> location;
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void playerTracksEntityEvent(PlayerTrackEntityEvent event) {
+        entity = new EntityTag(event.getEntity());
+        location = new LocationTag(event.getEntity().getLocation());
+        player = event.getPlayer();
+        type = "tracks";
+        fire(event);
+    }
+
+    @EventHandler
+    public void playerUntracksEntityEvent(PlayerUntrackEntityEvent event) {
+        entity = new EntityTag(event.getEntity());
+        location = new LocationTag(event.getEntity().getLocation());
+        player = event.getPlayer();
+        type = "untracks";
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
@@ -26,7 +26,7 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     //
     // @Warning This event may fire very rapidly.
     //
-    // @Triggers when a player starts or stop tracking an entity.
+    // @Triggers when a player starts or stop tracking an entity. An entity is tracked when it is visible to the client. An entity will be untracked when it is no longer visible, e.g. it despawns, dies, or is unloaded.
     //
     // @Context
     // <context.entity> returns an EntityTag of the entity being tracked.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
@@ -2,7 +2,6 @@ package com.denizenscript.denizen.paper.events;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
@@ -26,7 +25,7 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     //
     // @Warning This event may fire very rapidly.
     //
-    // @Triggers when a player starts or stop tracking an entity. An entity is tracked when it is visible to the client. An entity will be untracked when it is no longer visible, e.g. it despawns, dies, or is unloaded.
+    // @Triggers when a player starts or stops tracking an entity. An entity is tracked/untracked by a player's client when the player moves in/out of its <@link mechanism EntityTag.tracking_range>.
     //
     // @Context
     // <context.entity> returns an EntityTag of the entity being tracked.
@@ -51,11 +50,10 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     public String type;
     public Player player;
     public EntityTag entity;
-    public LocationTag location;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runInCheck(path, location)) {
+        if (!runInCheck(path, entity.getLocation())) {
             return false;
         }
         if (!path.eventArgLowerAt(1).equals(type)) {
@@ -76,7 +74,7 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "entity" -> entity;
-            case "location" -> location;
+            case "location" -> entity.getLocation();
             default -> super.getContext(name);
         };
     }
@@ -84,7 +82,6 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     @EventHandler
     public void playerTracksEntityEvent(PlayerTrackEntityEvent event) {
         entity = new EntityTag(event.getEntity());
-        location = new LocationTag(event.getEntity().getLocation());
         player = event.getPlayer();
         type = "tracks";
         fire(event);
@@ -93,9 +90,10 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     @EventHandler
     public void playerUntracksEntityEvent(PlayerUntrackEntityEvent event) {
         entity = new EntityTag(event.getEntity());
-        location = new LocationTag(event.getEntity().getLocation());
         player = event.getPlayer();
         type = "untracks";
+        EntityTag.rememberEntity(event.getEntity());
         fire(event);
+        EntityTag.forgetEntity(event.getEntity());
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
@@ -28,15 +28,14 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     // @Triggers when a player starts or stops tracking an entity. An entity is tracked/untracked by a player's client when the player moves in/out of its <@link mechanism EntityTag.tracking_range>.
     //
     // @Context
-    // <context.entity> returns an EntityTag of the entity being tracked.
-    // <context.location> returns a LocationTag of the entity.
+    // <context.entity> returns an EntityTag of the entity being tracked or untracked.
     //
     // @Player Always.
     //
     // @Example
     // # Narrate when the player tracks all entities except for item frames.
     // on player tracks !item_frame:
-    // - narrate "You are now tracking <context.entity.name> at <context.location.simple>"
+    // - narrate "You are now tracking <context.entity.name> at <context.entity.location.simple>"
     //
     // @Example
     // on player untracks chicken:
@@ -53,13 +52,13 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runInCheck(path, entity.getLocation())) {
-            return false;
-        }
         if (!path.eventArgLowerAt(1).equals(type)) {
             return false;
         }
         if (!path.tryArgObject(2, entity)) {
+            return false;
+        }
+        if (!runInCheck(path, entity.getLocation())) {
             return false;
         }
         return super.matches(path);
@@ -74,7 +73,6 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "entity" -> entity;
-            case "location" -> entity.getLocation();
             default -> super.getContext(name);
         };
     }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerTracksEntityScriptEvent.java
@@ -78,7 +78,7 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     }
 
     @EventHandler
-    public void playerTracksEntityEvent(PlayerTrackEntityEvent event) {
+    public void onPlayerTracksEntityEvent(PlayerTrackEntityEvent event) {
         entity = new EntityTag(event.getEntity());
         player = event.getPlayer();
         type = "tracks";
@@ -86,7 +86,7 @@ public class PlayerTracksEntityScriptEvent extends BukkitScriptEvent implements 
     }
 
     @EventHandler
-    public void playerUntracksEntityEvent(PlayerUntrackEntityEvent event) {
+    public void onPlayerUntracksEntityEvent(PlayerUntrackEntityEvent event) {
         entity = new EntityTag(event.getEntity());
         player = event.getPlayer();
         type = "untracks";


### PR DESCRIPTION
### `player tracks|untracks <entity>`

For when the player stops or starts tracking an entity.

#### Contexts
- `<context.entity>` - the entity being tracked or untracked
- ~~`<context.location>` = the location of the entity~~ removed for redundancy (you can just use `<context.entity.location>` instead

Requested by Mergu on [Discord](https://discord.com/channels/315163488085475337/1084605292215537705/1084605292215537705)

###### 🛤️🛤️🛤️