### PR TITLE
fix publishing task by removing default-deploy rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
+                <version>3.1.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This will allow the ci to push all maven artifacts to the maven artifactory.

Resolves #2478 .