### PR TITLE
Packet helper cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -3,7 +3,6 @@ package com.denizenscript.denizen.nms.interfaces;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.utilities.maps.MapImage;
 import com.denizenscript.denizencore.objects.core.ColorTag;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
 import org.bukkit.EntityEffect;
 import org.bukkit.Location;

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -66,7 +66,7 @@ public interface PacketHelper {
         float progressFloat;
         if (progress >= 0 && progress <= 9) {
             // Spigot treats 0 as -1, so add 0.1 which will then get floored
-            progressFloat = (progress + 0.1f) / 9f;
+            progressFloat = Math.max(progress, 0.1f) / 9f;
         }
         else {
             progressFloat = 0;

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -62,13 +62,10 @@ public interface PacketHelper {
     void showBlockAction(Player player, Location location, int action, int state);
 
     default void showBlockCrack(Player player, int id, Location location, int progress) {
-        float progressFloat;
+        float progressFloat = 0;
         if (progress >= 0 && progress <= 9) {
-            // Spigot treats 0 as -1, so add 0.1 which will then get floored
+            // Spigot treats 0 as -1, so replace 0 with 0.1 which will then get floored
             progressFloat = Math.max(progress, 0.1f) / 9f;
-        }
-        else {
-            progressFloat = 0;
         }
         player.sendBlockDamage(location, progressFloat, id);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -3,10 +3,12 @@ package com.denizenscript.denizen.nms.interfaces;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.utilities.maps.MapImage;
 import com.denizenscript.denizencore.objects.core.ColorTag;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
+import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.WorldBorder;
+import org.bukkit.block.Banner;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -60,11 +62,36 @@ public interface PacketHelper {
 
     void showBlockAction(Player player, Location location, int action, int state);
 
-    void showBlockCrack(Player player, int id, Location location, int progress);
+    default void showBlockCrack(Player player, int id, Location location, int progress) {
+        float progressFloat;
+        if (progress >= 0 && progress <= 9) {
+            // Spigot treats 0 as -1, so add 0.1 which will then get floored
+            progressFloat = (progress + 0.1f) / 9f;
+        }
+        else {
+            progressFloat = 0;
+        }
+        player.sendBlockDamage(location, progressFloat, id);
+        Debug.log("Actual sent progress: " + getSpigotProgress(progressFloat));
+    }
 
-    void showTileEntityData(Player player, Location location, int action, CompoundTag compoundTag);
+    default int getSpigotProgress(float progress) {
+        int stage = (int)(9.0F * progress);
+        if (progress == 0.0F) {
+            stage = -1;
+        }
+        return stage;
+    }
 
-    void showBannerUpdate(Player player, Location location, DyeColor base, List<Pattern> patterns);
+    default void showTileEntityData(Player player, Location location, int action, CompoundTag compoundTag) { // TODO: once minimum version is 1.20, remove in favor of Player#sendBlockUpdate
+        throw new UnsupportedOperationException();
+    }
+
+    default void showBannerUpdate(Player player, Location location, List<Pattern> patterns) { // TODO: once minimum version is 1.20, remove from NMS
+        Banner banner = (Banner) location.getBlock().getState();
+        banner.setPatterns(patterns);
+        player.sendBlockUpdate(location, banner);
+    }
 
     void showTabListHeaderFooter(Player player, String header, String footer);
 
@@ -83,11 +110,15 @@ public interface PacketHelper {
         player.sendEquipmentChange(entity, equipmentMap);
     }
 
-    void showHealth(Player player, float health, int food, float saturation);
+    default void showHealth(Player player, float health, int food, float saturation) { // TODO: once minimum version is 1.20, remove from NMS
+        player.sendHealthUpdate(health, food, saturation);
+    }
 
     void showMobHealth(Player player, LivingEntity mob, double health, double maxHealth);
 
-    void resetHealth(Player player);
+    default void resetHealth(Player player) { // TODO: once minimum version is 1.20, remove from NMS
+        player.sendHealthUpdate(player.getHealth(), player.getFoodLevel(), player.getSaturation());
+    }
 
     void showSignEditor(Player player, Location location); // TODO: once minimum version is 1.18 or higher, change to "showFakeSignEditor" and remove location param
 
@@ -107,7 +138,7 @@ public interface PacketHelper {
 
     void sendEntityMetadataFlagsUpdate(Player player, Entity entity);
 
-    void sendEntityEffect(Player player, Entity entity, byte effectId);
+    void sendEntityEffect(Player player, Entity entity, EntityEffect effect);
 
     int getPacketStats(Player player, boolean sent);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -72,15 +72,6 @@ public interface PacketHelper {
             progressFloat = 0;
         }
         player.sendBlockDamage(location, progressFloat, id);
-        Debug.log("Actual sent progress: " + getSpigotProgress(progressFloat));
-    }
-
-    default int getSpigotProgress(float progress) {
-        int stage = (int)(9.0F * progress);
-        if (progress == 0.0F) {
-            stage = -1;
-        }
-        return stage;
     }
 
     default void showTileEntityData(Player player, Location location, int action, CompoundTag compoundTag) { // TODO: once minimum version is 1.20, remove in favor of Player#sendBlockUpdate

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2764,12 +2764,6 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Forces the player to respawn if they are on the death screen.
         // -->
         if (mechanism.matches("respawn")) {
-            if (mechanism.value != null) {
-                Debug.log("Spigot respawn");
-                getPlayerEntity().spigot().respawn();
-                return;
-            }
-            Debug.log("NMS respawned");
             NMSHandler.packetHelper.respawn(getPlayerEntity());
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -42,6 +42,7 @@ import org.bukkit.advancement.Advancement;
 import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.banner.Pattern;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.boss.BossBar;
 import org.bukkit.command.PluginCommand;
@@ -2763,6 +2764,12 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Forces the player to respawn if they are on the death screen.
         // -->
         if (mechanism.matches("respawn")) {
+            if (mechanism.value != null) {
+                Debug.log("Spigot respawn");
+                getPlayerEntity().spigot().respawn();
+                return;
+            }
+            Debug.log("NMS respawned");
             NMSHandler.packetHelper.respawn(getPlayerEntity());
         }
 
@@ -3862,7 +3869,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         if (mechanism.matches("banner_update")) {
             if (mechanism.getValue().asString().length() > 0) {
                 String[] split = mechanism.getValue().asString().split("\\|");
-                List<org.bukkit.block.banner.Pattern> patterns = new ArrayList<>();
+                List<Pattern> patterns = new ArrayList<>();
                 if (LocationTag.matches(split[0]) && split.length > 1) {
                     List<String> splitList;
                     for (int i = 1; i < split.length; i++) {
@@ -3872,7 +3879,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                         }
                         try {
                             splitList = CoreUtilities.split(string, '/', 2);
-                            patterns.add(new org.bukkit.block.banner.Pattern(DyeColor.valueOf(splitList.get(0).toUpperCase()),
+                            patterns.add(new Pattern(DyeColor.valueOf(splitList.get(0).toUpperCase()),
                                     PatternType.valueOf(splitList.get(1).toUpperCase())));
                         }
                         catch (Exception e) {
@@ -3880,7 +3887,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                         }
                     }
                     LocationTag location = LocationTag.valueOf(split[0], mechanism.context);
-                    NMSHandler.packetHelper.showBannerUpdate(getPlayerEntity(), location, DyeColor.WHITE, patterns);
+                    NMSHandler.packetHelper.showBannerUpdate(getPlayerEntity(), location, patterns);
                 }
                 else {
                     Debug.echoError("Must specify a valid location and pattern list!");

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AnimateCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AnimateCommand.java
@@ -132,7 +132,7 @@ public class AnimateCommand extends AbstractCommand {
                     else if (effect != null) {
                         if (forPlayers != null) {
                             for (PlayerTag player : forPlayers) {
-                                NMSHandler.packetHelper.sendEntityEffect(player.getPlayerEntity(), entity.getBukkitEntity(), effect.getData());
+                                NMSHandler.packetHelper.sendEntityEffect(player.getPlayerEntity(), entity.getBukkitEntity(), effect);
                             }
                         }
                         else {

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PacketHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PacketHelperImpl.java
@@ -49,7 +49,7 @@ import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Team;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
+import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.craftbukkit.v1_17_R1.CraftEquipmentSlot;
@@ -210,7 +210,7 @@ public class PacketHelperImpl implements PacketHelper {
     }
 
     @Override
-    public void showBannerUpdate(Player player, Location location, DyeColor base, List<Pattern> patterns) {
+    public void showBannerUpdate(Player player, Location location, List<Pattern> patterns) {
         List<CompoundTag> nbtPatterns = new ArrayList<>();
         for (Pattern pattern : patterns) {
             nbtPatterns.add(NMSHandler.instance
@@ -397,8 +397,8 @@ public class PacketHelperImpl implements PacketHelper {
     }
 
     @Override
-    public void sendEntityEffect(Player player, Entity entity, byte effectId) {
-        send(player, new ClientboundEntityEventPacket(((CraftEntity) entity).getHandle(), effectId));
+    public void sendEntityEffect(Player player, Entity entity, EntityEffect effect) {
+        send(player, new ClientboundEntityEventPacket(((CraftEntity) entity).getHandle(), effect.getData()));
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PacketHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PacketHelperImpl.java
@@ -48,7 +48,7 @@ import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Team;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
+import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.banner.Pattern;
@@ -189,7 +189,7 @@ public class PacketHelperImpl implements PacketHelper {
     }
 
     @Override
-    public void showBannerUpdate(Player player, Location location, DyeColor base, List<Pattern> patterns) {
+    public void showBannerUpdate(Player player, Location location, List<Pattern> patterns) {
         List<CompoundTag> nbtPatterns = new ArrayList<>();
         for (Pattern pattern : patterns) {
             nbtPatterns.add(NMSHandler.instance
@@ -360,8 +360,8 @@ public class PacketHelperImpl implements PacketHelper {
     }
 
     @Override
-    public void sendEntityEffect(Player player, Entity entity, byte effectId) {
-        send(player, new ClientboundEntityEventPacket(((CraftEntity) entity).getHandle(), effectId));
+    public void sendEntityEffect(Player player, Entity entity, EntityEffect effect) {
+        send(player, new ClientboundEntityEventPacket(((CraftEntity) entity).getHandle(), effect.getData()));
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PacketHelperImpl.java
@@ -47,7 +47,7 @@ import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Team;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
+import org.bukkit.EntityEffect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.banner.Pattern;
@@ -176,7 +176,7 @@ public class PacketHelperImpl implements PacketHelper {
     }
 
     @Override
-    public void showBannerUpdate(Player player, Location location, DyeColor base, List<Pattern> patterns) {
+    public void showBannerUpdate(Player player, Location location, List<Pattern> patterns) {
         List<CompoundTag> nbtPatterns = new ArrayList<>();
         for (Pattern pattern : patterns) {
             nbtPatterns.add(NMSHandler.instance
@@ -333,8 +333,8 @@ public class PacketHelperImpl implements PacketHelper {
     }
 
     @Override
-    public void sendEntityEffect(Player player, Entity entity, byte effectId) {
-        send(player, new ClientboundEntityEventPacket(((CraftEntity) entity).getHandle(), effectId));
+    public void sendEntityEffect(Player player, Entity entity, EntityEffect effect) {
+        send(player, new ClientboundEntityEventPacket(((CraftEntity) entity).getHandle(), effect.getData()));
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.nms.v1_20.helpers;
 
+import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.interfaces.PacketHelper;
 import com.denizenscript.denizen.nms.v1_20.Handler;
 import com.denizenscript.denizen.nms.v1_20.ReflectionMappingsInfo;
@@ -137,8 +138,7 @@ public class PacketHelperImpl implements PacketHelper {
         // allowing the player to retain whatever vision the mob they spectated had.
         send(player, new ClientboundAddEntityPacket(entity));
         send(player, new ClientboundSetCameraPacket(entity));
-        ((CraftServer) Bukkit.getServer()).getHandle().respawn(((CraftPlayer) player).getHandle(),
-                ((CraftWorld) player.getWorld()).getHandle(), true, player.getLocation(), false, PlayerRespawnEvent.RespawnReason.PLUGIN);
+        NMSHandler.playerHelper.refreshPlayer(player);
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
@@ -187,7 +187,7 @@ public class PacketHelperImpl implements PacketHelper {
         FakeBlock.showFakeBlockTo(Collections.singletonList(new PlayerTag(player)), fakeSign, new MaterialTag(Material.OAK_WALL_SIGN), new DurationTag(1), true);
         BlockPos pos = new BlockPos(fakeSign.getBlockX(), 0, fakeSign.getBlockZ());
         DenizenNetworkManagerImpl.getNetworkManager(player).packetListener.fakeSignExpected = pos;
-        send(player, new ClientboundOpenSignEditorPacket(pos, true)); // TODO: 1.20: "isFrontText"?
+        send(player, new ClientboundOpenSignEditorPacket(pos, true));
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
@@ -52,6 +52,7 @@ import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R1.map.CraftMapCanvas;
 import org.bukkit.craftbukkit.v1_20_R1.map.CraftMapView;
+import org.bukkit.craftbukkit.v1_20_R1.util.CraftLocation;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -142,7 +143,7 @@ public class PacketHelperImpl implements PacketHelper {
 
     @Override
     public void showBlockAction(Player player, Location location, int action, int state) {
-        BlockPos position = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        BlockPos position = CraftLocation.toBlockPosition(location);
         Block block = ((CraftWorld) location.getWorld()).getHandle().getBlockState(position).getBlock();
         send(player, new ClientboundBlockEventPacket(position, block, action, state));
     }
@@ -151,8 +152,7 @@ public class PacketHelperImpl implements PacketHelper {
     public void showTabListHeaderFooter(Player player, String header, String footer) {
         Component cHeader = Handler.componentToNMS(FormattedTextHelper.parse(header, ChatColor.WHITE));
         Component cFooter = Handler.componentToNMS(FormattedTextHelper.parse(footer, ChatColor.WHITE));
-        ClientboundTabListPacket packet = new ClientboundTabListPacket(cHeader, cFooter);
-        send(player, packet);
+        send(player, new ClientboundTabListPacket(cHeader, cFooter));
     }
 
     @Override
@@ -168,7 +168,7 @@ public class PacketHelperImpl implements PacketHelper {
 
     @Override
     public void showMobHealth(Player player, LivingEntity mob, double health, double maxHealth) {
-        AttributeInstance attr = new AttributeInstance(Attributes.MAX_HEALTH, (a) -> { });
+        AttributeInstance attr = new AttributeInstance(Attributes.MAX_HEALTH, (a) -> {});
         attr.setBaseValue(maxHealth);
         send(player, new ClientboundUpdateAttributesPacket(mob.getEntityId(), Collections.singletonList(attr)));
         FriendlyByteBuf healthData = new FriendlyByteBuf(Unpooled.buffer());
@@ -336,21 +336,19 @@ public class PacketHelperImpl implements PacketHelper {
     public void showDebugTestMarker(Player player, Location location, ColorTag color, String name, int time) {
         ResourceLocation packetKey = new ResourceLocation("minecraft", "debug/game_test_add_marker");
         FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
-        buf.writeBlockPos(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        buf.writeBlockPos(CraftLocation.toBlockPosition(location));
         int colorInt = color.blue | (color.green << 8) | (color.red << 16) | (color.alpha << 24);
         buf.writeInt(colorInt);
         buf.writeByteArray(name.getBytes(StandardCharsets.UTF_8));
         buf.writeInt(time);
-        ClientboundCustomPayloadPacket packet = new ClientboundCustomPayloadPacket(packetKey, buf);
-        send(player, packet);
+        send(player, new ClientboundCustomPayloadPacket(packetKey, buf));
     }
 
     @Override
     public void clearDebugTestMarker(Player player) {
         ResourceLocation packetKey = new ResourceLocation("minecraft", "debug/game_test_clear");
         FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
-        ClientboundCustomPayloadPacket packet = new ClientboundCustomPayloadPacket(packetKey, buf);
-        send(player, packet);
+        send(player, new ClientboundCustomPayloadPacket(packetKey, buf));
     }
 
     @Override
@@ -358,8 +356,7 @@ public class PacketHelperImpl implements PacketHelper {
         ResourceLocation packetKey = new ResourceLocation("minecraft", "brand");
         FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
         buf.writeUtf(brand);
-        ClientboundCustomPayloadPacket packet = new ClientboundCustomPayloadPacket(packetKey, buf);
-        send(player, packet);
+        send(player, new ClientboundCustomPayloadPacket(packetKey, buf));
     }
 
     @Override


### PR DESCRIPTION
## Changes

- Changed `showBlockCrack` to use Spigot's `Player#sendBlockDamage`, with some conversion as Spigot uses a 0-1 float input format.
- Marked `showTileEntityData` for removal in favor of Spigot's `Player#sendBlockUpdate`
- Removed `showBannerUpdate`'s `DyeColor base` parameter, as it was unused and only ever got `WHITE` (just a leftover from when all banner base colors were a single block, afaik).
- Implemented `showBannerUpdate` using Spigot's `Player#sendBlockUpdate`, and marked it for removal from NMS.
- Implemented `showHealth` and `resetHealth` using Spigot's `Player#sendHealthUpdate`, and marked them for removal from NMS.
- Changed `sendEntityEffect` to take an `EntityEffect` instead of the raw `byte` and do the byte conversion internally instead, as that's just a better practice/makes more sense (use the internal network values in the internal code).
- **(Unrelated minor cleanup)** imported `org.bukkit.block.banner.Pattern` in `PlayerTag` instead of using the fully qualified name.

## Changes to the 1.20 impl
Most cleanups were only made for the 1.20 impl, both for easier testing and because that's what eventually gets used in new versions.

- Added `final` to some reflection constants.
- Removed `BLOCK_ENTITY_DATA_PACKET_CONSTRUCTOR`, as it was used for `showTileEntityData` which is no longer implemented/is marked for removal.
- **_Addition_** `createEntityData` - takes in an entity data serializer and a value; added it as `DataValue#create` cloned the value, and calling the constructor directly every time was a bit verbose.
- `setFakeAbsorption` now uses `List#of` and the new `createEntityData` instead of creating a new `SynchedEntityData`.
- `setVision` now uses `PlayerHelper#refreshPlayer` instead of calling the internal respawn logic and actually respawning the player server-side (less likely to cause potential issues/conflicts).
- Replaced some direct `BlockPos` constructor use with `CraftLocation#toBlockPosition`.
- `showMobHealth` now uses `createEntityData` with the health entity data accessor instead of manually writing the data.
- Removed the `isFrontText` TODO from `showSignEditor`, as I don't think it's relevant for that method's purpose (opening a fake sign editor).
- `sendRename` and `sendEntityMetadataFlagsUpdate` now use `List#of` and the new `createEntityData` instead of creating a new `ArrayList` and creating the `DataValue`s directly.
- Some other minor code cleanups, mainly passing the packet directly to `send` instead of saving it in a field (most places already did that, just changed the rest to be consistent).

## Notes

- Spigot has a respawn method, but it's not exactly the same as the NMS respawn we currently use, some of the differences include:
  - Spigot's doesn't fire criteria triggers
  - The NMS one moves players in hardcore into spectator
  - Sets the spectator generate chunks gamerule? might be mis-reading

  I'd say using Spigot's might make more sense, as it's just a respawn VS the NMS one having a fair bit of vanilla logic, although I can see it making sense either way - let me know what do you think.