### PR TITLE
Add `EntityTag.step_height` property

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -445,4 +445,12 @@ public abstract class EntityHelper {
     public void setUUID(Entity entity, UUID id) {
         throw new UnsupportedOperationException();
     }
+
+    public float getStepHeight(Entity entity) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setStepHeight(Entity entity, float stepHeight) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -115,6 +115,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntitySize.class, EntityTag.class);
         PropertyParser.registerProperty(EntitySpeed.class, EntityTag.class);
         PropertyParser.registerProperty(EntitySpell.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            PropertyParser.registerProperty(EntityStepHeight.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityStrength.class, EntityTag.class);
         PropertyParser.registerProperty(EntityTame.class, EntityTag.class);
         PropertyParser.registerProperty(EntityEyeTargetLocation.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStepHeight.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStepHeight.java
@@ -1,0 +1,56 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+
+public class EntityStepHeight extends EntityProperty {
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(NMSHandler.entityHelper.getStepHeight(getEntity()));
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "step_height";
+    }
+
+    public static void register() {
+
+        // <--[tag]
+        // @attribute <EntityTag.step_height>
+        // @returns ElementTag(Decimal)
+        // @mechanism EntityTag.step_height
+        // @group properties
+        // @description
+        // Returns the entity's step height, which controls how many blocks can it walk over.
+        // As this is based on an internal value, it has some edge-cases, for example:
+        // - most (but not all) living entities can still step over 1 block tall things as usual, even if this is set to 0.
+        // - this doesn't apply to vehicles when the player is controlling them.
+        // Note that this also applies to things like getting pushed.
+        // -->
+        PropertyParser.registerTag(EntityStepHeight.class, ElementTag.class, "step_height", (attribute, prop) -> {
+            return prop.getPropertyValue();
+        });
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name step_height
+        // @input ElementTag(Decimal)
+        // @description
+        // Sets the entity's step height, which controls how many blocks can it walk over.
+        // As this is based on an internal value, it has some edge-cases, for example:
+        // - most (but not all) living entities can still step over 1 block tall things as usual, even if this is set to 0.
+        // - this doesn't apply to vehicles when the player is controlling them.
+        // Note that this also applies to things like getting pushed.
+        // @tags
+        // <EntityTag.step_height>
+        // -->
+        PropertyParser.registerMechanism(EntityStepHeight.class, ElementTag.class, "step_height", (prop, mechanism, input) -> {
+            if (mechanism.requireFloat()) {
+                NMSHandler.entityHelper.setStepHeight(prop.getEntity(), input.asFloat());
+            }
+        });
+    }
+}

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -833,4 +833,14 @@ public class EntityHelperImpl extends EntityHelper {
             Debug.echoError(ex);
         }
     }
+
+    @Override
+    public float getStepHeight(Entity entity) {
+        return ((CraftEntity) entity).getHandle().maxUpStep();
+    }
+
+    @Override
+    public void setStepHeight(Entity entity, float stepHeight) {
+        ((CraftEntity) entity).getHandle().setMaxUpStep(stepHeight);
+    }
 }


### PR DESCRIPTION
## Additions

- Added an `EntityTag.step_height` property, which controls how many blocks can an entity walk over - has some internal weirdness because Mojang, but hopefully I managed to find and document the major ones; we can always expand the meta later on.

The code itself is pretty straightforward, mostly made it a PR for a meta review