### PR TITLE
NPC chat system cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/npc/TraitRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/TraitRegistry.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.npc;
 
-import com.denizenscript.denizen.npc.speech.DenizenChat;
 import com.denizenscript.denizen.npc.traits.*;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.trait.TraitInfo;
@@ -25,8 +24,5 @@ public class TraitRegistry {
         CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(SleepingTrait.class).withName("sleeping"));
         CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(SneakingTrait.class).withName("sneaking"));
         CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(TriggerTrait.class).withName("triggers"));
-
-        // Register Speech AI
-        CitizensAPI.getSpeechFactory().register(DenizenChat.class, "denizen_chat");
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/speech/DenizenChat.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/speech/DenizenChat.java
@@ -10,8 +10,7 @@ import com.denizenscript.denizencore.scripts.queues.ScriptQueue;
 import com.denizenscript.denizencore.tags.TagManager;
 import net.citizensnpcs.api.ai.speech.SpeechContext;
 import net.citizensnpcs.api.ai.speech.Talkable;
-import net.citizensnpcs.api.ai.speech.VocalChord;
-import net.citizensnpcs.npc.ai.speech.TalkableEntity;
+import net.citizensnpcs.api.ai.speech.TalkableEntity;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 
@@ -19,22 +18,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class DenizenChat implements VocalChord {
+public class DenizenChat {
 
-    public final String VOCAL_CHORD_NAME = "denizen_chat";
-
-    @Override
-    public String getName() {
-        return VOCAL_CHORD_NAME;
-    }
-
-    @Override
-    public void talk(SpeechContext speechContext) {
-        if (!(speechContext instanceof DenizenSpeechContext)) {
+    public static void talk(SpeechContext speechContext) {
+        if (!(speechContext instanceof DenizenSpeechContext context)) {
             return;
         }
-
-        DenizenSpeechContext context = (DenizenSpeechContext) speechContext;
 
         Talkable talker = context.getTalker();
         if (talker == null) {
@@ -67,7 +56,7 @@ public class DenizenChat implements VocalChord {
             // Send chat to target
             String text = TagManager.tag(Settings.chatToTargetFormat(), new BukkitTagContext(entry));
             for (Talkable entity : context) {
-                entity.talkTo(context, PaperAPITools.instance.convertTextToMiniMessage(text, true), this);
+                entity.talkTo(context, PaperAPITools.instance.convertTextToMiniMessage(text, true));
             }
             // Check if bystanders hear targeted chat
             if (context.isBystandersEnabled()) {
@@ -89,7 +78,7 @@ public class DenizenChat implements VocalChord {
             // Send chat to targets
             String text = TagManager.tag(Settings.chatToTargetFormat(), new BukkitTagContext(entry));
             for (Talkable entity : context) {
-                entity.talkTo(context, PaperAPITools.instance.convertTextToMiniMessage(text, true), this);
+                entity.talkTo(context, PaperAPITools.instance.convertTextToMiniMessage(text, true));
             }
             if (context.isBystandersEnabled()) {
                 String[] format = Settings.chatMultipleTargetsFormat().split("%target%");
@@ -132,7 +121,7 @@ public class DenizenChat implements VocalChord {
         }
     }
 
-    private void talkToBystanders(Talkable talkable, String text, DenizenSpeechContext context) {
+    public static void talkToBystanders(Talkable talkable, String text, DenizenSpeechContext context) {
         double range = context.getChatRange();
         List<Entity> bystanderEntities;
         if (range == 0D) {
@@ -155,7 +144,7 @@ public class DenizenChat implements VocalChord {
             // Found a nearby LivingEntity, make it Talkable and
             // talkNear it if 'should_talk'
             if (shouldTalk) {
-                new TalkableEntity(bystander).talkNear(context, PaperAPITools.instance.convertTextToMiniMessage(text, true), this);
+                new TalkableEntity(bystander).talkNear(context, PaperAPITools.instance.convertTextToMiniMessage(text, true));
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/speech/DenizenSpeechController.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/speech/DenizenSpeechController.java
@@ -17,44 +17,22 @@ public class DenizenSpeechController implements SpeechController {
         isNPC = CitizensAPI.getNPCRegistry().isNPC(entity);
     }
 
-    /**
-     * Makes the talker speak, based on the context given, with the DenizenChat vocal chord.
-     *
-     * @param context the context
-     */
     public void speak(DenizenSpeechContext context) {
         context.setTalker(entity);
         if (isNPC) {
-            NPCSpeechEvent event = new NPCSpeechEvent(context, "denizen_chat");
+            NPCSpeechEvent event = new NPCSpeechEvent(context);
             Bukkit.getServer().getPluginManager().callEvent(event);
             if (event.isCancelled()) {
                 return;
             }
         }
-        CitizensAPI.getSpeechFactory().getVocalChord("denizen_chat").talk(context);
+        DenizenChat.talk(context);
     }
 
     @Override
     public void speak(SpeechContext context) {
-        if (context instanceof DenizenSpeechContext) {
-            speak((DenizenSpeechContext) context);
+        if (context instanceof DenizenSpeechContext denizenSpeechContext) {
+            speak(denizenSpeechContext);
         }
-        else {
-            speak(context, "chat");
-        }
-    }
-
-    @Override
-    public void speak(SpeechContext context, String vocalChordName) {
-        context.setTalker(entity);
-        if (isNPC) {
-            NPCSpeechEvent event = new NPCSpeechEvent(context, vocalChordName);
-            Bukkit.getServer().getPluginManager().callEvent(event);
-            if (event.isCancelled()) {
-                return;
-            }
-            vocalChordName = event.getVocalChordName();
-        }
-        CitizensAPI.getSpeechFactory().getVocalChord(vocalChordName).talk(context);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SleepingTrait.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SleepingTrait.java
@@ -102,8 +102,7 @@ public class SleepingTrait extends Trait {
             Debug.echoError("NPC " + npc.getId() + " cannot sleep: invalid bed location.");
             return;
         }
-        //TODO Adjust the .add()
-        npc.getEntity().teleport(location.clone().add(0.5, 0, 0.5));
+        npc.getEntity().teleport(location.clone());
         bedLocation = location.clone();
         internalSleepNow();
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -1134,10 +1134,10 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 return getDenizenPlayer().identify();
             }
             if (entityScript != null) {
-                return "e@" + getUUID() + "/" + entityScript + mechsHandler.get();
+                return "e@" + getUUID() + "/" + entityScript;
             }
             if (entity_type != null) {
-                return "e@" + getUUID() + "/" + entity_type.getLowercaseName() + mechsHandler.get();
+                return "e@" + getUUID() + "/" + entity_type.getLowercaseName();
             }
         }
         if (entityScript != null) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2980,13 +2980,11 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
 
     @Override
     public void adjust(Mechanism mechanism) {
-
         if (isGeneric()) {
             mechanisms.add(mechanism);
             mechanism.fulfill();
             return;
         }
-
         if (getBukkitEntity() == null) {
             if (isCitizensNPC()) {
                 mechanism.echoError("Cannot adjust not-spawned NPC " + getDenizenNPC());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2899,6 +2899,22 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 mechanism.echoError("Cannot parse UUID input '" + new_id + "': " + ex.getMessage());
             }
         });
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name visual_pose
+        // @input ElementTag
+        // @description
+        // Sets the entity's visual pose, must be one of <@link url https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/Pose.html>.
+        // Note that not all entities support all poses, some are only supported by specific entity types.
+        // @tags
+        // <EntityTag.visual_pose>
+        // -->
+        registerSpawnedOnlyMechanism("visual_pose", false, ElementTag.class, (object, mechanism, input) -> {
+            if (mechanism.requireEnum(Pose.class)) {
+                NMSHandler.entityHelper.setPose(object.getBukkitEntity(), input.asEnum(Pose.class));
+            }
+        });
     }
 
     public EntityTag describe(TagContext context) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisplayEntityData.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDisplayEntityData.java
@@ -184,7 +184,7 @@ public class EntityDisplayEntityData implements Property {
                 item.setItemDisplayTransform(map.getElement("item_transform").asEnum(ItemDisplay.ItemDisplayTransform.class));
             }
             else if (display instanceof TextDisplay text) {
-                text.setAlignment(map.getElement("text_alignment", text.getAlignment().name()).asEnum(TextDisplay.TextAligment.class));
+                text.setAlignment(map.getElement("text_alignment", text.getAlignment().name()).asEnum(TextDisplay.TextAlignment.class));
                 if (map.getObject("text_background_color") != null) {
                     //text.setBackgroundColor(map.getObjectAs("text_background_color", ColorTag.class, mechanism.context).getColor());
                 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProperty.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProperty.java
@@ -32,4 +32,14 @@ public abstract class EntityProperty<TData extends ObjectTag> extends ObjectProp
     public <T extends Entity> T as(Class<T> entityClass) {
         return (T) getEntity();
     }
+
+    public static String getReasonNotDescribed(EntityTag entity) {
+        if (entity.getUUID() == null) {
+            return "generic entity-types cannot match any properties, you must spawn an entity to interact with its properties directly.";
+        }
+        else if (!entity.isSpawnedOrValidForTag()) {
+            return "that entity is not spawned.";
+        }
+        return "unspecified reason - are you sure this property applies to that EntityType?";
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/ChatCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/ChatCommand.java
@@ -108,7 +108,7 @@ public class ChatCommand extends AbstractCommand {
             chatRange = Settings.chatBystandersRange();
         }
         DenizenSpeechContext context = new DenizenSpeechContext(message, scriptEntry, chatRange);
-        if (!targets.isEmpty()) {
+        if (targets != null && !targets.isEmpty()) {
             for (EntityTag ent : targets) {
                 context.addRecipient(ent.getBukkitEntity());
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
@@ -474,7 +474,7 @@ public class NPCCommandHandler {
             if (npc.hasTrait(Anchors.class)) {
                 Anchors anchors = npc.getOrAddTrait(Anchors.class);
                 if (anchors.getAnchor(args.getFlag("anchor")) != null) {
-                    trait.toSleep(anchors.getAnchor(args.getFlag("anchor")).getLocation());
+                    trait.toSleep(anchors.getAnchor(args.getFlag("anchor")).getLocation().clone().add(0.5, 0, 0.5));
                     Messaging.send(sender, npc.getName() + " is now sleeping.");
                     return;
                 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/DenizenMapManager.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/DenizenMapManager.java
@@ -156,7 +156,8 @@ public class DenizenMapManager {
         int mapId = map.getId();
         DenizenMapRenderer dmr;
         if (!mapRenderers.containsKey(mapId)) {
-            dmr = new DenizenMapRenderer(map.getRenderers(), false, false);
+            boolean contextual = map.isTrackingPosition() || map.isUnlimitedTracking();
+            dmr = new DenizenMapRenderer(map.getRenderers(), false, contextual);
             setMap(map, dmr);
         }
         else {

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
@@ -62,6 +62,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapPalette;
@@ -146,7 +147,7 @@ public class PacketHelperImpl implements PacketHelper {
         send(player, new ClientboundAddEntityPacket(entity));
         send(player, new ClientboundSetCameraPacket(entity));
         ((CraftServer) Bukkit.getServer()).getHandle().respawn(((CraftPlayer) player).getHandle(),
-                ((CraftWorld) player.getWorld()).getHandle(), true, player.getLocation(), false);
+                ((CraftWorld) player.getWorld()).getHandle(), true, player.getLocation(), false, PlayerRespawnEvent.RespawnReason.PLUGIN);
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
@@ -22,6 +22,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_19_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerRespawnEvent;
 
 import java.lang.reflect.Field;
 import java.util.EnumSet;
@@ -46,7 +47,7 @@ public class ProfileEditorImpl extends ProfileEditor {
             }
         }
         if (isSkinChanging) {
-            ((CraftServer) Bukkit.getServer()).getHandle().respawn(nmsPlayer, (ServerLevel) nmsPlayer.level, true, player.getLocation(), false);
+            ((CraftServer) Bukkit.getServer()).getHandle().respawn(nmsPlayer, (ServerLevel) nmsPlayer.level, true, player.getLocation(), false, PlayerRespawnEvent.RespawnReason.PLUGIN);
         }
         player.updateInventory();
     }


### PR DESCRIPTION
Citizens removed the entire `VocalChord`/`SpeechFactory` system - a quick patch was already done @ https://github.com/DenizenScript/Denizen/commit/c251bc02edc8e0b470bc198b93f9a525a5d78554, but this change still leaves Denizen with a lot of unnecessary classes/systems.

## Changes

- The logic from `DenizenSpeechController` and `DenizenChat` was moved into `ChatCommand`, as it was only ever used there and having entire separate classes didn't make much sense.
- Minor cleanup to `DenizenSpeechContext`, mainly using the super constructor instead of `setMessage`.
- Removed the redundant `hasDefinition` checks, as getting the definition already returns `null` if it doesn't exist.
- Changed definition handling to use `ObjectTag`s instead of `String`s, which I assume was just legacy code (although lmk if there was a specific reason).
- It will now only covert to `MiniMessage` once, instead of for every target - let me know if there's a specific reason it was done that way.
- Moved some of the code into a separate method and changed to use early return instead of nested ifs, for clearer code.
- The multiple targets formatting code now uses an enhanced `for` loop instead of an iterator.
- `talkToBystanders` now uses a `Set<UUID>` to check if an entity is a recipient instead of iterating over all of them for every nearby entity.
- `talkToBystanders` now gets the list inline, as it was only ever used once for the loop either way.

## Notes

- Is there any reason the tag contexts are re-created for every call? couldn't you just construct it once?