### PR TITLE
Sign updates

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.objects;
 
+import com.denizenscript.denizen.utilities.MultiVersionHelper1_20;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
@@ -19,10 +20,11 @@ import com.denizenscript.denizen.utilities.flags.DataPersistenceFlagTracker;
 import com.denizenscript.denizen.utilities.flags.LocationFlagSearchHelper;
 import com.denizenscript.denizen.utilities.world.PathFinder;
 import com.denizenscript.denizen.utilities.world.WorldListChangeTracker;
+import com.denizenscript.denizencore.objects.core.*;
+import com.denizenscript.denizencore.utilities.EnumHelper;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizencore.objects.core.*;
 import com.denizenscript.denizencore.objects.notable.Notable;
 import com.denizenscript.denizencore.objects.notable.Note;
 import com.denizenscript.denizencore.objects.notable.NoteManager;
@@ -33,6 +35,7 @@ import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.SimplexNoise;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.denizencore.utilities.text.StringHolder;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.*;
@@ -40,6 +43,7 @@ import org.bukkit.block.*;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
+import org.bukkit.block.sign.Side;
 import org.bukkit.block.structure.Mirror;
 import org.bukkit.block.structure.StructureRotation;
 import org.bukkit.block.structure.UsageMode;
@@ -1234,19 +1238,30 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
 
         // <--[tag]
         // @attribute <LocationTag.sign_contents>
-        // @returns ListTag
+        // @returns ObjectTag
         // @mechanism LocationTag.sign_contents
         // @group world
         // @description
+        // Pre 1.20
         // Returns a list of lines on a sign.
+        // 1.20+
+        // Returns a map of each side and lines on that side.
         // -->
-        tagProcessor.registerTag(ListTag.class, "sign_contents", (attribute, object) -> {
-            if (object.getBlockStateForTag(attribute) instanceof Sign) {
-                return new ListTag(Arrays.asList(PaperAPITools.instance.getSignLines(((Sign) object.getBlockStateForTag(attribute)))));
-            }
-            else {
+        tagProcessor.registerTag(ObjectTag.class, "sign_contents", (attribute, object) -> {
+            BlockState state = object.getBlockStateForTag(attribute);
+            if (!(state instanceof Sign)) {
+                attribute.echoError("Location is not a valid Sign block.");
                 return null;
             }
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                String[][] contents = MultiVersionHelper1_20.getSignLines((Sign) state);
+                MapTag content = new MapTag();
+                content.putObject("front", new ListTag(Arrays.asList(contents[0])));
+                content.putObject("back", new ListTag(Arrays.asList(contents[1])));
+                return content;
+            }
+            return new ListTag(Arrays.asList(PaperAPITools.instance.getSignLines(((Sign) state))));
+
         });
 
         // <--[tag]
@@ -4119,38 +4134,77 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
 
         // <--[tag]
         // @attribute <LocationTag.sign_glowing>
-        // @returns ElementTag(Boolean)
+        // @returns ObjectTag
         // @mechanism LocationTag.sign_glowing
         // @group world
         // @description
+        // Pre 1.20
         // Returns whether the location is a Sign block that is glowing.
+        // 1.20+
+        // Returns a map of each side and whether the side is glowing.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "sign_glowing", (attribute, object) -> {
+        tagProcessor.registerTag(ObjectTag.class, "sign_glowing", (attribute, object) -> {
             BlockState state = object.getBlockStateForTag(attribute);
             if (!(state instanceof Sign)) {
                 attribute.echoError("Location is not a valid Sign block.");
                 return null;
+            }
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                MapTag glowMap = new MapTag();
+                glowMap.putObject("front", new ElementTag(((Sign) state).getSide(Side.FRONT).isGlowingText()));
+                glowMap.putObject("back", new ElementTag(((Sign) state).getSide(Side.BACK).isGlowingText()));
+                return glowMap;
             }
             return new ElementTag(((Sign) state).isGlowingText());
         });
 
         // <--[tag]
         // @attribute <LocationTag.sign_glow_color>
-        // @returns ElementTag
+        // @returns ObjectTag
         // @mechanism LocationTag.sign_glow_color
         // @group world
         // @description
+        // Pre 1.20
         // Returns the name of the glow-color of the sign at the location.
+        // 1.20+
+        // Returns a map of each side and the name of the color.
         // See also <@link tag LocationTag.sign_glowing>
         // -->
-        tagProcessor.registerTag(ElementTag.class, "sign_glow_color", (attribute, object) -> {
+        tagProcessor.registerTag(ObjectTag.class, "sign_glow_color", (attribute, object) -> {
             BlockState state = object.getBlockStateForTag(attribute);
             if (!(state instanceof Sign)) {
                 attribute.echoError("Location is not a valid Sign block.");
                 return null;
             }
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                MapTag glowMap = new MapTag();
+                glowMap.putObject("front", new ElementTag(((Sign) state).getSide(Side.FRONT).getColor()));
+                glowMap.putObject("back", new ElementTag(((Sign) state).getSide(Side.BACK).getColor()));
+                return glowMap;
+            }
             return new ElementTag(((Sign) state).getColor());
         });
+
+        // <--[tag]
+        // @attribute <LocationTag.sign_waxed>
+        // @returns ElementTag(Boolean)
+        // @mechanism LocationTag.sign_waxed
+        // @group world
+        // @description
+        // Returns whether the location is a Sign block that is waxed.
+        // See also <@link tag LocationTag.sign_glowing>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            tagProcessor.registerTag(ObjectTag.class, "sign_waxed", (attribute, object) -> {
+                BlockState state = object.getBlockStateForTag(attribute);
+                if (!(state instanceof Sign)) {
+                    attribute.echoError("Location is not a valid Sign block.");
+                    return null;
+                }
+                return new ElementTag(((Sign) state).isWaxed());
+            });
+        }
+
 
         // <--[tag]
         // @attribute <LocationTag.map_color>
