### PR TITLE
Update for new determination system

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityTeleportedByPortalScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityTeleportedByPortalScriptEvent.java
@@ -5,7 +5,6 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import io.papermc.paper.event.entity.EntityPortalReadyEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -43,6 +42,8 @@ public class EntityTeleportedByPortalScriptEvent extends BukkitScriptEvent imple
     public EntityTeleportedByPortalScriptEvent() {
         registerCouldMatcher("<entity> teleported by portal");
         registerSwitches("to", "portal_type");
+        registerDetermination("target_world", WorldTag.class, (context, targetWorld) -> event.setTargetWorld(targetWorld.getWorld()));
+        registerTextDetermination("remove_target_world", () -> event.setTargetWorld(null));
     }
 
     EntityPortalReadyEvent event;
@@ -72,25 +73,6 @@ public class EntityTeleportedByPortalScriptEvent extends BukkitScriptEvent imple
             case "portal_type" -> new ElementTag(event.getPortalType());
             default -> super.getContext(name);
         };
-    }
-
-    @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag) {
-            String determination = CoreUtilities.toLowerCase(determinationObj.toString());
-            if (determination.startsWith("target_world:")) {
-                WorldTag world = WorldTag.valueOf(determination.substring("target_world:".length()), getTagContext(path));
-                if (world != null) {
-                    event.setTargetWorld(world.getWorld());
-                    return true;
-                }
-            }
-            else if (determination.equals("remove_target_world")) {
-                event.setTargetWorld(null);
-                return true;
-            }
-        }
-        return super.applyDetermination(path, determinationObj);
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityCombustsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityCombustsScriptEvent.java
@@ -1,12 +1,12 @@
 package com.denizenscript.denizen.events.entity;
 
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -46,6 +46,14 @@ public class EntityCombustsScriptEvent extends BukkitScriptEvent implements List
 
     public EntityCombustsScriptEvent() {
         registerCouldMatcher("<entity> combusts");
+        registerDetermination(null, ObjectTag.class, (context, determination) -> {
+            if (determination instanceof ElementTag element && element.isInt()) {
+                event.setDuration(element.asInt());
+            }
+            else if (determination.canBeType(DurationTag.class)) {
+                event.setDuration(determination.asType(DurationTag.class, context).getSecondsAsInt());
+            }
+        });
     }
 
     public EntityTag entity;
@@ -60,19 +68,6 @@ public class EntityCombustsScriptEvent extends BukkitScriptEvent implements List
             return false;
         }
         return super.matches(path);
-    }
-
-    @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag element && element.isInt()) {
-            event.setDuration(element.asInt());
-            return true;
-        }
-        else if (DurationTag.matches(determinationObj.toString())) {
-            event.setDuration(DurationTag.valueOf(determinationObj.toString(), getTagContext(path)).getTicksAsInt());
-            return true;
-        }
-        return super.applyDetermination(path, determinationObj);
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityCombustsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityCombustsScriptEvent.java
@@ -46,13 +46,16 @@ public class EntityCombustsScriptEvent extends BukkitScriptEvent implements List
 
     public EntityCombustsScriptEvent() {
         registerCouldMatcher("<entity> combusts");
-        registerDetermination(null, ObjectTag.class, (context, determination) -> {
+        registerOptionalDetermination(null, ObjectTag.class, (context, determination) -> {
             if (determination instanceof ElementTag element && element.isInt()) {
                 event.setDuration(element.asInt());
+                return true;
             }
             else if (determination.canBeType(DurationTag.class)) {
                 event.setDuration(determination.asType(DurationTag.class, context).getSecondsAsInt());
+                return true;
             }
+            return false;
         });
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialLevel.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialLevel.java
@@ -1,15 +1,15 @@
 package com.denizenscript.denizen.objects.properties.material;
 
 import com.denizenscript.denizen.objects.MaterialTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Levelled;
-import org.bukkit.block.data.type.Cake;
 import org.bukkit.block.data.type.Beehive;
+import org.bukkit.block.data.type.Cake;
 import org.bukkit.block.data.type.Farmland;
 import org.bukkit.block.data.type.Snow;
 
@@ -90,6 +90,7 @@ public class MaterialLevel implements Property {
         // For beehives/bee nests, this is the amount of honey contained.
         // For snow, this is the number of partial layers, or the height, of a snow block.
         // For farmland, this is the moisture level.
+        // For composters, this is the amount of compost.
         // -->
         PropertyParser.registerStaticTag(MaterialLevel.class, ElementTag.class, "level", (attribute, material) -> {
             return new ElementTag(material.getCurrent());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialSwitchable.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialSwitchable.java
@@ -69,7 +69,7 @@ public class MaterialSwitchable implements Property {
         // - a Powerable material (like pressure plates) is activated
         // - an Openable material (like doors) is open
         // - a dispenser is powered and should dispense its contents
-        // - a daylight sensor can see the sun
+        // - a daylight sensor is inverted (detects darkness instead of light)
         // - a lightable block is lit
         // - a piston block is extended
         // - an end portal frame has an ender eye in it

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/triggers/core/ChatTrigger.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/triggers/core/ChatTrigger.java
@@ -403,7 +403,7 @@ public class ChatTrigger extends AbstractTrigger implements Listener {
         }
 
         public String getChanges() {
-            return changed_text != null ? changed_text : DetermineCommand.DETERMINE_NONE;
+            return changed_text != null ? changed_text : "none";
         }
 
         public boolean wasTriggered() {


### PR DESCRIPTION
## Changes

- Updated `EntityTeleportedByPortalScriptEvent` to the modern determination system (was used for testing).
- Updated `EntityCombustsScriptEvent` to the modern determination system (was used for testing).
- Removed `DetermineCommand.DETERMINE_NONE` usage in `ChatTrigger`, as that's been removed.
- _Unrelated minor fix_ - Fixed `EntityCombustsScriptEvent` duration determination setting ticks when the method actually takes seconds.
- _Unrelated minor fix_ - added composters to `MaterialLevel` meta.
- _Unrelated minor fix_ - improved daylight sensor meta in `MaterialSwitchable`.