### PR TITLE
Bug fix - allow player tracker to update in the denizen map renderer

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/DenizenMapManager.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/DenizenMapManager.java
@@ -156,7 +156,8 @@ public class DenizenMapManager {
         int mapId = map.getId();
         DenizenMapRenderer dmr;
         if (!mapRenderers.containsKey(mapId)) {
-            dmr = new DenizenMapRenderer(map.getRenderers(), false, false);
+            boolean contextual = map.isTrackingPosition() || map.isUnlimitedTracking();
+            dmr = new DenizenMapRenderer(map.getRenderers(), false, contextual);
             setMap(map, dmr);
         }
         else {


### PR DESCRIPTION
Bug reported by Mars, Arkyoh, and DerQualle on [Discord](https://discord.com/channels/315163488085475337/1087166438348967967/1087166438348967967) where adding any custom denizen features to the map stopped the player tracker.

DenizenMapRenderer is now made aware to update if tracking is on

Tested on 1.19.4

First PR, so let me know if somethings wrong here :D