@@ -4468,22 +4522,65 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @tags
         // <LocationTag.sign_contents>
         // -->
-        if (mechanism.matches("sign_contents") && getBlockState() instanceof Sign) {
-            Sign state = (Sign) getBlockState();
-            for (int i = 0; i < 4; i++) {
-                PaperAPITools.instance.setSignLine(state, i, "");
-            }
-            ListTag list = mechanism.valueAsType(ListTag.class);
-            CoreUtilities.fixNewLinesToListSeparation(list);
-            if (list.size() > 4) {
-                mechanism.echoError("Sign can only hold four lines!");
-            }
-            else {
-                for (int i = 0; i < list.size(); i++) {
-                    PaperAPITools.instance.setSignLine(state, i, list.get(i));
+        if (mechanism.matches("sign_contents")) {
+            BlockState state = getBlockState();
+            if (!(state instanceof Sign sign)) {
+                mechanism.echoError("'sign_contents' mechanism can only be called on Sign blocks.");
+            } else {
+                for (int i = 0; i < 4; i++) {
+                    PaperAPITools.instance.setSignLine(sign, i, "");
                 }
+                ListTag list = mechanism.valueAsType(ListTag.class);
+                CoreUtilities.fixNewLinesToListSeparation(list);
+                if (list.size() > 4) {
+                    mechanism.echoError("Sign can only hold four lines!");
+                } else {
+                    for (int i = 0; i < list.size(); i++) {
+                        PaperAPITools.instance.setSignLine(sign, i, list.get(i));
+                    }
+                }
+                state.update();
             }
-            state.update();
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_sides_contents
+        // @input MapTag
+        // @description
+        // Sets the contents of each side for a sign block.
+        // The input map keys are either 'Front' or 'Back'
+        // @tags
+        // <LocationTag.sign_contents>
+        // -->
+        if (mechanism.matches("sign_sides_contents") && mechanism.requireObject(MapTag.class)) {
+            BlockState state = getBlockState();
+            if (!(state instanceof Sign sign)) {
+                mechanism.echoError("'sign_sides_contents' mechanism can only be called on Sign blocks.");
+            } else {
+                MapTag glowMap = mechanism.valueAsType(MapTag.class);
+                for (Map.Entry<StringHolder, ObjectTag> entry : glowMap.map.entrySet()) {
+                    if (EnumHelper.get(Side.class).valuesMapLower.containsKey(entry.getKey().str)) {
+                        Side side = Side.valueOf(entry.getKey().toString().toUpperCase());
+                        for (int i = 0; i < 4; i++) {
+                            sign.getSide(side).setLine(i, "");
+                        }
+                        ListTag list = entry.getValue().asType(ListTag.class, mechanism.context);
+                        CoreUtilities.fixNewLinesToListSeparation(list);
+                        if (list.size() > 4) {
+                            mechanism.echoError("Sign can only hold four lines!");
+                        } else {
+                            for (int i = 0; i < list.size(); i++) {
+                                sign.getSide(side).setLine(i, list.get(i));
+                            }
+                        }
+                        sign.getSide(side).setGlowingText(entry.getValue().asElement().asBoolean());
+                    } else {
+                        mechanism.echoError("Unknown sign side " + entry.getKey());
+                    }
+                }
+                state.update();
+            }
         }
 
         // <--[mechanism]
@@ -5141,13 +5238,43 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // -->
         if (mechanism.matches("sign_glowing") && mechanism.requireBoolean()) {
             BlockState state = getBlockState();
-            if (!(state instanceof Sign)) {
+            if (!(state instanceof Sign sign)) {
                 mechanism.echoError("'sign_glowing' mechanism can only be called on Sign blocks.");
             }
             else {
-                Sign sign = (Sign) state;
                 sign.setGlowingText(mechanism.getValue().asBoolean());
                 sign.update();
+            }
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_sides_glowing
+        // @input MapTag
+        // @description
+        // Changes whether each side for a sign block is glowing.
+        // The input map keys are either 'Front' or 'Back'
+        // @tags
+        // <LocationTag.sign_glow_color>
+        // <LocationTag.sign_glowing>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("sign_sides_glowing") && mechanism.requireObject(MapTag.class)) {
+                BlockState state = getBlockState();
+                if (!(state instanceof Sign sign)) {
+                    mechanism.echoError("'sign_sides_glowing' mechanism can only be called on Sign blocks.");
+                } else {
+                    MapTag glowMap = mechanism.valueAsType(MapTag.class);
+                    for (Map.Entry<StringHolder, ObjectTag> entry : glowMap.map.entrySet()) {
+                        if (EnumHelper.get(Side.class).valuesMapLower.containsKey(entry.getKey().str)) {
+                            Side side = Side.valueOf(entry.getKey().toString().toUpperCase());
+                            sign.getSide(side).setGlowingText(entry.getValue().asElement().asBoolean());
+                        } else {
+                            mechanism.echoError("Unknown sign side " + entry.getKey());
+                        }
+                    }
+                    sign.update();
+                }
             }
         }
 
@@ -5166,13 +5293,72 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // -->
         if (mechanism.matches("sign_glow_color") && mechanism.requireEnum(DyeColor.class)) {
             BlockState state = getBlockState();
-            if (!(state instanceof Sign)) {
+            if (!(state instanceof Sign sign)) {
                 mechanism.echoError("'sign_glow_color' mechanism can only be called on Sign blocks.");
             }
             else {
-                Sign sign = (Sign) state;
                 sign.setColor(mechanism.getValue().asEnum(DyeColor.class));
                 sign.update();
+            }
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_sides_glow_color
+        // @input MapTag
+        // @description
+        // Changes the glow color of each side of the sign.
+        // For the list of possible colors, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html>.
+        // If a sign is not glowing, this is equivalent to applying a chat color to the sign.
+        // The input map keys are either 'Front' or 'Back'
+        // Use <@link mechanism LocationTag.sign_glowing> to toggle whether the sign is glowing.
+        // @tags
+        // <LocationTag.sign_glow_color>
+        // <LocationTag.sign_glowing>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("sign_sides_glow_color") && mechanism.requireObject(MapTag.class)) {
+                BlockState state = getBlockState();
+                if (!(state instanceof Sign sign)) {
+                    mechanism.echoError("'sign_sides_glow_color' mechanism can only be called on Sign blocks.");
+                } else {
+                    MapTag glowMap = mechanism.valueAsType(MapTag.class);
+                    for (Map.Entry<StringHolder, ObjectTag> entry : glowMap.map.entrySet()) {
+                        if (EnumHelper.get(Side.class).valuesMapLower.containsKey(entry.getKey().str)) {
+                            Side side = Side.valueOf(entry.getKey().toString().toUpperCase());
+                            if (EnumHelper.get(DyeColor.class).valuesMapLower.containsKey(entry.getValue().asElement().asLowerString())) {
+                                DyeColor color = DyeColor.valueOf(entry.getValue().asElement().asLowerString().toUpperCase());
+                                sign.getSide(side).setColor(color);
+                            } else {
+                                mechanism.echoError("Unknown dye color " + entry.getValue());
+                            }
+                        } else {
+                            mechanism.echoError("Unknown sign side " + entry.getKey());
+                        }
+                    }
+                    sign.update();
+                }
+            }
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_waxed
+        // @input ElementTag(Boolean)
+        // @description
+        // Changes whether the sign at the location is waxed.
+        // @tags
+        // <LocationTag.sign_waxed>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("sign_waxed") && mechanism.requireBoolean()) {
+                BlockState state = getBlockState();
+                if (!(state instanceof Sign sign)) {
+                    mechanism.echoError("'sign_waxed' mechanism can only be called on Sign blocks.");
+                } else {
+                    sign.setWaxed(mechanism.getValue().asBoolean());
+                    sign.update();
+                }
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -43,6 +43,7 @@ import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.block.banner.PatternType;
+import org.bukkit.block.sign.Side;
 import org.bukkit.boss.BossBar;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.*;
@@ -3798,6 +3799,52 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             }
             else {
                 NMSHandler.packetHelper.showSignEditor(getPlayerEntity(), null);
+            }
+        }
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name edit_sign_front
+        // @input LocationTag
+        // @description
+        // Allows the player to edit the front of an existing sign. To create a sign, see <@link command Sign>.
+        // Give no input to make a fake edit interface.
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("edit_sign_front")) {
+                if (mechanism.hasValue() && mechanism.requireObject(LocationTag.class)) {
+                    BlockState state = mechanism.valueAsType(LocationTag.class).getBlockState();
+                    if (!(state instanceof Sign)) {
+                        mechanism.echoError("Invalid location specified: must be a sign.");
+                        return;
+                    }
+                    getPlayerEntity().openSign((Sign) state, Side.FRONT);
+                } else {
+                    NMSHandler.packetHelper.showSignEditor(getPlayerEntity(), null);
+                }
+            }
+        }
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name edit_sign_back
+        // @input LocationTag
+        // @description
+        // Allows the player to edit the back of an existing sign. To create a sign, see <@link command Sign>.
+        // Give no input to make a fake edit interface.
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("edit_sign_back")) {
+                if (mechanism.hasValue() && mechanism.requireObject(LocationTag.class)) {
+                    BlockState state = mechanism.valueAsType(LocationTag.class).getBlockState();
+                    if (!(state instanceof Sign)) {
+                        mechanism.echoError("Invalid location specified: must be a sign.");
+                        return;
+                    }
+                    getPlayerEntity().openSign((Sign) state, Side.BACK);
+                } else {
+                    NMSHandler.packetHelper.showSignEditor(getPlayerEntity(), null);
+                }
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -1,7 +1,10 @@
 package com.denizenscript.denizen.scripts.commands.world;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.objects.properties.material.MaterialDirectional;
+import com.denizenscript.denizen.utilities.MultiVersionHelper1_20;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -16,19 +19,20 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
 
 public class SignCommand extends AbstractCommand {
 
     public SignCommand() {
         setName("sign");
-        setSyntax("sign (type:{automatic}/sign_post/wall_sign) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)");
+        setSyntax("sign (type:{automatic}/sign_post/wall_sign) (material:<material>) (side:{front}/back) [<line>|...] [<location>] (direction:north/east/south/west)");
         setRequiredArguments(1, 5);
         isProcedural = false;
     }
 
     // <--[command]
     // @Name Sign
-    // @Syntax sign (type:{automatic}/sign_post/wall_sign) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)
+    // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging_sign) (material:<material>) (side:{front}/back) [<line>|...] [<location>] (direction:north/east/south/west)
     // @Required 1
     // @Maximum 5
     // @Short Modifies a sign.
@@ -94,6 +98,11 @@ public class SignCommand extends AbstractCommand {
             else if (!scriptEntry.hasObject("text")) {
                 scriptEntry.addObject("text", arg.asType(ListTag.class));
             }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)
+                        && !scriptEntry.hasObject("side")
+                        && arg.matchesEnum(Side.class)) {
+                scriptEntry.addObject("side", arg.asElement());
+            }
             else {
                 arg.reportUnhandled();
             }
@@ -105,6 +114,10 @@ public class SignCommand extends AbstractCommand {
             throw new InvalidArgumentsException("Must specify sign text!");
         }
         scriptEntry.defaultObject("type", new ElementTag(Type.AUTOMATIC));
+
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            scriptEntry.defaultObject("side", new ElementTag(Side.FRONT));
+        }
     }
 
     public void setWallSign(Block sign, BlockFace bf, MaterialTag material) {
@@ -147,7 +160,11 @@ public class SignCommand extends AbstractCommand {
     }
 
     public static boolean isAnySign(Material material) {
-        return isStandingSign(material) || isWallSign(material);
+        boolean isSign = isStandingSign(material) || isWallSign(material);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            isSign = isSign || MultiVersionHelper1_20.isAnySign(material);
+        }
+        return isSign;
     }
 
     @Override
