### PR TITLE
Fix `server.biome_types` on 1.19.4

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -717,8 +717,9 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
             listDeprecateWarn(attribute);
             ListTag biomes = new ListTag();
             for (Biome biome : Biome.values()) {
-                if (biome != Biome.CUSTOM) {
-                    biomes.addObject(new BiomeTag(biome));
+                BiomeTag biomeTag = new BiomeTag(biome);
+                if (biomeTag.getBiome() != null) {
+                    biomes.addObject(biomeTag);
                 }
             }
             return biomes;


### PR DESCRIPTION
Spigot added the experimental `1.20` biomes into the `Biome` enum as they're available though the experimental features data packs, but that means `biome_types` would error trying to get these as they're not present by default.

## Changes

- `server.biome_types` now checks whether the `BiomeTag`'s `BiomeNMS` object isn't null, thus making sure that biome is actually present on the server.