### PR TITLE
Add Spigot's TNT Priming Event

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -74,7 +74,9 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(ServerListPingScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(ServerResourcesReloadedScriptEvent.class);
         ScriptEvent.registerScriptEvent(SkeletonHorseTrapScriptEvent.class);
-        ScriptEvent.registerScriptEvent(TNTPrimesScriptEvent.class);
+        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_18)) {
+            ScriptEvent.registerScriptEvent(TNTPrimesScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(UnknownCommandScriptEvent.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             ScriptEvent.registerScriptEvent(WardenChangesAngerLevelScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/TNTPrimesScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/TNTPrimesScriptEvent.java
@@ -13,29 +13,6 @@ import org.bukkit.event.Listener;
 
 public class TNTPrimesScriptEvent extends BukkitScriptEvent implements Listener {
 
-    // <--[event]
-    // @Events
-    // tnt primes
-    //
-    // @Location true
-    //
-    // @Plugin Paper
-    //
-    // @Group Paper
-    //
-    // @Cancellable true
-    //
-    // @Triggers when TNT is activated and will soon explode.
-    //
-    // @Context
-    // <context.entity> returns the entity that primed the TNT, if any.
-    // <context.location> returns the location of the TNT block being primed.
-    // <context.reason> returns the reason the TNT was primed. Refer to <@link url https://papermc.io/javadocs/paper/1.17/com/destroystokyo/paper/event/block/TNTPrimeEvent.PrimeReason.html>
-    //
-    // @Player when the priming entity is a player.
-    //
-    // -->
-
     public TNTPrimesScriptEvent() {
         registerCouldMatcher("tnt primes");
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -86,6 +86,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PistonExtendsScriptEvent.class);
         ScriptEvent.registerScriptEvent(PistonRetractsScriptEvent.class);
         ScriptEvent.registerScriptEvent(RedstoneScriptEvent.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            ScriptEvent.registerScriptEvent(TNTPrimesScriptEvent.class);
+        }
 
         // Entity events
         if (!Denizen.supportsPaper) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
@@ -30,7 +30,7 @@ public class TNTPrimesScriptEvent extends BukkitScriptEvent implements Listener 
     // <context.block> returns the location of the block that primed the TNT, if any.
     // <context.location> returns the location of the TNT block being primed.
     // <context.cause> returns the cause of the TNT being primed. Refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/block/TNTPrimeEvent.PrimeCause.html>
-    // <context.reason> deprecated in favor of <context.cause> for versions below 1.19.
+    // <context.reason> deprecated in favor of <context.cause> for 1.19+.
     //
     // @Player when the priming entity is a player.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
@@ -59,11 +59,11 @@ public class TNTPrimesScriptEvent extends BukkitScriptEvent implements Listener 
     @Override
     public ObjectTag getContext(String name) {
         return switch (name) {
-            case "entity" -> event.getPrimingEntity() != null ? new EntityTag(event.getPrimingEntity()).getDenizenObject() : super.getContext(name);
-            case "block" -> event.getPrimingBlock() != null ? new LocationTag(event.getPrimingBlock().getLocation()) : super.getContext(name);
+            case "entity" -> event.getPrimingEntity() != null ? new EntityTag(event.getPrimingEntity()).getDenizenObject() : null;
+            case "block" -> event.getPrimingBlock() != null ? new LocationTag(event.getPrimingBlock().getLocation()) : null;
             case "location" -> location;
             case "cause" -> new ElementTag(event.getCause());
-            case "reason" -> new ElementTag(event.getCause().name().equals("PLAYER") ? "ITEM" : event.getCause().name()); // For backwards-compatibility
+            case "reason" -> new ElementTag(event.getCause() == TNTPrimeEvent.PrimeCause.PLAYER ? "ITEM" : event.getCause().name(), true); // For backwards-compatibility
             default -> super.getContext(name);
         };
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
@@ -23,7 +23,7 @@ public class TNTPrimesScriptEvent extends BukkitScriptEvent implements Listener 
     //
     // @Cancellable true
     //
-    // @Triggers when TNT is activated and will soon explode (Spigot 1.19+).
+    // @Triggers when TNT is activated and will soon explode.
     //
     // @Context
     // <context.entity> returns the entity that primed the TNT, if any.

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
@@ -69,7 +69,7 @@ public class TNTPrimesScriptEvent extends BukkitScriptEvent implements Listener 
     }
 
     @EventHandler
-    public void tntPrimeEvent(TNTPrimeEvent event) {
+    public void onTntPrimesEvent(TNTPrimeEvent event) {
         this.event = event;
         location = new LocationTag(event.getBlock().getLocation());
         fire(event);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/TNTPrimesScriptEvent.java
@@ -1,0 +1,77 @@
+package com.denizenscript.denizen.events.block;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.TNTPrimeEvent;
+
+public class TNTPrimesScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // tnt primes
+    //
+    // @Location true
+    //
+    // @Group Block
+    //
+    // @Cancellable true
+    //
+    // @Triggers when TNT is activated and will soon explode (Spigot 1.19+).
+    //
+    // @Context
+    // <context.entity> returns the entity that primed the TNT, if any.
+    // <context.location> returns the location of the TNT block being primed.
+    // <context.reason> returns the reason the TNT was primed. Refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/block/TNTPrimeEvent.PrimeCause.html>
+    //
+    // @Player when the priming entity is a player.
+    //
+    // -->
+
+    public TNTPrimesScriptEvent() {
+        registerCouldMatcher("tnt primes");
+    }
+
+    public TNTPrimeEvent event;
+    public LocationTag location;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPrimingEntity());
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("entity") && event.getPrimingEntity() != null) {
+            return new EntityTag(event.getPrimingEntity()).getDenizenObject();
+        }
+        else if (name.equals("location")) {
+            return location;
+        }
+        else if (name.equals("reason")) {
+            return new ElementTag(event.getCause());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void tntPrimeEvent(TNTPrimeEvent event) {
+        this.event = event;
+        location = new LocationTag(event.getBlock().getLocation());
+        fire(event);
+    }
+}


### PR DESCRIPTION
See discussion about it [here](https://discord.com/channels/315163488085475337/1108497338147807262/1108499832236158977)

Deprecation of Paper's event reported by [LG_Legacy](https://discord.com/channels/315163488085475337/1108497338147807262)

Changes:
- Removed meta entry from paper event
- Restrict paper's event to versions < 1.19
- Add Spigot's TNTPrimeEvent and restrict to versions >= 1.19
- Change event handler name in new event to follow the `onX` naming convention