@@ -190,6 +207,15 @@ public class SignCommand extends AbstractCommand {
             }
         }
         BlockState signState = sign.getState();
-        Utilities.setSignLines((Sign) signState, text.toArray(new String[4]));
+        String[] textArr = text.toArray(new String[4]);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            ElementTag sideElement = scriptEntry.getObjectTag("side");
+            for (int n = 0; n < 4; n++) {
+                ((Sign) signState).getSide(Side.valueOf(sideElement.asLowerString().toUpperCase())).setLine(n, textArr[n]);
+            }
+            signState.update();
+        } else {
+            Utilities.setSignLines((Sign) signState, textArr);
+        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.utilities;
 
+import org.bukkit.Material;
 import org.bukkit.block.Sign;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
@@ -11,5 +12,25 @@ public class MultiVersionHelper1_20 {
         contents[0] = sign.getSide(Side.FRONT).getLines();
         contents[1] = sign.getSide(Side.BACK).getLines();
         return contents;
+    }
+
+    public static boolean isAnyHangingSign(Material material) {
+        switch (material) {
+            case CRIMSON_HANGING_SIGN:
+            case WARPED_HANGING_SIGN:
+            case ACACIA_HANGING_SIGN:
+            case BIRCH_HANGING_SIGN:
+            case DARK_OAK_HANGING_SIGN:
+            case JUNGLE_HANGING_SIGN:
+            case OAK_HANGING_SIGN:
+            case SPRUCE_HANGING_SIGN:
+            case CHERRY_HANGING_SIGN:
+                return true;
+            default:
+                return false;
+        }
+    }
+    public static boolean isAnySign(Material material) {
+        return material == Material.CHERRY_SIGN || material == Material.CHERRY_WALL_SIGN || isAnyHangingSign(material);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
@@ -1,0 +1,15 @@
+package com.denizenscript.denizen.utilities;
+
+import org.bukkit.block.Sign;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import org.bukkit.block.sign.Side;
+
+public class MultiVersionHelper1_20 {
+    public static String[][] getSignLines(Sign sign) {
+        String[][] contents = new String[2][];
+        contents[0] = sign.getSide(Side.FRONT).getLines();
+        contents[1] = sign.getSide(Side.BACK).getLines();
+        return contents;
+    }
+}


### PR DESCRIPTION
Changing tags about signs to return maps in 1.20 of the format `[front=;back=]` for the relevant information

added new mechs to take in map input for dealing with either front, back, or both at the same time (these are of the name `sign_sides_mechname` )

added 2 new mechs for the player for editing front and back sign

changed the sign command to give an argument of whether the text is going to the front or back


this is the first time ive had to deal with cross version code, so any advise on what should be done differently would be appreciated.
i am also concerned about the `PaperAPITools.set/getSignLines()`, i dont really know how to handle this for the new signs so i kinda ignored it entirely. Would appreciate some guidance here on if this should be changing in place and how.

 