### PR TITLE
Update for 1.19 biome changes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.nms.abstracts;
 
 import com.denizenscript.denizencore.objects.core.ColorTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
@@ -20,15 +21,32 @@ public abstract class BiomeNMS {
         this.name = CoreUtilities.toLowerCase(name);
     }
 
-    public abstract DownfallType getDownfallType();
-
     public String getName() {
         return name;
     }
 
+    public DownfallType getDownfallType() {
+        if (!hasDownfall()) {
+            return DownfallType.NONE;
+        }
+        return getBaseTemperature() > 0.15f ? DownfallType.RAIN : DownfallType.SNOW;
+    }
+
+    public DownfallType getDownfallTypeAt(Location location) {
+        throw new UnsupportedOperationException();
+    }
+
     public abstract float getHumidity();
 
-    public abstract float getTemperature();
+    public abstract float getBaseTemperature();
+
+    public float getTemperatureAt(Location location) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean hasDownfall() {
+        throw new UnsupportedOperationException();
+    }
 
     public List<EntityType> getAllEntities() {
         List<EntityType> entityTypes = new ArrayList<>();
@@ -51,9 +69,13 @@ public abstract class BiomeNMS {
 
     public abstract void setHumidity(float humidity);
 
-    public abstract void setTemperature(float temperature);
+    public abstract void setBaseTemperature(float temperature);
 
     public void setPrecipitation(DownfallType type) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setHasDownfall(boolean hasDownfall) {
         throw new UnsupportedOperationException();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -1,13 +1,17 @@
 package com.denizenscript.denizen.objects;
 
+import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizen.nms.abstracts.BiomeNMS;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.flags.RedirectionFlagTracker;
-import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.abstracts.BiomeNMS;
+import com.denizenscript.denizencore.objects.Adjustable;
+import com.denizenscript.denizencore.objects.Fetchable;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ColorTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
@@ -15,7 +19,6 @@ import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.Biome;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -376,27 +376,6 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
 
         // <--[mechanism]
         // @object BiomeTag
-        // @name base_temperature
-        // @input ElementTag(Decimal)
-        // @description
-        // Sets the base temperature for this biome server-wide.
-        // This is used as a base for temperature calculations, but the end temperature is calculated per-location (see <@link tag BiomeTag.temperature_at>).
-        // Resets on server restart.
-        // @tags
-        // <BiomeTag.base_temperature>
-        // @example
-        // # Adjusts the temperature of the plains biome permanently, using a server start event to keep it applied.
-        // on server start:
-        // - adjust <biome[plains]> temperature:0.5
-        // -->
-        tagProcessor.registerMechanism("base_temperature", false, ElementTag.class, (object, mechanism, input) -> {
-            if (mechanism.requireFloat()) {
-                object.biome.setBaseTemperature(input.asFloat());
-            }
-        }, "temperature");
-
-        // <--[mechanism]
-        // @object BiomeTag
         // @name humidity
         // @input ElementTag(Decimal)
         // @description
@@ -415,6 +394,27 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
                 object.biome.setHumidity(input.asFloat());
             }
         });
+
+        // <--[mechanism]
+        // @object BiomeTag
+        // @name base_temperature
+        // @input ElementTag(Decimal)
+        // @description
+        // Sets the base temperature for this biome server-wide.
+        // This is used as a base for temperature calculations, but the end temperature is calculated per-location (see <@link tag BiomeTag.temperature_at>).
+        // Resets on server restart.
+        // @tags
+        // <BiomeTag.base_temperature>
+        // @example
+        // # Adjusts the temperature of the plains biome permanently, using a server start event to keep it applied.
+        // on server start:
+        // - adjust <biome[plains]> temperature:0.5
+        // -->
+        tagProcessor.registerMechanism("base_temperature", false, ElementTag.class, (object, mechanism, input) -> {
+            if (mechanism.requireFloat()) {
+                object.biome.setBaseTemperature(input.asFloat());
+            }
+        }, "temperature");
 
         // <--[mechanism]
         // @object BiomeTag

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -171,10 +171,11 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
         // @attribute <BiomeTag.downfall_type>
         // @returns ElementTag
         // @mechanism BiomeTag.downfall_type
