### PR TITLE
Fix skin mirroring, bump Citizens dependency

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>net.citizensnpcs</groupId>
             <artifactId>citizens-main</artifactId>
-            <version>2.0.31-SNAPSHOT</version>
+            <version>2.0.32-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
             <exclusions>

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/traits/MirrorTrait.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/traits/MirrorTrait.java
@@ -34,7 +34,7 @@ public class MirrorTrait extends Trait {
 
     public void mirrorOn() {
         NetworkInterceptHelper.enable();
-        UUID uuid = npc.getUniqueId();
+        UUID uuid = npc.getMinecraftUniqueId();
         if (!ProfileEditor.mirrorUUIDs.contains(uuid)) {
             ProfileEditor.mirrorUUIDs.add(uuid);
             respawn();
@@ -42,7 +42,7 @@ public class MirrorTrait extends Trait {
     }
 
     public void mirrorOff() {
-        UUID uuid = npc.getUniqueId();
+        UUID uuid = npc.getMinecraftUniqueId();
         if (ProfileEditor.mirrorUUIDs.contains(uuid)) {
             ProfileEditor.mirrorUUIDs.remove(uuid);
             respawn();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -3665,11 +3665,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // -->
         if (mechanism.matches("mirror_player") && mechanism.requireBoolean()) {
             if (isNPC()) {
-                NPC npc = getDenizenNPC().getCitizen();
-                if (!npc.hasTrait(MirrorTrait.class)) {
-                    npc.addTrait(MirrorTrait.class);
-                }
-                MirrorTrait mirror = npc.getOrAddTrait(MirrorTrait.class);
+                MirrorTrait mirror = getDenizenNPC().getCitizen().getOrAddTrait(MirrorTrait.class);
                 if (mechanism.getValue().asBoolean()) {
                     mirror.enableMirror();
                 }


### PR DESCRIPTION
Making this a PR as I'm not sure the Citizens dependency is handled correctly there ([See](https://discord.com/channels/315163488085475337/1011496047811506227/1120258090017759323)) - currently I just added the repo (which made it load everything properly), then removed it after.

## Changes

- `MirrorTrait` now uses the new `getMinecraftUniqueId` method, which returns the same UUID Citizens uses for networking (previously [broke](https://discord.com/channels/315163488085475337/1011496047811506227/1119664653753127014) because the UUID used in the trait and the UUID Citizens sends in packets didn't match).
- Bumped Citizens dependency to `2.0.32-SNAPSHOT` for the new `getMinecraftUniqueId` method.
- Minor code cleanup in the `EntityTag.mirror_player` mechanism.