### PR TITLE
Paper-only event `skeleton horse trap` and `EntityTrapped` properties for `SkeletonHorse`s

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -72,6 +72,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(ProjectileCollideScriptEvent.class);
         ScriptEvent.registerScriptEvent(ServerListPingScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(ServerResourcesReloadedScriptEvent.class);
+        ScriptEvent.registerScriptEvent(SkeletonHorseTrapScriptEvent.class);
         ScriptEvent.registerScriptEvent(TNTPrimesScriptEvent.class);
         ScriptEvent.registerScriptEvent(UnknownCommandScriptEvent.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/SkeletonHorseTrapScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/SkeletonHorseTrapScriptEvent.java
@@ -1,0 +1,71 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.destroystokyo.paper.event.entity.SkeletonHorseTrapEvent;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class SkeletonHorseTrapScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // skeleton horse trap
+    //
+    // @Location true
+    //
+    // @Group Paper
+    //
+    // @Plugin Paper
+    //
+    // @Triggers when a player gets too close to a trapped skeleton horse and triggers the trap.
+    //
+    // @Context
+    // <context.entity> returns an EntityTag of the skeleton horse.
+    // <context.players> returns a ListTag(PlayerTag) of the players involved in the trap.
+    // -->
+
+    public SkeletonHorseTrapScriptEvent() {
+        registerCouldMatcher("skeleton horse trap");
+    }
+
+    public EntityTag entity;
+    public SkeletonHorseTrapEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, entity.getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "entity" -> entity;
+            case "players" -> {
+                ListTag players = new ListTag();
+                for (HumanEntity human : event.getEligibleHumans()) {
+                    if (!EntityTag.isNPC(human) && human instanceof Player player) {
+                        players.addObject(new PlayerTag(player));
+                    }
+                }
+                yield players;
+            }
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void onSkeletonHorseTrap(SkeletonHorseTrapEvent event) {
+        this.event = event;
+        entity = new EntityTag(event.getEntity());
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -119,6 +119,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityTrades.class, EntityTag.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
             PropertyParser.registerProperty(EntityTrapped.class, EntityTag.class);
+            PropertyParser.registerProperty(EntityTrapTime.class, EntityTag.class);
         }
         PropertyParser.registerProperty(EntityVillagerExperience.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVillagerLevel.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -117,7 +117,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityTame.class, EntityTag.class);
         PropertyParser.registerProperty(EntityEyeTargetLocation.class, EntityTag.class);
         PropertyParser.registerProperty(EntityTrades.class, EntityTag.class);
-        PropertyParser.registerProperty(EntityTrapped.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+            PropertyParser.registerProperty(EntityTrapped.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityVillagerExperience.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVillagerLevel.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVisible.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -117,6 +117,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityTame.class, EntityTag.class);
         PropertyParser.registerProperty(EntityEyeTargetLocation.class, EntityTag.class);
         PropertyParser.registerProperty(EntityTrades.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityTrapped.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVillagerExperience.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVillagerLevel.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVisible.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapTime.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapTime.java
@@ -3,28 +3,27 @@ package com.denizenscript.denizen.objects.properties.entity;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.DurationTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.entity.SkeletonHorse;
 
-public class EntityTrapped implements Property {
+public class EntityTrapTime implements Property {
 
     public static boolean describes(ObjectTag entity) {
         return entity instanceof EntityTag ent &&
                 (ent.getBukkitEntity() instanceof SkeletonHorse);
     }
 
-    public static EntityTrapped getFrom(ObjectTag entity) {
+    public static EntityTrapTime getFrom(ObjectTag entity) {
         if (!describes(entity)) {
             return null;
         }
         else {
-            return new EntityTrapped((EntityTag) entity);
+            return new EntityTrapTime((EntityTag) entity);
         }
     }
 
-    private EntityTrapped(EntityTag ent) {
+    private EntityTrapTime(EntityTag ent) {
         entity = ent;
     }
 
@@ -32,45 +31,44 @@ public class EntityTrapped implements Property {
 
     @Override
     public String getPropertyString() {
-        return String.valueOf(((SkeletonHorse) entity.getBukkitEntity()).isTrapped());
+        return String.valueOf(((SkeletonHorse) entity.getBukkitEntity()).getTrapTime());
     }
 
     @Override
     public String getPropertyId() {
-        return "trapped";
+        return "trap_time";
     }
 
     public static void register() {
 
         // <--[tag]
-        // @attribute <EntityTag.trapped>
+        // @attribute <EntityTag.trap_time>
         // @returns ElementTag(Boolean)
-        // @mechanism EntityTag.trapped
+        // @mechanism EntityTag.trap_time
         // @group properties
         // @description
-        // Returns whether the skeleton horse is trapped.
-        // A trapped skeleton horse will trigger the skeleton horse trap when the player is within 10 blocks of it.
+        // Returns the skeleton horse's trap time in ticks.
+        // Trap time will go up every tick for as long as the horse is trapped (see <@link tag EntityTag.trapped>).
+        // A trapped horse will despawn after it reaches 18000 ticks (15 minutes).
         // -->
-        PropertyParser.registerTag(EntityTrapped.class, ElementTag.class, "trapped", (attribute, object) -> {
-            return new ElementTag(object.isTrapped());
+        PropertyParser.registerTag(EntityTrapTime.class, DurationTag.class, "trap_time", (attribute, object) -> {
+            return new DurationTag(object.getSkeletonHorse().getTrapTime());
         });
 
         // <--[mechanism]
         // @object EntityTag
-        // @name trapped
-        // @input ElementTag(Boolean)
+        // @name trap_time
+        // @input DurationTag
         // @description
-        // Sets whether the skeleton horse is trapped.
-        // A trapped skeleton horse will trigger the skeleton horse trap when the player is within 10 blocks of it.
+        // Sets the skeleton horse's trap time.
+        // Trap time will go up every tick for as long as the horse is trapped (see <@link tag EntityTag.trapped>).
+        // A trap time greater than 18000 ticks (15 minutes) will despawn the horse on the next tick.
         // @tags
         // <EntityTag.trapped>
         // -->
-        PropertyParser.registerMechanism(EntityTrapped.class, ElementTag.class, "trapped", (object, mechanism, input) -> {
-            if (!mechanism.requireBoolean()) {
-                return;
-            }
+        PropertyParser.registerMechanism(EntityTrapTime.class, DurationTag.class, "trap_time", (object, mechanism, duration) -> {
             if (object.isSkeletonHorse()) {
-                object.getSkeletonHorse().setTrapped(input.asBoolean());
+                object.getSkeletonHorse().setTrapTime(duration.getTicksAsInt());
             }
         });
     }
@@ -81,12 +79,5 @@ public class EntityTrapped implements Property {
 
     public SkeletonHorse getSkeletonHorse() {
         return (SkeletonHorse) entity.getBukkitEntity();
-    }
-
-    public boolean isTrapped() {
-        if (isSkeletonHorse()) {
-            return getSkeletonHorse().isTrapped();
-        }
-        return false;
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapTime.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapTime.java
@@ -31,7 +31,7 @@ public class EntityTrapTime implements Property {
 
     @Override
     public String getPropertyString() {
-        return String.valueOf(((SkeletonHorse) entity.getBukkitEntity()).getTrapTime());
+        return new DurationTag((long) getSkeletonHorse().getTrapTime()).identify();
     }
 
     @Override
@@ -43,7 +43,7 @@ public class EntityTrapTime implements Property {
 
         // <--[tag]
         // @attribute <EntityTag.trap_time>
-        // @returns ElementTag(Boolean)
+        // @returns DurationTag
         // @mechanism EntityTag.trap_time
         // @group properties
         // @description
@@ -52,7 +52,7 @@ public class EntityTrapTime implements Property {
         // A trapped horse will despawn after it reaches 18000 ticks (15 minutes).
         // -->
         PropertyParser.registerTag(EntityTrapTime.class, DurationTag.class, "trap_time", (attribute, object) -> {
-            return new DurationTag(object.getSkeletonHorse().getTrapTime());
+            return new DurationTag((long) object.getSkeletonHorse().getTrapTime());
         });
 
         // <--[mechanism]
@@ -67,14 +67,8 @@ public class EntityTrapTime implements Property {
         // <EntityTag.trapped>
         // -->
         PropertyParser.registerMechanism(EntityTrapTime.class, DurationTag.class, "trap_time", (object, mechanism, duration) -> {
-            if (object.isSkeletonHorse()) {
-                object.getSkeletonHorse().setTrapTime(duration.getTicksAsInt());
-            }
+            object.getSkeletonHorse().setTrapTime(duration.getTicksAsInt());
         });
-    }
-
-    public boolean isSkeletonHorse() {
-        return entity.getBukkitEntity() instanceof SkeletonHorse;
     }
 
     public SkeletonHorse getSkeletonHorse() {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapped.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapped.java
@@ -1,0 +1,123 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.entity.SkeletonHorse;
+
+public class EntityTrapped implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag &&
+                (((EntityTag) entity).getBukkitEntity() instanceof SkeletonHorse);
+    }
+
+    public static EntityTrapped getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        else {
+            return new EntityTrapped((EntityTag) entity);
+        }
+    }
+
+    private EntityTrapped(EntityTag ent) {
+        entity = ent;
+    }
+
+    EntityTag entity;
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(((SkeletonHorse) entity.getBukkitEntity()).isTrapped());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "trapped";
+    }
+
+    public static void register() {
+
+        // <--[tag]
+        // @attribute <EntityTag.trapped>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.trapped
+        // @group properties
+        // @description
+        // Returns whether the skeleton horse is trapped.
+        // A trapped skeleton horse will trigger the skeleton horse trap when the player is within 10 blocks of it.
+        // -->
+        PropertyParser.registerTag(EntityTrapped.class, ElementTag.class, "trapped", (attribute, object) -> {
+            return new ElementTag(object.isTrapped());
+        });
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name trapped
+        // @input ElementTag(Boolean)
+        // @description
+        // Sets whether the skeleton horse is trapped.
+        // A trapped skeleton horse will trigger the skeleton horse trap when the player is within 10 blocks of it.
+        // @tags
+        // <EntityTag.trapped>
+        // -->
+        PropertyParser.registerMechanism(EntityTrapped.class, ElementTag.class, "trapped", (object, mechanism, input) -> {
+            if (!mechanism.requireBoolean()) {
+                return;
+            }
+            if (object.isSkeletonHorse()) {
+                object.getSkeletonHorse().setTrapped(input.asBoolean());
+            }
+        });
+
+        // <--[tag]
+        // @attribute <EntityTag.trap_time>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.trap_time
+        // @group properties
+        // @description
+        // Returns the skeleton horse's trap time in ticks.
+        // Trap time will go up every tick for as long as the horse is trapped (see <@link tag EntityTag.trapped>).
+        // A trapped horse will despawn after it reaches 18000 ticks (15 minutes).
+        // -->
+        PropertyParser.registerTag(EntityTrapped.class, DurationTag.class, "trap_time", (attribute, object) -> {
+            return new DurationTag(object.getSkeletonHorse().getTrapTime());
+        });
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name trap_time
+        // @input DurationTag
+        // @description
+        // Sets the skeleton horse's trap time.
+        // Trap time will go up every tick for as long as the horse is trapped (see <@link tag EntityTag.trapped>).
+        // A trap time greater than 18000 ticks (15 minutes) will despawn the horse on the next tick.
+        // @tags
+        // <EntityTag.trapped>
+        // -->
+        PropertyParser.registerMechanism(EntityTrapped.class, DurationTag.class, "trap_time", (object, mechanism, duration) -> {
+            if (object.isSkeletonHorse()) {
+                object.getSkeletonHorse().setTrapTime(duration.getTicksAsInt());
+            }
+        });
+    }
+
+    public boolean isSkeletonHorse() {
+        return entity.getBukkitEntity() instanceof SkeletonHorse;
+    }
+
+    public SkeletonHorse getSkeletonHorse() {
+        return (SkeletonHorse) entity.getBukkitEntity();
+    }
+
+    public boolean isTrapped() {
+        if (isSkeletonHorse()) {
+            return getSkeletonHorse().isTrapped();
+        }
+        return false;
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapped.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapped.java
@@ -2,7 +2,6 @@ package com.denizenscript.denizen.objects.properties.entity;
 
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
@@ -52,7 +51,7 @@ public class EntityTrapped implements Property {
         // A trapped skeleton horse will trigger the skeleton horse trap when the player is within 10 blocks of it.
         // -->
         PropertyParser.registerTag(EntityTrapped.class, ElementTag.class, "trapped", (attribute, object) -> {
-            return new ElementTag(object.isTrapped());
+            return new ElementTag(object.getSkeletonHorse().isTrapped());
         });
 
         // <--[mechanism]
@@ -69,24 +68,11 @@ public class EntityTrapped implements Property {
             if (!mechanism.requireBoolean()) {
                 return;
             }
-            if (object.isSkeletonHorse()) {
-                object.getSkeletonHorse().setTrapped(input.asBoolean());
-            }
+            object.getSkeletonHorse().setTrapped(input.asBoolean());
         });
-    }
-
-    public boolean isSkeletonHorse() {
-        return entity.getBukkitEntity() instanceof SkeletonHorse;
     }
 
     public SkeletonHorse getSkeletonHorse() {
         return (SkeletonHorse) entity.getBukkitEntity();
-    }
-
-    public boolean isTrapped() {
-        if (isSkeletonHorse()) {
-            return getSkeletonHorse().isTrapped();
-        }
-        return false;
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapped.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityTrapped.java
@@ -11,8 +11,8 @@ import org.bukkit.entity.SkeletonHorse;
 public class EntityTrapped implements Property {
 
     public static boolean describes(ObjectTag entity) {
-        return entity instanceof EntityTag &&
-                (((EntityTag) entity).getBukkitEntity() instanceof SkeletonHorse);
+        return entity instanceof EntityTag ent &&
+                (ent.getBukkitEntity() instanceof SkeletonHorse);
     }
 
     public static EntityTrapped getFrom(ObjectTag entity) {


### PR DESCRIPTION
## Event

### `skeleton horse trap`
Triggers when a player gets too close to a trapped skeleton horse and triggers the trap.
Paper only

#### Contexts
- `<context.entity>` - the skeleton horse
- `<context.players>` - the players involved in the trap

## Property (for Spigot and Paper)

### `EntityTrapped`
For `SkeletonHorse`s. When they are trapped, they can trigger the skeleton horse trap with the lightening and all that jazz.
They also have a trap time. If the skeleton horse is trapped, the trap time will increment until it reaches 18,000 ticks and will despawn automatically.

#### Tags
- `<EntityTag.trapped>` - if the skeleton horse is trapped or not
- `<EntityTag.trap_time>` - returns the trap time

#### Mechanisms
- `trapped` - sets if the skeleton horse is trapped or not
- `trap_time` - sets the trap time. setting to 18000t will despawn it on the next tick

Requested by LeafyMitsuwa on [Discord](https://discord.com/channels/315163488085475337/1079315566512308285/1079315566512308285)

###### 🦴🦴🦴

(P.S. I've never made a property before. Hope I did it right! :D)