+        // @deprecated Minecraft changed the way biome downfall works, use <@link tag BiomeTag.downfall_at> on 1.19+.
         // @description
+        // Deprecated in favor of <@link tag BiomeTag.downfall_at> on 1.19+, as downfall is block-specific now.
         // Returns this biome's downfall type for when a world has weather.
         // This can be RAIN, SNOW, or NONE.
-        // @deprecated Minecraft changed the way biome downfall works, use <@link tag BiomeTag.downfall_at> on 1.19+.
         // @example
         // # In a plains biome, this fills with 'RAIN'.
         // - narrate "The downfall type in plains biomes is: <biome[plains].downfall_type>!"
@@ -419,9 +420,19 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
         // @object BiomeTag
         // @name downfall_type
         // @input ElementTag
+        // @deprecated This functionality was removed from Minecraft as of 1.19.
         // @description
-        // No longer works on 1.19+, as Minecraft removed the ability to set this value.
-        // @deprecated This functionality was removed from Minecraft.
+        // Deprecated on 1.19+, as Minecraft removed the ability to set this value.
+        // Sets the downfall-type for this biome server-wide.
+        // This can be RAIN, SNOW, or NONE.
+        // Resets on server restart.
+        // @tags
+        // <BiomeTag.temperature>
+        // @example
+        // # Adjusts the downfall type of the plains biome permanently, using a server start event to keep it applied.
+        // on server start:
+        // - adjust <biome[plains]> temperature:-0.2
+        // - adjust <biome[plains]> downfall_type:SNOW
         // -->
         tagProcessor.registerMechanism("downfall_type", false, ElementTag.class, (object, mechanism, input) -> {
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -299,6 +299,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
             // @description
             // Returns the temperature of a specific location in this biome.
             // If this is less than 0.15, snow will form on the ground when weather occurs in the world and a layer of ice will form over water.
+            // Generally <@link tag LocationTag.temperature> should be preferred, other than some special cases.
             // @example
             // # Gives the player water if they are standing in a warm location.
             // - if <player.location.biome.temperature_at[<player.location]> > 0.5:
@@ -314,6 +315,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
             // @description
             // Returns this biome's downfall type at a location (for when a world has weather).
             // This can be RAIN, SNOW, or NONE.
+            // Generally <@link tag LocationTag.downfall_type> should be preferred, other than some special cases.
             // @example
             // # Tells the linked player what the downfall type at their location is.
             // - narrate "The downfall type at your location is: <player.location.biome.downfall_at[<player.location>]>!"

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4222,6 +4222,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @description
             // Returns a location's temperature, based on the biome it's in.
             // If this is less than 0.15, snow will form on the ground when weather occurs in the world and a layer of ice will form over water.
+            // See also <@link tag BiomeTag.temperature_at>.
             // @example
             // # Gives the player water if they are standing in a warm location.
             // - if <player.location.temperature> > 0.5:
@@ -4238,6 +4239,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @description
             // Returns a location's downfall type (for when a world has weather), based on the biome it's in.
             // This can be RAIN, SNOW, or NONE.
+            // See also <@link tag BiomeTag.downfall_at>.
             // @example
             // # Tells the linked player what the downfall type at their location is.
             // - narrate "The downfall type at your location is: <player.location.downfall_type>!"

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -169,8 +169,13 @@ public class BukkitImplDeprecations {
     public static Warning materialPropertyTags = new SlowWarning("materialPropertyTags", "Old MaterialTag.is_x property tags are deprecated in favor of PropertyHolderObject.supports[property-name]");
 
     // In Paper module, Added 2022/03/20
-    // // bump to normal warning and/or past warning after 1.18 is the minimum supported version (change happened in MC 1.18)
+    // bump to normal warning and/or past warning after 1.18 is the minimum supported version (change happened in MC 1.18)
     public static Warning paperNoTickViewDistance = new SlowWarning("paperNoTickViewDistance", "Paper's 'no_tick_view_distance' is deprecated in favor of modern minecraft's 'simulation_distance' and 'view_distance' separation");
+
+    // Added 2023/06/30
+    // Bump to normal/past warning after 1.19 is the minimum supported version (change happened in 1.19)
+    public static Warning biomeGlobalDownfallType = new SlowWarning("biomeGlobalDownfallType", "The 'BiomeTag.downfall_type' tag is deprecated in favor of 'BiomeTag.downfall_at', as biome downfall is now location-based");
+    public static Warning biomeSettingDownfallType = new SlowWarning("biomeSettingDownfallType", "The 'BiomeTag.downfall_type' mechanism is removed, as Minecraft no longer allows for this value to be set.");
 
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/BiomeNMSImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/BiomeNMSImpl.java
@@ -57,7 +57,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public float getTemperature() {
+    public float getBaseTemperature() {
         return biomeBase.getBaseTemperature();
     }
 
@@ -88,7 +88,7 @@ public class BiomeNMSImpl extends BiomeNMS {
             return biomeBase.getFoliageColor();
         }
         // Based on net.minecraft.world.level.biome.Biome#getFoliageColorFromTexture()
-        float temperature = clampColor(getTemperature());
+        float temperature = clampColor(getBaseTemperature());
         float humidity = clampColor(getHumidity());
         // Based on net.minecraft.world.level.FoliageColor#get()
         humidity *= temperature;
@@ -109,7 +109,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public void setTemperature(float temperature) {
+    public void setBaseTemperature(float temperature) {
         Object climate = getClimate();
         ReflectionHelper.setFieldValue(climate.getClass(), ReflectionMappingsInfo.Biome_ClimateSettings_temperature, climate, temperature);
     }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/BiomeNMSImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/BiomeNMSImpl.java
@@ -55,7 +55,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public float getTemperature() {
+    public float getBaseTemperature() {
         return biomeBase.value().getBaseTemperature();
     }
 
@@ -86,7 +86,7 @@ public class BiomeNMSImpl extends BiomeNMS {
             return biomeBase.value().getFoliageColor();
         }
         // Based on net.minecraft.world.level.biome.Biome#getFoliageColorFromTexture()
-        float temperature = clampColor(getTemperature());
+        float temperature = clampColor(getBaseTemperature());
         float humidity = clampColor(getHumidity());
         // Based on net.minecraft.world.level.FoliageColor#get()
         humidity *= temperature;
@@ -107,7 +107,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public void setTemperature(float temperature) {
+    public void setBaseTemperature(float temperature) {
         Object climate = getClimate();
         ReflectionHelper.setFieldValue(climate.getClass(), ReflectionMappingsInfo.Biome_ClimateSettings_temperature, climate, temperature);
     }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
@@ -59,9 +59,6 @@ public class ReflectionMappingsInfo {
     // net.minecraft.world.level.biome.Biome
     public static String Biome_climateSettings = "i";
 
-    // net.minecraft.world.level.biome.Biome$ClimateSettings
-    public static String BiomeClimateSettings_temperatureModifier = "d";
-
     // net.minecraft.world.level.biome.BiomeSpecialEffects
     public static String BiomeSpecialEffects_foliageColorOverride = "f";
 
@@ -77,9 +74,6 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket
     public static String ClientboundPlayerAbilitiesPacket_walkingSpeed = "j";
-
-    // net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket
-    public static String ClientboundSetEntityDataPacket_packedItems = "c";
 
     // net.minecraft.network.protocol.game.ClientboundSectionBlocksUpdatePacket
     public static String ClientboundSectionBlocksUpdatePacket_sectionPos = "b";

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
@@ -64,7 +64,6 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     @Override
     public float getTemperatureAt(Location location) {
-        //noinspection deprecation
         return biomeHolder.value().getTemperature(CraftLocation.toBlockPosition(location));
     }
 

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
@@ -44,8 +44,8 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     @Override
     public DownfallType getDownfallTypeAt(Location location) {
-        Biome.Precipitation nmsType = biomeHolder.value().getPrecipitationAt(CraftLocation.toBlockPosition(location));
-        return switch (nmsType) {
+        Biome.Precipitation precipitation = biomeHolder.value().getPrecipitationAt(CraftLocation.toBlockPosition(location));
+        return switch (precipitation) {
             case RAIN -> DownfallType.RAIN;
             case SNOW -> DownfallType.SNOW;
             case NONE -> DownfallType.NONE;
@@ -62,9 +62,9 @@ public class BiomeNMSImpl extends BiomeNMS {
         return biomeHolder.value().getBaseTemperature();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public float getTemperatureAt(Location location) {
+        //noinspection deprecation
         return biomeHolder.value().getTemperature(CraftLocation.toBlockPosition(location));
     }
 
@@ -126,8 +126,8 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public void setBaseTemperature(float temperature) {
-        setClimate(hasDownfall(), temperature, getTemperatureModifier(), getHumidity());
+    public void setBaseTemperature(float baseTemperature) {
+        setClimate(hasDownfall(), baseTemperature, getTemperatureModifier(), getHumidity());
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
@@ -13,10 +13,14 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.MobCategory;
-import net.minecraft.world.level.biome.*;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_19_R3.util.CraftLocation;
 import org.bukkit.entity.EntityType;
 
 import java.lang.invoke.MethodHandle;
@@ -27,7 +31,7 @@ import java.util.Optional;
 
 public class BiomeNMSImpl extends BiomeNMS {
 
-    public static final MethodHandle BIOME_CLIMATESETTINGS_CONSTRUCTOR = ReflectionHelper.getConstructor(Biome.class.getDeclaredClasses()[0], boolean.class, float.class, Biome.TemperatureModifier.class, float.class);
+    public static final MethodHandle BIOME_CLIMATESETTINGS_CONSTRUCTOR = ReflectionHelper.getConstructor(Biome.ClimateSettings.class, boolean.class, float.class, Biome.TemperatureModifier.class, float.class);
 
     public Holder<Biome> biomeHolder;
     public ServerLevel world;
@@ -39,20 +43,13 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public DownfallType getDownfallType() { // TODO: 1.19.4: This is no longer valid, downfall is based on height now
-        throw new UnsupportedOperationException();
-        /*
-        Biome.Precipitation nmsType = biomeHolder.value().getPrecipitation();
-        switch (nmsType) {
-            case RAIN:
-                return DownfallType.RAIN;
-            case SNOW:
-                return DownfallType.SNOW;
-            case NONE:
-                return DownfallType.NONE;
-            default:
-                throw new UnsupportedOperationException();
-        }*/
+    public DownfallType getDownfallTypeAt(Location location) {
+        Biome.Precipitation nmsType = biomeHolder.value().getPrecipitationAt(CraftLocation.toBlockPosition(location));
+        return switch (nmsType) {
+            case RAIN -> DownfallType.RAIN;
+            case SNOW -> DownfallType.SNOW;
+            case NONE -> DownfallType.NONE;
+        };
     }
 
     @Override
@@ -61,8 +58,19 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public float getTemperature() {
+    public float getBaseTemperature() {
         return biomeHolder.value().getBaseTemperature();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public float getTemperatureAt(Location location) {
+        return biomeHolder.value().getTemperature(CraftLocation.toBlockPosition(location));
+    }
+
+    @Override
+    public boolean hasDownfall() {
+        return biomeHolder.value().hasPrecipitation();
     }
 
     @Override
@@ -92,7 +100,7 @@ public class BiomeNMSImpl extends BiomeNMS {
             return biomeHolder.value().getFoliageColor();
         }
         // Based on net.minecraft.world.level.biome.Biome#getFoliageColorFromTexture()
-        float temperature = clampColor(getTemperature());
+        float temperature = clampColor(getBaseTemperature());
         float humidity = clampColor(getHumidity());
         // Based on net.minecraft.world.level.FoliageColor#get()
         humidity *= temperature;
@@ -100,10 +108,6 @@ public class BiomeNMSImpl extends BiomeNMS {
         int temperatureValue = (int)((1.0f - temperature) * 255.0f);
         int index = temperatureValue << 8 | humidityValue;
         return index >= 65536 ? 4764952 : getColor(index / 256, index % 256).asRGB();
-    }
-
-    public Object getClimate() {
-        return ReflectionHelper.getFieldValue(Biome.class, ReflectionMappingsInfo.Biome_climateSettings, biomeHolder.value());
     }
 
     public void setClimate(boolean hasPrecipitation, float temperature, Biome.TemperatureModifier temperatureModifier, float downfall) {
@@ -118,33 +122,17 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     @Override
     public void setHumidity(float humidity) {
-        setClimate(biomeHolder.value().climateSettings.hasPrecipitation(), getTemperature(), getTemperatureModifier(), humidity);
+        setClimate(hasDownfall(), getBaseTemperature(), getTemperatureModifier(), humidity);
     }
 
     @Override
-    public void setTemperature(float temperature) {
-        setClimate(biomeHolder.value().hasPrecipitation(), temperature, getTemperatureModifier(), getHumidity());
+    public void setBaseTemperature(float temperature) {
+        setClimate(hasDownfall(), temperature, getTemperatureModifier(), getHumidity());
     }
 
     @Override
-    public void setPrecipitation(DownfallType type) { // TODO: 1.19.4: This is no longer valid, downfall is based on height now
-        throw new UnsupportedOperationException();
-        /*
-        Biome.Precipitation nmsType;
-        switch (type) {
-            case NONE:
-                nmsType = Biome.Precipitation.NONE;
-                break;
-            case RAIN:
-                nmsType = Biome.Precipitation.RAIN;
-                break;
-            case SNOW:
-                nmsType = Biome.Precipitation.SNOW;
-                break;
-            default:
-                throw new UnsupportedOperationException();
-        }
-        setClimate(nmsType, getTemperature(), getTemperatureModifier(), getHumidity());*/
+    public void setHasDownfall(boolean hasDownfall) {
+        setClimate(hasDownfall, getBaseTemperature(), getTemperatureModifier(), getHumidity());
     }
 
     @Override
@@ -198,7 +186,6 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     public Biome.TemperatureModifier getTemperatureModifier() {
-        Object climate = getClimate();
-        return ReflectionHelper.getFieldValue(climate.getClass(), ReflectionMappingsInfo.BiomeClimateSettings_temperatureModifier, climate);
+        return biomeHolder.value().climateSettings.temperatureModifier();
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
@@ -59,9 +59,6 @@ public class ReflectionMappingsInfo {
     // net.minecraft.world.level.biome.Biome
     public static String Biome_climateSettings = "i";
 
-    // net.minecraft.world.level.biome.Biome$ClimateSettings
-    public static String BiomeClimateSettings_temperatureModifier = "d";
-
     // net.minecraft.world.level.biome.BiomeSpecialEffects
     public static String BiomeSpecialEffects_foliageColorOverride = "f";
 
@@ -77,9 +74,6 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket
     public static String ClientboundPlayerAbilitiesPacket_walkingSpeed = "j";
-
-    // net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket
-    public static String ClientboundSetEntityDataPacket_packedItems = "c";
 
     // net.minecraft.network.protocol.game.ClientboundSectionBlocksUpdatePacket
     public static String ClientboundSectionBlocksUpdatePacket_sectionPos = "b";

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
@@ -64,7 +64,6 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     @Override
     public float getTemperatureAt(Location location) {
-        //noinspection deprecation
         return biomeHolder.value().getTemperature(CraftLocation.toBlockPosition(location));
     }
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
@@ -13,10 +13,14 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.MobCategory;
-import net.minecraft.world.level.biome.*;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_20_R1.util.CraftLocation;
 import org.bukkit.entity.EntityType;
 
 import java.lang.invoke.MethodHandle;
@@ -27,7 +31,7 @@ import java.util.Optional;
 
 public class BiomeNMSImpl extends BiomeNMS {
 
-    public static final MethodHandle BIOME_CLIMATESETTINGS_CONSTRUCTOR = ReflectionHelper.getConstructor(Biome.class.getDeclaredClasses()[0], boolean.class, float.class, Biome.TemperatureModifier.class, float.class);
+    public static final MethodHandle BIOME_CLIMATESETTINGS_CONSTRUCTOR = ReflectionHelper.getConstructor(Biome.ClimateSettings.class, boolean.class, float.class, Biome.TemperatureModifier.class, float.class);
 
     public Holder<Biome> biomeHolder;
     public ServerLevel world;
@@ -39,20 +43,13 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public DownfallType getDownfallType() { // TODO: 1.19.4: This is no longer valid, downfall is based on height now
-        throw new UnsupportedOperationException();
-        /*
-        Biome.Precipitation nmsType = biomeHolder.value().getPrecipitation();
-        switch (nmsType) {
-            case RAIN:
-                return DownfallType.RAIN;
-            case SNOW:
-                return DownfallType.SNOW;
-            case NONE:
-                return DownfallType.NONE;
-            default:
-                throw new UnsupportedOperationException();
-        }*/
+    public DownfallType getDownfallTypeAt(Location location) {
+        Biome.Precipitation precipitation = biomeHolder.value().getPrecipitationAt(CraftLocation.toBlockPosition(location));
+        return switch (precipitation) {
+            case RAIN -> DownfallType.RAIN;
+            case SNOW -> DownfallType.SNOW;
+            case NONE -> DownfallType.NONE;
+        };
     }
 
     @Override
@@ -61,8 +58,19 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     @Override
-    public float getTemperature() {
+    public float getBaseTemperature() {
         return biomeHolder.value().getBaseTemperature();
+    }
+
+    @Override
+    public float getTemperatureAt(Location location) {
+        //noinspection deprecation
+        return biomeHolder.value().getTemperature(CraftLocation.toBlockPosition(location));
+    }
+
+    @Override
+    public boolean hasDownfall() {
+        return biomeHolder.value().hasPrecipitation();
     }
 
     @Override
@@ -92,7 +100,7 @@ public class BiomeNMSImpl extends BiomeNMS {
             return biomeHolder.value().getFoliageColor();
         }
         // Based on net.minecraft.world.level.biome.Biome#getFoliageColorFromTexture()
-        float temperature = clampColor(getTemperature());
+        float temperature = clampColor(getBaseTemperature());
         float humidity = clampColor(getHumidity());
         // Based on net.minecraft.world.level.FoliageColor#get()
         humidity *= temperature;
@@ -100,10 +108,6 @@ public class BiomeNMSImpl extends BiomeNMS {
         int temperatureValue = (int)((1.0f - temperature) * 255.0f);
         int index = temperatureValue << 8 | humidityValue;
         return index >= 65536 ? 4764952 : getColor(index / 256, index % 256).asRGB();
-    }
-
-    public Object getClimate() {
-        return ReflectionHelper.getFieldValue(Biome.class, ReflectionMappingsInfo.Biome_climateSettings, biomeHolder.value());
     }
 
     public void setClimate(boolean hasPrecipitation, float temperature, Biome.TemperatureModifier temperatureModifier, float downfall) {
@@ -118,33 +122,17 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     @Override
     public void setHumidity(float humidity) {
-        setClimate(biomeHolder.value().climateSettings.hasPrecipitation(), getTemperature(), getTemperatureModifier(), humidity);
+        setClimate(hasDownfall(), getBaseTemperature(), getTemperatureModifier(), humidity);
     }
 
     @Override
-    public void setTemperature(float temperature) {
-        setClimate(biomeHolder.value().hasPrecipitation(), temperature, getTemperatureModifier(), getHumidity());
+    public void setBaseTemperature(float baseTemperature) {
+        setClimate(hasDownfall(), baseTemperature, getTemperatureModifier(), getHumidity());
     }
 
     @Override
-    public void setPrecipitation(DownfallType type) { // TODO: 1.19.4: This is no longer valid, downfall is based on height now
-        throw new UnsupportedOperationException();
-        /*
-        Biome.Precipitation nmsType;
-        switch (type) {
-            case NONE:
-                nmsType = Biome.Precipitation.NONE;
-                break;
-            case RAIN:
-                nmsType = Biome.Precipitation.RAIN;
-                break;
-            case SNOW:
-                nmsType = Biome.Precipitation.SNOW;
-                break;
-            default:
-                throw new UnsupportedOperationException();
-        }
-        setClimate(nmsType, getTemperature(), getTemperatureModifier(), getHumidity());*/
+    public void setHasDownfall(boolean hasDownfall) {
+        setClimate(hasDownfall, getBaseTemperature(), getTemperatureModifier(), getHumidity());
     }
 
     @Override
@@ -198,7 +186,6 @@ public class BiomeNMSImpl extends BiomeNMS {
     }
 
     public Biome.TemperatureModifier getTemperatureModifier() {
-        Object climate = getClimate();
-        return ReflectionHelper.getFieldValue(climate.getClass(), ReflectionMappingsInfo.BiomeClimateSettings_temperatureModifier, climate);
+        return biomeHolder.value().climateSettings.temperatureModifier();
     }
 }


### PR DESCRIPTION
1.19 changed biome handling in a few ways, mainly temperature & downfall to be per-block instead of global, this PR updates Denizen's handling for these changes.

## Changes

- `BiomeNMS#getDownfallType` now has a default impl with a rough estimate based on the biome's base temperature, to maintain back-support as much as possible.
- `BiomeNMS#get/setTemperature` was renamed to `get/setBaseTemperature`, to better match what it does now.
- `BiomeTag.temperature (tag + mech)` were renamed to `base_temperature` (with a deprecated variant), to better match what they represent. Meta description was updated as well.
- Added `@deprecated` meta to `BiomeTag.downfall_type (tag + mech)`, but kept the original meta for now as it's still valid on older versions.
- `BiomeTag.downfall_type (tag)` now displays the `biomeGlobalDownfallType` warning on 1.19+.
- `BiomeTag.downfall_type` (mech) now displays the `biomeSettingDownfallType` warning and stops on 1.19+, as this functionality is no longer available.
- `Biome(NMS)$ClimateSettings` is `public` now, so updated reflection usage for that.
- `BiomeNMSImpl(1.19/1.20)#getClimate` was removed, as the field is public now.
- `BiomeNMSImpl(1.19/1.20)#getTemperatureModifier` now gets it directly, as reflection is no longer needed.
- **(Unrelated minor cleanup)** `BiomeTag.spawnable_entities[(<type>)]` now uses a modern switch + `ListTag` convertor constructor.
- **(Unrelated minor cleanup)** removed the redundant `ColorTag` constructor call from `BiomeTag.foliage_color (tag)`, as `ColorTag#fromRGB` already returns a (new) `ColorTag`.
- **(Unrelated minor cleanup)** made `BiomeTag.tagProcessor` `final`.
- **(Unrelated minor cleanup)** Updated all `BiomeTag` mechanisms to modern mechanism registration (`humidity`, `temperature`/`base_temperature`, `downfall_type`).
- **(Unrelated minor cleanup)** Updated `BiomeTag.downfall_type (mech)` to modern `ElementTag#asEnum`.

## Additions
- `BiomeNMS#getDownfallTypeAt(Location)` & `BiomeTag.downfall_at[<location>]` - gets the downfall type at a location.
- `BiomeNMS#getTemperatureAt(Location)` & `BiomeTag.temperature_at[<location>]` - gets the temperature at a location.
- `BiomeNMS#hasDownfall` & `BiomeTag.has_downfall (tag)` - whether a biome has downfall.
- `BiomeNMS#setHasDownfall` & `BiomeTag.has_downfall (mech)` - sets whether a biome has downfall.
- `biomeGlobalDownfallType` slow warning - for `BiomeTag.downfall_type (tag)`.
- `biomeSettingDownfallType` slow warning - for `BiomeTag.downfall_type (mech)`.

## Removals

- `ReflectionMappingsInfo.BiomeClimateSettings_temperatureModifier` - reflection is no longer needed.
- **(Unrelated minor removal)** `ReflectionMappingsInfo.ClientboundSetEntityDataPacket_packedItems` - was unused.

## Notes

- This breaks back-support for `BiomeTag.downfall_type (mech)`, as that functionality was simply removed; we could theoretically implement partial back-support by modifying the base temperature to extremely high/low values that will basically guarantee the entire biome having that downfall type, but that could obviously mess up other scripts doing stuff with temperature, and we'll probably need to store the original temperature to set it back when setting to `NONE`?
- I didn't include setters for per-block temperature, as that's not really possible to cleanly implement - there is an internal `ThreadLocal` that provides a cache map of temperatures; if we really wanted to we could override that with our own `ThreadLocal` that provides our own map implementations (that redirects to the original cache) and have that return our overrides, but that's way too hacky and prone to break imo - you can still modify the base temperature.