### PR TITLE
`Instrument` property for goat horns

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -154,7 +154,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(ItemFlags.class, ItemTag.class);
         PropertyParser.registerProperty(ItemFrameInvisible.class, ItemTag.class);
         PropertyParser.registerProperty(ItemHidden.class, ItemTag.class);
-        PropertyParser.registerProperty(ItemHornInstrument.class, ItemTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            PropertyParser.registerProperty(ItemHornInstrument.class, ItemTag.class);
+        }
         PropertyParser.registerProperty(ItemInventory.class, ItemTag.class);
         PropertyParser.registerProperty(ItemKnowledgeBookRecipes.class, ItemTag.class);
         PropertyParser.registerProperty(ItemLock.class, ItemTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -155,7 +155,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(ItemFrameInvisible.class, ItemTag.class);
         PropertyParser.registerProperty(ItemHidden.class, ItemTag.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-            PropertyParser.registerProperty(ItemHornInstrument.class, ItemTag.class);
+            PropertyParser.registerProperty(ItemInstrument.class, ItemTag.class);
         }
         PropertyParser.registerProperty(ItemInventory.class, ItemTag.class);
         PropertyParser.registerProperty(ItemKnowledgeBookRecipes.class, ItemTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -154,6 +154,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(ItemFlags.class, ItemTag.class);
         PropertyParser.registerProperty(ItemFrameInvisible.class, ItemTag.class);
         PropertyParser.registerProperty(ItemHidden.class, ItemTag.class);
+        PropertyParser.registerProperty(ItemHornInstrument.class, ItemTag.class);
         PropertyParser.registerProperty(ItemInventory.class, ItemTag.class);
         PropertyParser.registerProperty(ItemKnowledgeBookRecipes.class, ItemTag.class);
         PropertyParser.registerProperty(ItemLock.class, ItemTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemHornInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemHornInstrument.java
@@ -69,7 +69,7 @@ public class ItemHornInstrument extends ItemProperty {
         // Sets the instrument of a goat horn.
         // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
         // @tags
-        // <EntityTag.horn_instrument>
+        // <ItemTag.horn_instrument>
         // @example
         // - inventory adjust slot:hand horn_instrument:seek_goat_horn
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemHornInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemHornInstrument.java
@@ -1,0 +1,80 @@
+package com.denizenscript.denizen.objects.properties.item;
+
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.Material;
+import org.bukkit.MusicInstrument;
+import org.bukkit.inventory.meta.MusicInstrumentMeta;
+
+public class ItemHornInstrument extends ItemProperty {
+
+    public static boolean describes(ItemTag item) {
+        return item.getBukkitMaterial() == Material.GOAT_HORN;
+    }
+
+    @Override
+    public String getPropertyString() {
+        MusicInstrument instrument = getMusicInstrument();
+        if (instrument != null) {
+            return Utilities.namespacedKeyToString(instrument.getKey());
+        }
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "horn_instrument";
+    }
+
+    public MusicInstrument getMusicInstrument() {
+        MusicInstrumentMeta itemMeta = (MusicInstrumentMeta) getItemMeta();
+        return itemMeta.getInstrument();
+    }
+
+    public void setMusicInstrument(MusicInstrument instrument) {
+        MusicInstrumentMeta itemMeta = (MusicInstrumentMeta) getItemMeta();
+        itemMeta.setInstrument(instrument);
+        setItemMeta(itemMeta);
+    }
+
+    public static void register() {
+
+        // <--[tag]
+        // @attribute <ItemTag.horn_instrument>
+        // @returns ElementTag
+        // @group properties
+        // @mechanism ItemTag.horn_instrument
+        // @description
+        // Returns the instrument of a goat horn.
+        // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
+        // @example
+        // # This can narrate: "This horn has the ponder_goat_horn instrument!"
+        // - narrate "This horn has the <player.item_in_hand.horn_instrument> instrument!"
+        // -->
+        PropertyParser.registerTag(ItemHornInstrument.class, ElementTag.class, "horn_instrument", (attribute, prop) -> {
+            MusicInstrument musicInstrument = prop.getMusicInstrument();
+            if (musicInstrument == null) {
+                return null;
+            }
+            return new ElementTag(Utilities.namespacedKeyToString(musicInstrument.getKey()));
+        });
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name horn_instrument
+        // @input ElementTag
+        // @description
+        // Sets the instrument of a goat horn.
+        // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
+        // @tags
+        // <EntityTag.horn_instrument>
+        // @example
+        // - adjust <player.item_in_hand> horn_instrument:seek_goat_horn
+        // -->
+        PropertyParser.registerMechanism(ItemHornInstrument.class, ElementTag.class, "horn_instrument", (prop, mechanism, param) -> {
+            prop.setMusicInstrument(MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString())));
+        });
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemHornInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemHornInstrument.java
@@ -62,7 +62,7 @@ public class ItemHornInstrument extends ItemProperty {
         });
 
         // <--[mechanism]
-        // @object EntityTag
+        // @object ItemTag
         // @name horn_instrument
         // @input ElementTag
         // @description
@@ -71,7 +71,7 @@ public class ItemHornInstrument extends ItemProperty {
         // @tags
         // <EntityTag.horn_instrument>
         // @example
-        // - adjust <player.item_in_hand> horn_instrument:seek_goat_horn
+        // - inventory adjust slot:hand horn_instrument:seek_goat_horn
         // -->
         PropertyParser.registerMechanism(ItemHornInstrument.class, ElementTag.class, "horn_instrument", (prop, mechanism, param) -> {
             prop.setMusicInstrument(MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString())));

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
@@ -8,24 +8,24 @@ import org.bukkit.Material;
 import org.bukkit.MusicInstrument;
 import org.bukkit.inventory.meta.MusicInstrumentMeta;
 
-public class ItemHornInstrument extends ItemProperty {
+public class ItemInstrument extends ItemProperty {
 
     public static boolean describes(ItemTag item) {
         return item.getBukkitMaterial() == Material.GOAT_HORN;
     }
 
     @Override
-    public String getPropertyString() {
+    public ElementTag getPropertyValue() {
         MusicInstrument instrument = getMusicInstrument();
         if (instrument != null) {
-            return Utilities.namespacedKeyToString(instrument.getKey());
+            return new ElementTag(Utilities.namespacedKeyToString(instrument.getKey()));
         }
         return null;
     }
 
     @Override
     public String getPropertyId() {
-        return "horn_instrument";
+        return "instrument";
     }
 
     public MusicInstrument getMusicInstrument() {
@@ -42,18 +42,18 @@ public class ItemHornInstrument extends ItemProperty {
     public static void register() {
 
         // <--[tag]
-        // @attribute <ItemTag.horn_instrument>
+        // @attribute <ItemTag.instrument>
         // @returns ElementTag
         // @group properties
-        // @mechanism ItemTag.horn_instrument
+        // @mechanism ItemTag.instrument
         // @description
         // Returns the instrument of a goat horn.
         // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
         // @example
         // # This can narrate: "This horn has the ponder_goat_horn instrument!"
-        // - narrate "This horn has the <player.item_in_hand.horn_instrument> instrument!"
+        // - narrate "This horn has the <player.item_in_hand.instrument> instrument!"
         // -->
-        PropertyParser.registerTag(ItemHornInstrument.class, ElementTag.class, "horn_instrument", (attribute, prop) -> {
+        PropertyParser.registerTag(ItemInstrument.class, ElementTag.class, "instrument", (attribute, prop) -> {
             MusicInstrument musicInstrument = prop.getMusicInstrument();
             if (musicInstrument == null) {
                 return null;
@@ -63,17 +63,22 @@ public class ItemHornInstrument extends ItemProperty {
 
         // <--[mechanism]
         // @object ItemTag
-        // @name horn_instrument
+        // @name instrument
         // @input ElementTag
         // @description
         // Sets the instrument of a goat horn.
         // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
         // @tags
-        // <ItemTag.horn_instrument>
+        // <ItemTag.instrument>
         // @example
-        // - inventory adjust slot:hand horn_instrument:seek_goat_horn
+        // - inventory adjust slot:hand instrument:seek_goat_horn
         // -->
-        PropertyParser.registerMechanism(ItemHornInstrument.class, ElementTag.class, "horn_instrument", (prop, mechanism, param) -> {
+        PropertyParser.registerMechanism(ItemInstrument.class, ElementTag.class, "instrument", (prop, mechanism, param) -> {
+            MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString()));
+            if (instrument == null) {
+                mechanism.echoError("Invalid horn instrument: '" + param.asString() + "'! Instrument names should be like this: 'seek_goat_horn'.");
+                return;
+            }
             prop.setMusicInstrument(MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString())));
         });
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
@@ -83,7 +83,9 @@ public class ItemRawNBT implements Property {
                 //"LodestoneDimension", "LodestonePos", // Temporarily sent through due to "Dimension" inconsistency, and compatibility with unloaded worlds
                 "LodestoneTracked",
                 // Bundle specific
-                "Items"
+                "Items",
+                // Goat Horn specific
+                "instrument",
         };
         defaultNbtKeys = new StringHolder[defaultNbtKeysRaw.length];
         for (int i = 0; i < defaultNbtKeysRaw.length; i++) {


### PR DESCRIPTION
# `Instrument` property

For changing the horn instrument of a goat horn (the song that plays when you use it).

## Tags
- `<ItemTag.instrument>` - returns the instrument of the horn

## Mechanisms
- `ItemTag.instrument` - set the instrument of the horn

## Notes
The instrument names aren't just `ponder`, `call`, `dream` (like the class field names), etc., but are actually `ponder_goat_horn`, `call_goat_horn`, `dream_goat_horn`, etc. Not sure if we should make it accept the former later on or in this PR, or just keep the latter for now. As always let me know :)

Kinda requested by Icecapade over a VC