### PR TITLE
Patch attached entity jumping between targets

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/EntityAttachmentHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/EntityAttachmentHelper.java
@@ -240,15 +240,12 @@ public class EntityAttachmentHelper {
         }
     }
 
-    public static void registerAttachment(AttachmentData attachment) {
-        NetworkInterceptHelper.enable();
-        removeAttachment(attachment.attached.getUUID(), attachment.forPlayer);
-        attachment.startTask();
-        PlayerAttachMap map = attachedEntityToData.get(attachment.attached.getUUID());
+    public static void addPlayerAttachMap(Map<UUID, PlayerAttachMap> target, AttachmentData attachment) {
+        PlayerAttachMap map = target.get(attachment.attached.getUUID());
         if (map == null) {
             map = new PlayerAttachMap();
             map.attached = attachment.attached;
-            attachedEntityToData.put(attachment.attached.getUUID(), map);
+            target.put(attachment.attached.getUUID(), map);
         }
         if (attachment.forPlayer == null) {
             map.everyoneAttachment = attachment;
@@ -259,12 +256,19 @@ public class EntityAttachmentHelper {
             }
             map.playerToAttachment.put(attachment.forPlayer, attachment);
         }
+    }
+
+    public static void registerAttachment(AttachmentData attachment) {
+        NetworkInterceptHelper.enable();
+        removeAttachment(attachment.attached.getUUID(), attachment.forPlayer);
+        attachment.startTask();
         EntityAttachedToMap toMap = toEntityToData.get(attachment.to.getUUID());
         if (toMap == null) {
             toMap = new EntityAttachedToMap();
             toEntityToData.put(attachment.to.getUUID(), toMap);
         }
-        toMap.attachedToMap.put(attachment.attached.getUUID(), map);
+        addPlayerAttachMap(attachedEntityToData, attachment);
+        addPlayerAttachMap(toMap.attachedToMap, attachment);
         if (attachment.syncServer) {
             attachment.doServerSync();
         }


### PR DESCRIPTION
This is a patch for https://discordapp.com/channels/315163488085475337/1097348205693370440

There is a good summary of the bug in the thread. Essentially, when building the mappings from target -> base entity, we were adding all of the player data for the mappings from base entity -> target. This causes teleport/move packets to be formed and sent to the wrong clients down the line when we pulled from the target -> base entity mappings as both players are present for both targets.

Booted up my alt account and tested global attachments, cancelling attachments, and the original bug. Works as expected now, entity does not dart between the two armor stands. Haven't come across any bugs caused by this, and also has made the associated tags accurate.
![image](https://user-images.githubusercontent.com/29823405/233820975-f2b02c23-d919-4c7b-8791-5966e99ed754.png)