### PR TITLE
Use Paper's kick function for `kick` command if using Paper.

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -328,4 +328,9 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     public void setText(TextDisplay textDisplay, String text) {
         textDisplay.text(PaperModule.parseFormattedText(text, ChatColor.WHITE));
     }
+
+    @Override
+    public void kickPlayer(Player player, String message) {
+        player.kick(PaperModule.parseFormattedText(message, ChatColor.WHITE));
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/KickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/KickCommand.java
@@ -2,10 +2,7 @@ package com.denizenscript.denizen.scripts.commands.player;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.utilities.PaperAPITools;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgLinear;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgSubType;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 
@@ -50,7 +47,7 @@ public class KickCommand extends AbstractCommand {
     // -->
 
     public static void autoExecute(@ArgName("targets") @ArgLinear @ArgSubType(PlayerTag.class) List<PlayerTag> targets,
-                                   @ArgName("reason") @ArgPrefixed String reason) {
+                                   @ArgName("reason") @ArgPrefixed @ArgDefaultText("Kicked.") String reason) {
         for (PlayerTag player : targets) {
             if (player.isValid() && player.isOnline()) {
                 if (Denizen.supportsPaper) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/KickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/KickCommand.java
@@ -50,11 +50,7 @@ public class KickCommand extends AbstractCommand {
                                    @ArgName("reason") @ArgPrefixed @ArgDefaultText("Kicked.") String reason) {
         for (PlayerTag player : targets) {
             if (player.isValid() && player.isOnline()) {
-                if (Denizen.supportsPaper) {
-                    PaperAPITools.instance.kickPlayer(player.getPlayerEntity(), reason);
-                    return;
-                }
-                player.getPlayerEntity().kickPlayer(reason);
+                PaperAPITools.instance.kickPlayer(player.getPlayerEntity(), reason);
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/KickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/KickCommand.java
@@ -1,12 +1,12 @@
 package com.denizenscript.denizen.scripts.commands.player;
 
-import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.utilities.PaperAPITools;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgLinear;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgSubType;
 import com.denizenscript.denizen.objects.PlayerTag;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
-import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 
 import java.util.List;
@@ -18,6 +18,7 @@ public class KickCommand extends AbstractCommand {
         setSyntax("kick [<player>|...] (reason:<text>)");
         setRequiredArguments(1, 2);
         isProcedural = false;
+        autoCompile();
     }
 
     // <--[command]
@@ -48,33 +49,15 @@ public class KickCommand extends AbstractCommand {
     // - kick <[player]> "reason:Because I can."
     // -->
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        for (Argument arg : scriptEntry) {
-            if (arg.matchesPrefix("reason")) {
-                scriptEntry.addObject("reason", arg.asElement());
-            }
-            else if (arg.matchesPrefix("targets", "target", "players")
-                    || arg.matchesArgumentList(PlayerTag.class)) {
-                scriptEntry.addObject("targets", arg.asType(ListTag.class).filter(PlayerTag.class, scriptEntry));
-            }
-        }
-        scriptEntry.defaultObject("reason", new ElementTag("Kicked."));
-        if (!scriptEntry.hasObject("targets")) {
-            throw new InvalidArgumentsException("Must specify target(s).");
-        }
-    }
-
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
-        ElementTag reason = scriptEntry.getElement("reason");
-        List<PlayerTag> targets = (List<PlayerTag>) scriptEntry.getObject("targets");
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), db("targets", targets), reason);
-        }
+    public static void autoExecute(@ArgName("targets") @ArgLinear @ArgSubType(PlayerTag.class) List<PlayerTag> targets,
+                                   @ArgName("reason") @ArgPrefixed String reason) {
         for (PlayerTag player : targets) {
             if (player.isValid() && player.isOnline()) {
-                player.getPlayerEntity().kickPlayer(reason.toString());
+                if (Denizen.supportsPaper) {
+                    PaperAPITools.instance.kickPlayer(player.getPlayerEntity(), reason);
+                    return;
+                }
+                player.getPlayerEntity().kickPlayer(reason);
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -174,4 +174,8 @@ public class PaperAPITools {
     public void setText(TextDisplay textDisplay, String text) {
         textDisplay.setText(text);
     }
+    
+    public void kickPlayer(Player player, String message) {
+        player.kickPlayer(message);
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -174,7 +174,7 @@ public class PaperAPITools {
     public void setText(TextDisplay textDisplay, String text) {
         textDisplay.setText(text);
     }
-    
+
     public void kickPlayer(Player player, String message) {
         player.kickPlayer(message);
     }


### PR DESCRIPTION
This lets formatting like colors and translation in the kick message.
### Changes:
- update to `autoExecute`.
- remove the `targets`, `target`, and `players` prefixes in favor of no prefix.

Requested by [Darwin](https://discord.com/channels/315163488085475337/1113146664329433128)