### PR TITLE
Update `EntityTag.age`, separate age locking, add `EntityProperty#as`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.objects.properties;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.*;
 import com.denizenscript.denizen.objects.properties.bukkit.*;
 import com.denizenscript.denizen.objects.properties.entity.*;
@@ -7,8 +9,6 @@ import com.denizenscript.denizen.objects.properties.inventory.*;
 import com.denizenscript.denizen.objects.properties.item.*;
 import com.denizenscript.denizen.objects.properties.material.*;
 import com.denizenscript.denizen.objects.properties.trade.*;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 public class PropertyRegistry {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -28,6 +28,7 @@ public class PropertyRegistry {
 
         // register core EntityTag properties
         PropertyParser.registerProperty(EntityAge.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityAgeLocked.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAggressive.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAI.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAnger.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAge.java
@@ -110,33 +110,5 @@ public class EntityAge extends EntityProperty {
                 }
             }
         });
-
-        // <--[tag]
-        // @attribute <EntityTag.is_age_locked>
-        // @returns ElementTag(Boolean)
-        // @group properties
-        // @deprecated use 'age_locked'.
-        // @description
-        // Deprecated in favor of <@link tag EntityTag.age_locked>.
-        // -->
-        PropertyParser.registerTag(EntityAge.class, ElementTag.class, "is_age_locked", (attribute, prop) -> {
-            BukkitImplDeprecations.oldAgeLockedControls.warn(attribute.context);
-            return new ElementTag(!(prop.getEntity() instanceof Breedable breedable) || breedable.getAgeLock());
-        });
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name age_lock
-        // @input ElementTag(Boolean)
-        // @deprecated use 'age_locked'.
-        // @description
-        // Deprecated in favor of <@link mechanism EntityTag.age_locked>.
-        // -->
-        PropertyParser.registerMechanism(EntityAge.class, ElementTag.class, "age_lock", (prop, mechanism, input) -> {
-            BukkitImplDeprecations.oldAgeLockedControls.warn(mechanism.context);
-            if (mechanism.requireBoolean() && prop.getEntity() instanceof Breedable breedable) {
-                breedable.setAgeLock(input.asBoolean());
-            }
-        });
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAgeLocked.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAgeLocked.java
@@ -1,0 +1,59 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import net.citizensnpcs.trait.Age;
+import org.bukkit.entity.Breedable;
+
+public class EntityAgeLocked extends EntityProperty {
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof Breedable;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return as(Breedable.class).getAgeLock() ? new ElementTag(true) : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "age_locked";
+    }
+
+    public static void register() {
+
+        // <--[tag]
+        // @attribute <EntityTag.age_locked>
+        // @returns ElementTag(Boolean)
+        // @mechanism EntityTag.age_locked
+        // @group properties
+        // @description
+        // Returns whether the entity is locked into it's current age.
+        // -->
+        PropertyParser.registerTag(EntityAgeLocked.class, ElementTag.class, "age_locked", (attribute, prop) -> {
+            return new ElementTag(prop.as(Breedable.class).getAgeLock());
+        });
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name age_locked
+        // @input ElementTag(Boolean)
+        // @description
+        // Sets whether the entity is locked into its current age.
+        // @tags
+        // <EntityTag.age_locked>
+        // -->
+        PropertyParser.registerMechanism(EntityAgeLocked.class, ElementTag.class, "age_locked", (prop, mechanism, input) -> {
+            if (mechanism.requireBoolean()) {
+                if (prop.object.isCitizensNPC()) {
+                    prop.object.getDenizenNPC().getCitizen().getOrAddTrait(Age.class).setLocked(input.asBoolean());
+                }
+                else {
+                    prop.as(Breedable.class).setAgeLock(input.asBoolean());
+                }
+            }
+        });
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAgeLocked.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAgeLocked.java
@@ -39,7 +39,7 @@ public class EntityAgeLocked extends EntityProperty {
         // @mechanism EntityTag.age_locked
         // @group properties
         // @description
-        // Returns whether the entity is locked into it's current age.
+        // Returns whether the entity is locked into its current age.
         // -->
         PropertyParser.registerTag(EntityAgeLocked.class, ElementTag.class, "age_locked", (attribute, prop) -> {
             return new ElementTag(prop.as(Breedable.class).getAgeLock());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAgeLocked.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAgeLocked.java
@@ -25,6 +25,15 @@ public class EntityAgeLocked extends EntityProperty {
     public static void register() {
 
         // <--[tag]
+        // @attribute <EntityTag.is_age_locked>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @deprecated use 'age_locked'.
+        // @description
+        // Deprecated in favor of <@link tag EntityTag.age_locked>.
+        // -->
+
+        // <--[tag]
         // @attribute <EntityTag.age_locked>
         // @returns ElementTag(Boolean)
         // @mechanism EntityTag.age_locked
@@ -34,7 +43,16 @@ public class EntityAgeLocked extends EntityProperty {
         // -->
         PropertyParser.registerTag(EntityAgeLocked.class, ElementTag.class, "age_locked", (attribute, prop) -> {
             return new ElementTag(prop.as(Breedable.class).getAgeLock());
-        });
+        }, "is_age_locked");
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name age_lock
+        // @input ElementTag(Boolean)
+        // @deprecated use 'age_locked'.
+        // @description
+        // Deprecated in favor of <@link mechanism EntityTag.age_locked>.
+        // -->
 
         // <--[mechanism]
         // @object EntityTag
@@ -54,6 +72,6 @@ public class EntityAgeLocked extends EntityProperty {
                     prop.as(Breedable.class).setAgeLock(input.asBoolean());
                 }
             }
-        });
+        }, "age_lock");
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProperty.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProperty.java
@@ -26,4 +26,9 @@ public abstract class EntityProperty extends ObjectProperty<EntityTag> {
     public EntityType getType() {
         return object.getBukkitEntityType();
     }
+
+    @SuppressWarnings({"unchecked", "unused"})
+    public <T extends Entity> T as(Class<T> entityClass) {
+        return (T) getEntity();
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AgeCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AgeCommand.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.scripts.commands.entity;
 
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.properties.entity.EntityAge;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
@@ -9,6 +8,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.entity.Breedable;
 
 import java.util.List;

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AgeCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AgeCommand.java
@@ -9,6 +9,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import org.bukkit.entity.Breedable;
 
 import java.util.List;
 
@@ -112,7 +113,9 @@ public class AgeCommand extends AbstractCommand {
                     else {
                         property.setAge(age);
                     }
-                    property.setLock(lock);
+                    if (entity instanceof Breedable breedable) {
+                        breedable.setAgeLock(lock);
+                    }
                 }
                 else {
                     Debug.echoError(scriptEntry, entity.identify() + " is not ageable!");

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -275,7 +275,7 @@ public class BukkitImplDeprecations {
     // Added 2023/03/05, deprecate officially by 2026
     public static Warning serverSystemMechanisms = new FutureWarning("serverSystemMechanisms", "Some 'server' mechanisms for core features are deprecated in favor of 'system' equivalents.");
 
-    // Added 2023/03/05, deprecate officially by 2026
+    // Added 2023/03/27, deprecate officially by 2026
 
     public static Warning oldAgeLockedControls = new FutureWarning("oldAgeLockedControls", "Several old ways of controlling whether an entity's age is locked are deprecated in favor of the 'EntityTag.age_locked' tag/mech pair.");
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -276,7 +276,6 @@ public class BukkitImplDeprecations {
     public static Warning serverSystemMechanisms = new FutureWarning("serverSystemMechanisms", "Some 'server' mechanisms for core features are deprecated in favor of 'system' equivalents.");
 
     // Added 2023/03/27, deprecate officially by 2026
-
     public static Warning oldAgeLockedControls = new FutureWarning("oldAgeLockedControls", "Several old ways of controlling whether an entity's age is locked are deprecated in favor of the 'EntityTag.age_locked' tag/mech pair.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -275,6 +275,10 @@ public class BukkitImplDeprecations {
     // Added 2023/03/05, deprecate officially by 2026
     public static Warning serverSystemMechanisms = new FutureWarning("serverSystemMechanisms", "Some 'server' mechanisms for core features are deprecated in favor of 'system' equivalents.");
 
+    // Added 2023/03/05, deprecate officially by 2026
+
+    public static Warning oldAgeLockedControls = new FutureWarning("oldAgeLockedControls", "Several old ways of controlling whether an entity's age is locked are deprecated in favor of the 'EntityTag.age_locked' tag/mech pair.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Added on 2019/10/13


### PR DESCRIPTION
## Changes

- Changed `EntityAge`'s property string to just the entity's age
- Changed the `age` mechanism to use modern `switch`es instead of an `if`/`else` chain.
- Changed up some meta to be more consistent (mainly the `age` tag + mech).
- Deprecated old age locked controls in favor of the new `EntityTag.age_locked` (`|locked/unlocked` in the `age` mech, `is_age_locked` tag, `age_lock` mechanism).

## Additions

- `EntityProperty#as(Class<? extends Entity>)` util method - replaces the existing `getX` boilerplate methods.
- `EntityAgeLocked` property - controls whether an entity's age is locked.
- `oldAgeLockedControls` future warning - for the old tags / mechs to control whether an entity's age is locked, which are now deprecated in favor of `EntityTag.age_locked`.

## Notes

- Let me know if the `EntityProperty#as` method should be moved into a separate PR, it's a really minor addition so currently it's included in here.