### PR TITLE
Patched malformed text in item lore/display crashing tags

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -59,6 +59,9 @@ public class FormattedTextHelper {
     }
 
     public static boolean hasRootFormat(BaseComponent component) {
+        if (component == null) {
+            return false;
+        }
         if (component.hasFormatting()) {
             return true;
         }
@@ -87,7 +90,9 @@ public class FormattedTextHelper {
             builder.append(RESET);
         }
         for (BaseComponent component : components) {
-            builder.append(stringify(component));
+            if (component != null) {
+                builder.append(stringify(component));
+            }
         }
         String output = builder.toString();
         while (output.endsWith(RESET)) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -296,8 +296,14 @@ public class ItemHelperImpl extends ItemHelper {
         }
         net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(item.getItemStack());
         String jsonText = ((net.minecraft.nbt.CompoundTag) nmsItemStack.getTag().get("display")).getString("Name");
-        BaseComponent[] nameComponent = ComponentSerializer.parse(jsonText);
-        return FormattedTextHelper.stringify(nameComponent);
+        try {
+            BaseComponent[] nameComponent = ComponentSerializer.parse(jsonText);
+            return FormattedTextHelper.stringify(nameComponent);
+        }
+        catch (Throwable ex) {
+            Debug.echoError(ex);
+            return null;
+        }
     }
 
     @Override
@@ -309,8 +315,13 @@ public class ItemHelperImpl extends ItemHelper {
         ListTag list = ((net.minecraft.nbt.CompoundTag) nmsItemStack.getTag().get("display")).getList("Lore", 8);
         List<String> outList = new ArrayList<>();
         for (int i = 0; i < list.size(); i++) {
-            BaseComponent[] lineComponent = ComponentSerializer.parse(list.getString(i));
-            outList.add(FormattedTextHelper.stringify(lineComponent));
+            try {
+                BaseComponent[] lineComponent = ComponentSerializer.parse(list.getString(i));
+                outList.add(FormattedTextHelper.stringify(lineComponent));
+            }
+            catch (Throwable ex) {
+                Debug.echoError(ex);
+            }
         }
         return outList;
     }


### PR DESCRIPTION
I rely on <InventoryTag.map_slots> and found it to be crashing when we added a few datapacks to a separate server. It turns out one of the datapacks had some lore on randomly-generated items set to null. These items looked normal to players, but when I would go to save their cross-server inventory to disk I'd call map_slots and it would fail, preventing their inventory from saving.

It turns out the spigot parser likes to throw exceptions when it runs into json it doesn't expect. This PR patches Denizen to be a bit more robust with those malformed items. I tested using the commands present in the thread, as well as similar forms for item display names https://discord.com/channels/315163488085475337/1125851477924131026/1125851477924131026

Didn't backport them because... meh, update. Niche issue that most won't hit