### PR TITLE
`Cast` command: update, support infinite durations

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
@@ -52,11 +52,11 @@ public class CastCommand extends AbstractCommand {
     // If you don't specify an amplifier level, it defaults to 1, meaning an effect of level 2 (this is for historical compatibility reasons).
     // Specify "amplifier:0" to have no amplifier applied (ie effect level 1).
     //
-    // If no player is specified, the command will target the player.
-    // If no player is present, the command will target the NPC. If an NPC is not present, there will be an error!
+    // If no entity is specified, the command will target the linked player.
+    // If there isn't one, the command will target the linked NPC. If there isn't one either, the command will error.
     //
     // Optionally, specify "no_ambient" to hide some translucent additional particles, while still rendering the main particles.
-    // "Ambient" effects in vanilla came from a beacon, while non-ambient came from a potion.
+    // "Ambient" effects in vanilla come from a beacon, while non-ambient come from a potion.
     //
     // Optionally, specify "hide_particles" to remove the particle effects entirely.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
@@ -71,7 +71,7 @@ public class CastCommand extends AbstractCommand {
     //
     // @Usage
     // Use to cast a level 1 effect onto the linked player or NPC for 50 seconds.
-    // - cast speed amplifier:0 duration:50s
+    // - cast speed duration:50s amplifier:0
     //
     // @Usage
     // Use to cast an effect onto the linked player or NPC for an infinite duration with an amplifier of 3 (effect level 4).

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
@@ -46,7 +46,7 @@ public class CastCommand extends AbstractCommand {
     // The effect type must be from <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/potion/PotionEffectType.html>.
     //
     // If you don't specify a duration, it defaults to 60 seconds.
-    // An infinite duration will create an infinite duration potion effect, refer to <@link objecttype DurationTag> for more details.
+    // An infinite duration will apply an infinite duration potion effect, refer to <@link objecttype DurationTag> for more details.
     //
     // The amplifier is how many levels to *add* over the normal level 1.
     // If you don't specify an amplifier level, it defaults to 1, meaning an effect of level 2 (this is for historical compatibility reasons).

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
@@ -70,11 +70,11 @@ public class CastCommand extends AbstractCommand {
     // <EntityTag.effects_data>
     //
     // @Usage
-    // Use to cast a level 1 effect onto the linked player for 50 seconds.
+    // Use to cast a level 1 effect onto the linked player or NPC for 50 seconds.
     // - cast speed amplifier:0 duration:50s
     //
     // @Usage
-    // Use to cast an effect onto the linked player for an infinite duration with an amplifier of 3 (effect level 4).
+    // Use to cast an effect onto the linked player or NPC for an infinite duration with an amplifier of 3 (effect level 4).
     // - cast jump duration:infinite amplifier:3
     //
     // @Usage

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/CastCommand.java
@@ -70,12 +70,12 @@ public class CastCommand extends AbstractCommand {
     // <EntityTag.effects_data>
     //
     // @Usage
-    // Use to cast a level 1 effect onto the linked player.
-    // - cast speed amplifier:0
+    // Use to cast a level 1 effect onto the linked player for 50 seconds.
+    // - cast speed amplifier:0 duration:50s
     //
     // @Usage
-    // Use to cast an effect onto the linked player for 120 seconds with an amplifier of 3 (effect level 4).
-    // - cast jump duration:120 amplifier:3
+    // Use to cast an effect onto the linked player for an infinite duration with an amplifier of 3 (effect level 4).
+    // - cast jump duration:infinite amplifier:3
     //
     // @Usage
     // Use to remove an effect from a specific entity.


### PR DESCRIPTION
## Changes

- Updated to modern `autoExecute` format.
- Cleaned up the logic a little bit (e.g. it will now only construct the potion effect once)
- Added handling for infinite durations: on 1.19+ will apply a proper infinite effect, on versions below that will apply a max duration one (which renders as `**:**`, I.e. infinite).
- Improved the meta & examples.