### PR TITLE
Add is_interactable tag to MaterialTag

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -358,6 +358,18 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         });
 
         // <--[tag]
+        // @attribute <MaterialTag.is_interactable>
+        // @returns ElementTag(Boolean)
+        // @description
+        // Returns whether the material can be interacted with.
+        // Some blocks such as piston heads and stairs are considered interactable.
+        // Note that this will return true if at least one state of a material has interaction handling.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "is_interactable", (attribute, object) -> {
+            return new ElementTag(object.material.isInteractable());
+        });
+
+        // <--[tag]
         // @attribute <MaterialTag.is_burnable>
         // @returns ElementTag(Boolean)
         // @description


### PR DESCRIPTION
Adds support for the isInteractable() check on Materials. Summarizes notes and oddities as described here:
https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/Material.java#8593-8609