### PR TITLE
new paper only property,  `should_burn` for zombies

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -100,6 +100,7 @@ public class PaperModule {
             PropertyParser.registerProperty(EntityFriction.class, EntityTag.class);
         }
         PropertyParser.registerProperty(EntityReputation.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityShouldBurn.class, EntityTag.class);
         PropertyParser.registerProperty(EntityWitherInvulnerable.class, EntityTag.class);
         PropertyParser.registerProperty(ItemArmorStand.class, ItemTag.class);
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityShouldBurn.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityShouldBurn.java
@@ -1,0 +1,44 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.properties.entity.EntityProperty;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.entity.Zombie;
+
+public class EntityShouldBurn extends EntityProperty<ElementTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name should_burn
+    // @input ElementTag(Boolean)
+    // @plugin Paper
+    // @description
+    // If the entity is a Zombie, controls whether it should burn in daylight.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof Zombie;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(as(Zombie.class).shouldBurnInDay());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "should_burn";
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag param, Mechanism mechanism) {
+        if (mechanism.requireBoolean()) {
+            as(Zombie.class).setShouldBurnInDay(param.asBoolean());
+        }
+    }
+
+    public static void register() {
+        autoRegister("should_burn", EntityShouldBurn.class, ElementTag.class, false);
+    }
+}


### PR DESCRIPTION
## `should_burn` property for Zombies

If the entity is a Zombie, controls whether it should burn in daylight.