### PR TITLE
`EntityTag.background_color` property

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -41,6 +41,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityArmorPose.class, EntityTag.class);
         PropertyParser.registerProperty(EntityArms.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAware.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            PropertyParser.registerProperty(EntityBackgroundColor.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityBasePlate.class, EntityTag.class);
         PropertyParser.registerProperty(EntityBeamTarget.class, EntityTag.class);
         PropertyParser.registerProperty(EntityBoatType.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBackgroundColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBackgroundColor.java
@@ -1,0 +1,49 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.properties.bukkit.BukkitColorExtensions;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ColorTag;
+import org.bukkit.Color;
+import org.bukkit.entity.TextDisplay;
+
+public class EntityBackgroundColor extends EntityProperty<ColorTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name background_color
+    // @input ColorTag
+    // @description
+    // A text display entity's background color.
+    // Note that this is based on experimental API; while unlikely, breaking changes aren't impossible.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof TextDisplay;
+    }
+
+    @Override
+    public ColorTag getPropertyValue() {
+        Color backgroundColor = as(TextDisplay.class).getBackgroundColor();
+        return BukkitColorExtensions.fromColor(backgroundColor != null ? backgroundColor : Color.WHITE);
+    }
+
+    @Override
+    public boolean isDefaultValue(ColorTag value) {
+        return value.red == 0 && value.green == 0 && value.blue == 0 && value.alpha == 64;
+    }
+
+    @Override
+    public void setPropertyValue(ColorTag value, Mechanism mechanism) {
+        as(TextDisplay.class).setBackgroundColor(BukkitColorExtensions.getColor(value));
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "background_color";
+    }
+
+    public static void register() {
+        autoRegister("background_color", EntityBackgroundColor.class, ColorTag.class, false);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDefaultBackground.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDefaultBackground.java
@@ -7,13 +7,12 @@ import org.bukkit.entity.TextDisplay;
 
 public class EntityDefaultBackground extends EntityProperty<ElementTag> {
 
-    // TODO: reference the background color property here, once that's created.
     // <--[property]
     // @object EntityTag
     // @name default_background
     // @input ElementTag(Boolean)
     // @description
-    // Whether a text display entity's background is default (same as the chat window), or custom set.
+    // Whether a text display entity's background is default (same as the chat window), or custom set (see <@link property EntityTag.background_color>).
     // -->
 
     public static boolean describes(EntityTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityText.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityText.java
@@ -22,7 +22,7 @@ public class EntityText extends EntityProperty<ElementTag> {
 
     @Override
     public ElementTag getPropertyValue() {
-        return new ElementTag(PaperAPITools.instance.getText(as(TextDisplay.class)));
+        return new ElementTag(PaperAPITools.instance.getText(as(TextDisplay.class)), true);
     }
 
     @Override


### PR DESCRIPTION
## Additions

- `EntityTag.background_color` property, controls a text display entity's background color.

## Changes

- Updates the `EntityTag.default_background` meta to reference the new property.
- A minor fix in `EntityTag.text`, making the returned `ElementTag` plain-text.

## Notes

- It is based on the experimental/subject to change Spigot API, which seems to function now - Spigot's API is nullable and treats `-1` as the default value (null) for... some reason; I've added handling to convert null (`-1`) to white, and have the proper default value.