### PR TITLE
Block helper cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -76,7 +76,7 @@ public interface BlockHelper {
 
     Instrument getInstrumentFor(Material mat);
 
-    default void ringBell(Bell bell) { // TODO: once 1.19 is the minimum supported version, remove from NMS
+    default void ringBell(Bell bell) { /// TODO: once minimum version is 1.19, remove from NMS
         bell.ring();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -32,9 +32,16 @@ public interface BlockHelper {
 
     BlockState generateBlockState(Block block, Material mat);
 
-    String getPushReaction(Material mat);
+    enum PistonPushReaction {
+        NORMAL, DESTROY, BLOCK, IGNORE, PUSH_ONLY;
+        public static final PistonPushReaction[] VALUES = values();
+    }
 
-    void setPushReaction(Material mat, String reaction);
+    default PistonPushReaction getPushReaction(Material mat) { // TODO: once minimum version is 1.19, remove from NMS
+        return PistonPushReaction.VALUES[mat.createBlockData().getPistonMoveReaction().ordinal()];
+    }
+
+    void setPushReaction(Material mat, PistonPushReaction reaction);
 
     float getBlockStrength(Material mat);
 
@@ -63,25 +70,17 @@ public interface BlockHelper {
         return Material.matchMaterial(material).createBlockData(otherData);
     }
 
-    default void makeBlockStateRaw(BlockState state) {
-        throw new UnsupportedOperationException();
+    void makeBlockStateRaw(BlockState state);
+
+    void doRandomTick(Location location);
+
+    Instrument getInstrumentFor(Material mat);
+
+    default void ringBell(Bell bell) { // TODO: once 1.19 is the minimum supported version, remove from NMS
+        bell.ring();
     }
 
-    default void doRandomTick(Location location) {
-        throw new UnsupportedOperationException();
-    }
-
-    default Instrument getInstrumentFor(Material mat) {
-        throw new UnsupportedOperationException();
-    }
-
-    default void ringBell(Bell block) {
-        throw new UnsupportedOperationException();
-    }
-
-    default int getExpDrop(Block block, ItemStack item) {
-        throw new UnsupportedOperationException();
-    }
+    int getExpDrop(Block block, ItemStack item);
 
     default void setSpawnerCustomRules(CreatureSpawner spawner, int skyMin, int skyMax, int blockMin, int blockMax) {
         throw new UnsupportedOperationException();
@@ -91,9 +90,7 @@ public interface BlockHelper {
         spawner.setSpawnedType(entity.getBukkitEntityType());
     }
 
-    default Color getMapColor(Block block) {
-        throw new UnsupportedOperationException();
-    }
+    Color getMapColor(Block block);
 
     default void setVanillaTags(Material material, Set<String> tags) {
         throw new UnsupportedOperationException();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4946,9 +4946,8 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                     ((Jukebox) state).setRecord(mechanism.valueAsType(ItemTag.class).getItemStack());
                 }
                 else {
-//                    NMSHandler.blockHelper.makeBlockStateRaw(state);
+                    NMSHandler.blockHelper.makeBlockStateRaw(state);
                     ((Jukebox) state).setRecord(null);
-                    Debug.log("Set record to null");
                 }
                 state.update();
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4946,8 +4946,9 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                     ((Jukebox) state).setRecord(mechanism.valueAsType(ItemTag.class).getItemStack());
                 }
                 else {
-                    NMSHandler.blockHelper.makeBlockStateRaw(state);
+//                    NMSHandler.blockHelper.makeBlockStateRaw(state);
                     ((Jukebox) state).setRecord(null);
+                    Debug.log("Set record to null");
                 }
                 state.update();
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -1,25 +1,26 @@
 package com.denizenscript.denizen.objects;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.interfaces.BlockHelper;
 import com.denizenscript.denizen.objects.properties.material.*;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.VanillaTagHelper;
-import com.denizenscript.denizencore.objects.core.MapTag;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.flags.RedirectionFlagTracker;
 import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -555,11 +556,27 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // Returns the material's piston reaction. (Only for block materials).
         // -->
         tagProcessor.registerTag(ElementTag.class, "piston_reaction", (attribute, object) -> {
-            String res = NMSHandler.blockHelper.getPushReaction(object.material);
-            if (res == null) {
-                return null;
+            return new ElementTag(NMSHandler.blockHelper.getPushReaction(object.material));
+        });
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name piston_reaction
+        // @input ElementTag
+        // @description
+        // Sets the piston reaction for all blocks of this material type.
+        // Input may be: NORMAL (push and pull allowed), DESTROY (break when pushed), BLOCK (prevent a push or pull), IGNORE (don't use this), or PUSH_ONLY (push allowed but not pull)
+        // @tags
+        // <MaterialTag.piston_reaction>
+        // -->
+        tagProcessor.registerMechanism("piston_reaction", false, ElementTag.class, (object, mechanism, input) -> {
+            if (!mechanism.requireEnum(BlockHelper.PistonPushReaction.class)) {
+                return;
             }
-            return new ElementTag(res);
+            if (!object.getMaterial().isBlock()) {
+                mechanism.echoError("'piston_reaction' mechanism is only valid for block types.");
+            }
+            NMSHandler.blockHelper.setPushReaction(object.getMaterial(), input.asEnum(BlockHelper.PistonPushReaction.class));
         });
 
         // <--[tag]
@@ -605,7 +622,7 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // @attribute <MaterialTag.produced_instrument>
         // @returns ElementTag
         // @description
-        // Returns the name of the instrument that would be used by a note block placed above a block of this material.
+        // Returns the name of the instrument that would be used by a note block placed above or below (depending on the material type) a block of this material.
         // See list at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Instrument.html>.
         // For the current instrument of a note block material refer to <@link tag MaterialTag.instrument>.
         // -->
@@ -733,23 +750,6 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
                 Debug.echoError("'block_strength' mechanism is only valid for block types.");
             }
             NMSHandler.blockHelper.setBlockStrength(material, mechanism.getValue().asFloat());
-        }
-
-        // <--[mechanism]
-        // @object MaterialTag
-        // @name piston_reaction
-        // @input ElementTag
-        // @description
-        // Sets the piston reaction for all blocks of this material type.
-        // Input may be: NORMAL (push and pull allowed), DESTROY (break when pushed), BLOCK (prevent a push or pull), IGNORE (don't use this), or PUSH_ONLY (push allowed but not pull)
-        // @tags
-        // <MaterialTag.piston_reaction>
-        // -->
-        if (!mechanism.isProperty && mechanism.matches("piston_reaction")) {
-            if (!material.isBlock()) {
-                Debug.echoError("'piston_reaction' mechanism is only valid for block types.");
-            }
-            NMSHandler.blockHelper.setPushReaction(material, mechanism.getValue().asString().toUpperCase());
         }
 
         tagProcessor.processMechanism(this, mechanism);

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/BlockHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/BlockHelperImpl.java
@@ -180,14 +180,14 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public String getPushReaction(Material mat) {
-        return getInternalMaterial(mat).getPushReaction().name();
+    public PistonPushReaction getPushReaction(Material mat) {
+        return PistonPushReaction.VALUES[getInternalMaterial(mat).getPushReaction().ordinal()];
     }
 
     @Override
-    public void setPushReaction(Material mat, String reaction) {
+    public void setPushReaction(Material mat, PistonPushReaction reaction) {
         try {
-            MATERIAL_PUSH_REACTION_SETTER.invoke(getInternalMaterial(mat), PushReaction.valueOf(reaction));
+            MATERIAL_PUSH_REACTION_SETTER.invoke(getInternalMaterial(mat), PushReaction.values()[reaction.ordinal()]);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -250,9 +250,9 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public void ringBell(Bell block) {
-        org.bukkit.block.data.type.Bell bellData = (org.bukkit.block.data.type.Bell) block.getBlockData();
-        Direction face = Direction.byName(bellData.getFacing().name());
+    public void ringBell(Bell bell) {
+        org.bukkit.block.data.type.Bell bellData = (org.bukkit.block.data.type.Bell) bell.getBlockData();
+        Direction face = CraftBlock.blockFaceToNotch(bellData.getFacing());
         Direction dir = Direction.NORTH;
         switch (bellData.getAttachment()) {
             case DOUBLE_WALL:
@@ -268,7 +268,7 @@ public class BlockHelperImpl implements BlockHelper {
                 dir = face;
                 break;
         }
-        CraftBlock craftBlock = (CraftBlock) block.getBlock();
+        CraftBlock craftBlock = (CraftBlock) bell.getBlock();
         ((BellBlock) Blocks.BELL).attemptToRing(craftBlock.getCraftWorld().getHandle(), craftBlock.getPosition(), dir);
     }
 

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
@@ -192,14 +192,14 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public String getPushReaction(Material mat) {
-        return getInternalMaterial(mat).getPushReaction().name();
+    public PistonPushReaction getPushReaction(Material mat) {
+        return PistonPushReaction.VALUES[getInternalMaterial(mat).getPushReaction().ordinal()];
     }
 
     @Override
-    public void setPushReaction(Material mat, String reaction) {
+    public void setPushReaction(Material mat, PistonPushReaction reaction) {
         try {
-            MATERIAL_PUSH_REACTION_SETTER.invoke(getInternalMaterial(mat), PushReaction.valueOf(reaction));
+            MATERIAL_PUSH_REACTION_SETTER.invoke(getInternalMaterial(mat), PushReaction.values()[reaction.ordinal()]);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -262,9 +262,9 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public void ringBell(Bell block) {
-        org.bukkit.block.data.type.Bell bellData = (org.bukkit.block.data.type.Bell) block.getBlockData();
-        Direction face = Direction.byName(bellData.getFacing().name());
+    public void ringBell(Bell bell) {
+        org.bukkit.block.data.type.Bell bellData = (org.bukkit.block.data.type.Bell) bell.getBlockData();
+        Direction face = CraftBlock.blockFaceToNotch(bellData.getFacing());
         Direction dir = Direction.NORTH;
         switch (bellData.getAttachment()) {
             case DOUBLE_WALL:
@@ -280,7 +280,7 @@ public class BlockHelperImpl implements BlockHelper {
                 dir = face;
                 break;
         }
-        CraftBlock craftBlock = (CraftBlock) block.getBlock();
+        CraftBlock craftBlock = (CraftBlock) bell.getBlock();
         ((BellBlock) Blocks.BELL).attemptToRing(craftBlock.getCraftWorld().getHandle(), craftBlock.getPosition(), dir);
     }
 

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
@@ -28,8 +28,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.SpawnData;
-import net.minecraft.world.level.block.BellBlock;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -194,14 +192,9 @@ public class BlockHelperImpl implements BlockHelper {
     }
 
     @Override
-    public String getPushReaction(Material mat) {
-        return getInternalMaterial(mat).getPushReaction().name();
-    }
-
-    @Override
-    public void setPushReaction(Material mat, String reaction) {
+    public void setPushReaction(Material mat, PistonPushReaction reaction) {
         try {
-            MATERIAL_PUSH_REACTION_SETTER.invoke(getInternalMaterial(mat), PushReaction.valueOf(reaction));
+            MATERIAL_PUSH_REACTION_SETTER.invoke(getInternalMaterial(mat), PushReaction.values()[reaction.ordinal()]);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -263,29 +256,6 @@ public class BlockHelperImpl implements BlockHelper {
         Optional<NoteBlockInstrument> aboveInstrument = NoteBlockInstrument.byStateAbove(blockType.defaultBlockState());
         NoteBlockInstrument nmsInstrument = aboveInstrument.orElse(NoteBlockInstrument.byStateBelow(blockType.defaultBlockState()));
         return Instrument.values()[(nmsInstrument.ordinal())];
-    }
-
-    @Override
-    public void ringBell(Bell block) {
-        org.bukkit.block.data.type.Bell bellData = (org.bukkit.block.data.type.Bell) block.getBlockData();
-        Direction face = Direction.byName(bellData.getFacing().name());
-        Direction dir = Direction.NORTH;
-        switch (bellData.getAttachment()) {
-            case DOUBLE_WALL:
-            case SINGLE_WALL:
-                switch (face) {
-                    case NORTH:
-                    case SOUTH:
-                        dir = Direction.EAST;
-                        break;
-                }
-                break;
-            case FLOOR:
-                dir = face;
-                break;
-        }
-        CraftBlock craftBlock = (CraftBlock) block.getBlock();
-        ((BellBlock) Blocks.BELL).attemptToRing(craftBlock.getCraftWorld().getHandle(), craftBlock.getPosition(), dir);
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
@@ -204,15 +204,6 @@ public class BlockHelperImpl implements BlockHelper {
         }
     }
 
-    // This is to debork Spigot's class remapper mishandling 'getFluidState' which remaps 'FluidState' to 'material.FluidType' (incorrectly) in the call and thus errors out.
-    // Relevant issue: https://hub.spigotmc.org/jira/browse/SPIGOT-6696
-    // NOTE: Not fixed as of 1.19 initial update
-    public static final MethodHandle BLOCKSTATEBASE_GETFLUIDSTATE = ReflectionHelper.getMethodHandle(BlockBehaviour.BlockStateBase.class, ReflectionMappingsInfo.BlockBehaviourBlockStateBase_getFluidState_method);
-    public static final MethodHandle FLUIDSTATE_ISRANDOMLYTICKING = ReflectionHelper.getMethodHandle(BLOCKSTATEBASE_GETFLUIDSTATE.type().returnType(), ReflectionMappingsInfo.FluidState_isRandomlyTicking_method);
-    public static final MethodHandle FLUIDSTATE_ISEMPTY = ReflectionHelper.getMethodHandle(BLOCKSTATEBASE_GETFLUIDSTATE.type().returnType(), ReflectionMappingsInfo.FluidState_isEmpty_method);
-    public static final MethodHandle FLUIDSTATE_CREATELEGACYBLOCK = ReflectionHelper.getMethodHandle(BLOCKSTATEBASE_GETFLUIDSTATE.type().returnType(), ReflectionMappingsInfo.FluidState_createLegacyBlock_method);
-    public static final MethodHandle FLUIDSTATE_ANIMATETICK = ReflectionHelper.getMethodHandle(BLOCKSTATEBASE_GETFLUIDSTATE.type().returnType(), ReflectionMappingsInfo.FluidState_animateTick_method, Level.class, BlockPos.class, RandomSource.class);
-
     @Override
     public void doRandomTick(Location location) {
         BlockPos pos = CraftLocation.toBlockPosition(location);
@@ -222,19 +213,9 @@ public class BlockHelperImpl implements BlockHelper {
         if (nmsBlock.isRandomlyTicking()) {
             nmsBlock.randomTick(nmsWorld, pos, nmsWorld.random);
         }
-        try {
-            Debug.log("Ticking fluid state");
-             FluidState fluid = nmsBlock.getFluidState();
-             if (fluid.isRandomlyTicking()) {
-                 fluid.animateTick(nmsWorld, pos, nmsWorld.random);
-             }
-//            Object fluid = BLOCKSTATEBASE_GETFLUIDSTATE.invoke(nmsBlock);
-//            if ((boolean) FLUIDSTATE_ISRANDOMLYTICKING.invoke(fluid)) {
-//                FLUIDSTATE_ANIMATETICK.invoke(fluid, nmsWorld, pos, nmsWorld.random);
-//            }
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
+        FluidState fluid = nmsBlock.getFluidState();
+        if (fluid.isRandomlyTicking()) {
+            fluid.animateTick(nmsWorld, pos, nmsWorld.random);
         }
     }
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -38,6 +38,7 @@ import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import org.bukkit.Bukkit;
@@ -354,43 +355,16 @@ public class ItemHelperImpl extends ItemHelper {
     }
 
     /**
-     * Copied from MapItem.getCorrectStateForFluidBlock, and rewritten as reflection due to Spigot bug - refer to bottom of BlockHelperImpl for detail.
+     * Copied from MapItem.getCorrectStateForFluidBlock.
      */
-    public static BlockState getCorrectStateForFluidBlock(Level world, BlockState iblockdata, BlockPos blockposition) {
-        try {
-            // FluidState fluid = iblockdata.getFluidState();
-            Object fluid = BlockHelperImpl.BLOCKSTATEBASE_GETFLUIDSTATE.invoke(iblockdata);
-            //return !fluid.isEmpty() && !iblockdata.isFaceSturdy(world, blockposition, Direction.UP) ? fluid.createLegacyBlock() : iblockdata;
-            boolean isEmpty = (boolean) BlockHelperImpl.FLUIDSTATE_ISEMPTY.invoke(fluid);
-            if (!isEmpty && !iblockdata.isFaceSturdy(world, blockposition, Direction.UP)) {
-                return (BlockState) BlockHelperImpl.FLUIDSTATE_CREATELEGACYBLOCK.invoke(fluid);
-            }
-            else {
-                return iblockdata;
-            }
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-            return iblockdata;
-        }
-    }
-
-    public static boolean blockStateFluidIsEmpty(BlockState iblockdata) {
-        try {
-            // return iblockdata.getFluidState().isEmpty();
-            Object fluid = BlockHelperImpl.BLOCKSTATEBASE_GETFLUIDSTATE.invoke(iblockdata);
-            return (boolean) BlockHelperImpl.FLUIDSTATE_ISEMPTY.invoke(fluid);
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-            return false;
-        }
+    public static BlockState getCorrectStateForFluidBlock(Level world, BlockState blockState, BlockPos blockPos) {
+        FluidState fluid = blockState.getFluidState();
+        return !fluid.isEmpty() && !blockState.isFaceSturdy(world, blockPos, Direction.UP) ? fluid.createLegacyBlock() : blockState;
     }
 
     /**
      * Copied from MapItem.update, redesigned slightly to render totally rather than just relative to a player.
      * Some variables manually renamed for readability.
-     * Also contains reflection fixes for Spigot's FluidState bug.
      */
     public static void renderFullMap(MapItemSavedData worldmap, int xMin, int zMin, int xMax, int zMax) {
         Level world = ((CraftWorld) worldmap.mapView.getWorld()).getHandle();
@@ -438,7 +412,7 @@ public class ItemHelperImpl extends ItemHelper {
                                         blockposition_mutableblockposition.set(chunkcoordintpair.getMinBlockX() + i4 + i3, k4, chunkcoordintpair.getMinBlockZ() + j4 + j3);
                                         iblockdata = chunk.getBlockState(blockposition_mutableblockposition);
                                     } while (iblockdata.getMapColor(world, blockposition_mutableblockposition) == MapColor.NONE && k4 > world.getMinBuildHeight());
-                                    if (k4 > world.getMinBuildHeight() && !blockStateFluidIsEmpty(iblockdata)) {
+                                    if (k4 > world.getMinBuildHeight() && !iblockdata.getFluidState().isEmpty()) {
                                         int l4 = k4 - 1;
                                         blockposition_mutableblockposition1.set(blockposition_mutableblockposition);
 
@@ -447,7 +421,7 @@ public class ItemHelperImpl extends ItemHelper {
                                             blockposition_mutableblockposition1.setY(l4--);
                                             iblockdata1 = chunk.getBlockState(blockposition_mutableblockposition1);
                                             k3++;
-                                        } while (l4 > world.getMinBuildHeight() && !blockStateFluidIsEmpty(iblockdata1));
+                                        } while (l4 > world.getMinBuildHeight() && !iblockdata1.getFluidState().isEmpty());
                                         iblockdata = getCorrectStateForFluidBlock(world, iblockdata, blockposition_mutableblockposition);
                                     }
                                 }


### PR DESCRIPTION
## Additions

- `BlockHelper$PistonPushReaction` enum mirroring the NMS one, for easier/cleaner handling.

## Changes

- `get/setPushReaction` now uses the `BlockHelper$PistonPushReaction` enum.
- `getPushReaction` now uses Spigot's new `BlockData#getPistonMoveReaction`.
- Removed a few `default -> throw` methods that were implemented on all versions' default impls.
- `ringBell` now uses Spigot's new `Bell#ring` method by default on 1.19+ (and gave the param a better name, `block` -> `bell`).
- Removed null handling from `MaterialTag.piston_reaction (tag)`, as the internal value doesn't seem to be nullable and the meta doesn't mention that either.
- Updated `MaterialTag.piston_reaction (mechanism)` to modern mech registration, and to use the new `BlockHelper$PistonPushReaction` enum for input handling.
- Updated `MaterialTag.produced_instrument`'s meta for the block being either above or below the noteblock.
- `ringBell`'s impls now use Spigot's `CraftBlock#blockFaceToNotch` instead of converting it by name - this caused a [bug](https://discord.com/channels/315163488085475337/1124686384700076042) on recent versions because of internal changes, but is a better practice overall.

## 1.20 impl changes
Made a few of the bigger changes/cleanups in the 1.20 impl only, both for easier testing and because that's the only place where it really matters (I.e. what gets used for new versions vs old code getting dropped).

- Updated some manual `BlockPos` creation via the constructor to `CraftLocation#toBlockPosition`.
- Replaced `getMaterialBlock` with `CraftMagicNumbers#getBlock`.
- `getMaterialBlockState` now uses `CraftMagicNumbers#getBlock#defaultBlockState`, instead of calling `createBlockData` every time; based on my testing this behaves the same (and `#defaultBlockState` is most likely the value used by Spigot internally), but let me know if I'm missing anything.
- `generateBlockState` now uses `getMaterialBlockState`.
- The `FluidState` remapping bug seems to be fixed now based on my testing, so removed the reflection patch - feel free to give this your own test to make sure I'm not messing up the testing somehow, but I've tested it on several versions and Spigot + Paper.
- Re-implemented `getInstrumentFor` using `BlockState(NMS)#instrument`.
- Improved naming + added `final` for some `MethodHandle`s.
- Removed `ItemHelper#blockStateFluidIsEmpty` in favor of just calling `getFluidState#isEmpty` directly in code, as it seems it was added because of the reflection mess that's no longer needed.

## Notes

- What is `makeBlockStateRaw` for/is it still needed? it's only used in `jukebox_record`, which seemed to still work fine when removing it.