### PR TITLE
Entity helper cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -88,7 +88,7 @@ public abstract class EntityHelper {
         ItemFrame best = null;
         Vector bestHitPos = null;
         BlockFace bestHitFace = null;
-        for (Entity entity : start.getWorld().getNearbyEntities(start.clone().add(direction.clone().multiply(50)), 100, 100, 100, (e) -> e instanceof ItemFrame && ((ItemFrame) e).getItem().getType() == Material.FILLED_MAP)) {
+        for (Entity entity : start.getWorld().getNearbyEntities(start.clone().add(direction.clone().multiply(50)), 100, 100, 100, (e) -> e instanceof ItemFrame itemFrame && itemFrame.getItem().getType() == Material.FILLED_MAP)) {
             double centerDist = entity.getLocation().distanceSquared(start);
             if (centerDist > bestDist) {
                 continue;
@@ -208,7 +208,7 @@ public abstract class EntityHelper {
                 return;
             }
         }
-        Location origin = from instanceof LivingEntity ? ((LivingEntity) from).getEyeLocation()
+        Location origin = from instanceof LivingEntity livingEntity ? livingEntity.getEyeLocation()
                 : new LocationTag(from.getLocation()).getBlockLocation().add(0.5, 0.5, 0.5);
         Location rotated = faceLocation(origin, at);
         rotate(from, rotated.getYaw(), rotated.getPitch());

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -46,7 +46,7 @@ public abstract class EntityHelper {
 
     public abstract void forceInteraction(Player player, Location location);
 
-    public abstract Entity getEntity(World world, UUID uuid); // TODO: Bukkit#getEntity?
+    public abstract Entity getEntity(World world, UUID uuid);
 
     public abstract CompoundTag getNbtData(Entity entity);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -98,9 +98,18 @@ public abstract class EntityHelper {
             double expandX = 0, expandY = 0, expandZ = 0;
             BlockFace face = frame.getFacing();
             switch (face) {
-                case SOUTH: case NORTH: expandX = EXP_RATE; expandY = EXP_RATE; break;
-                case EAST: case WEST: expandZ = EXP_RATE; expandY = EXP_RATE; break;
-                case UP: case DOWN: expandX = EXP_RATE; expandZ = EXP_RATE; break;
+                case SOUTH, NORTH -> {
+                    expandX = EXP_RATE;
+                    expandY = EXP_RATE;
+                }
+                case EAST, WEST -> {
+                    expandZ = EXP_RATE;
+                    expandY = EXP_RATE;
+                }
+                case UP, DOWN -> {
+                    expandX = EXP_RATE;
+                    expandZ = EXP_RATE;
+                }
             }
             RayTraceResult traced = frame.getBoundingBox().expand(expandX, expandY, expandZ).rayTrace(startVec, direction, range);
             if (traced == null || traced.getHitBlockFace() == null || traced.getHitBlockFace() != face) {
@@ -120,47 +129,47 @@ public abstract class EntityHelper {
         double basey = bestHitPos.getY() - Math.floor(bestHitPos.getY());
         double basez = bestHitPos.getZ() - Math.floor(bestHitPos.getZ());
         switch (bestHitFace) {
-            case NORTH:
+            case NORTH -> {
                 x = 128f - (basex * 128f);
                 y = 128f - (basey * 128f);
-                break;
-            case SOUTH:
+            }
+            case SOUTH -> {
                 x = basex * 128f;
                 y = 128f - (basey * 128f);
-                break;
-            case WEST:
+            }
+            case WEST -> {
                 x = basez * 128f;
                 y = 128f - (basey * 128f);
-                break;
-            case EAST:
+            }
+            case EAST -> {
                 x = 128f - (basez * 128f);
                 y = 128f - (basey * 128f);
-                break;
-            case UP:
+            }
+            case UP -> {
                 x = basex * 128f;
                 y = basez * 128f;
-                break;
-            case DOWN:
+            }
+            case DOWN -> {
                 x = basex * 128f;
                 y = 128f - (basez * 128f);
-                break;
+            }
         }
         MapMeta map = (MapMeta) best.getItem().getItemMeta();
         switch (best.getRotation()) {
-            case CLOCKWISE_45: case FLIPPED_45: // 90 deg
+            case CLOCKWISE_45, FLIPPED_45 -> { // 90 deg
                 double origX = x;
                 x = y;
                 y = 128f - origX;
-                break;
-            case CLOCKWISE: case COUNTER_CLOCKWISE: // 180 deg
+            }
+            case CLOCKWISE, COUNTER_CLOCKWISE -> { // 180 deg
                 x = 128f - x;
                 y = 128f - y;
-                break;
-            case CLOCKWISE_135: case COUNTER_CLOCKWISE_45: // 270 deg
+            }
+            case CLOCKWISE_135, COUNTER_CLOCKWISE_45 -> { // 270 deg
                 double origX2 = x;
                 x = 128f - y;
                 y = origX2;
-                break;
+            }
         }
         MapTag result = new MapTag();
         result.putObject("x", new ElementTag(Math.round(x)));

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -37,7 +37,7 @@ public abstract class EntityHelper {
         if (entity instanceof Player player) {
             player.setSneaking(sneak);
         }
-        NMSHandler.entityHelper.setPose(entity, sneak ? Pose.SNEAKING : Pose.STANDING);
+        setPose(entity, sneak ? Pose.SNEAKING : Pose.STANDING);
     }
 
     public abstract double getDamageTo(LivingEntity attacker, Entity target);

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.nms.interfaces;
 
-import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -390,13 +389,13 @@ public abstract class EntityHelper {
 
     public abstract void setTicksLived(Entity entity, int ticks);
 
-    public abstract void setHeadAngle(Entity entity, float angle);
+    public abstract void setHeadAngle(LivingEntity entity, float angle);
 
-    public void setGhastAttacking(Entity entity, boolean attacking) { // TODO: once minimum version is 1.19 or higher, remove from NMS
-        ((Ghast) entity).setCharging(attacking);
+    public void setGhastAttacking(Ghast ghast, boolean attacking) { // TODO: once minimum version is 1.19 or higher, remove from NMS
+        ghast.setCharging(attacking);
     }
 
-    public abstract void setEndermanAngry(Entity entity, boolean angry);
+    public abstract void setEndermanAngry(Enderman enderman, boolean angry);
 
     public static EntityDamageEvent fireFakeDamageEvent(Entity target, EntityTag source, Location sourceLoc, EntityDamageEvent.DamageCause cause, float amount) {
         EntityDamageEvent ede;

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -33,11 +33,11 @@ public abstract class EntityHelper {
 
     public abstract void setPose(Entity entity, Pose pose);
 
-    public void setSneaking(Entity player, boolean sneak) {
-        if (player instanceof  Player) {
-            ((Player) player).setSneaking(sneak);
+    public void setSneaking(Entity entity, boolean sneak) {
+        if (entity instanceof Player player) {
+            player.setSneaking(sneak);
         }
-        NMSHandler.entityHelper.setPose(player, sneak ? Pose.SNEAKING : Pose.STANDING);
+        NMSHandler.entityHelper.setPose(entity, sneak ? Pose.SNEAKING : Pose.STANDING);
     }
 
     public abstract double getDamageTo(LivingEntity attacker, Entity target);
@@ -46,7 +46,7 @@ public abstract class EntityHelper {
 
     public abstract void forceInteraction(Player player, Location location);
 
-    public abstract Entity getEntity(World world, UUID uuid);
+    public abstract Entity getEntity(World world, UUID uuid); // TODO: Bukkit#getEntity?
 
     public abstract CompoundTag getNbtData(Entity entity);
 
@@ -74,7 +74,7 @@ public abstract class EntityHelper {
      */
     public abstract void rotate(Entity entity, float yaw, float pitch);
 
-    public abstract float getBaseYaw(Entity entity);
+    public abstract float getBaseYaw(LivingEntity entity);
 
     // Taken from C2 NMS class for less dependency on C2
     public abstract void look(Entity entity, float yaw, float pitch);
@@ -406,37 +406,25 @@ public abstract class EntityHelper {
 
     public abstract void damage(LivingEntity target, float amount, EntityTag source, Location sourceLoc, EntityDamageEvent.DamageCause cause);
 
-    public void setLastHurtBy(LivingEntity mob, LivingEntity damager) {
-        throw new UnsupportedOperationException();
+    public abstract void setLastHurtBy(LivingEntity mob, LivingEntity damager);
+
+    public abstract void setFallingBlockType(FallingBlock entity, BlockData block);
+
+    public abstract EntityTag getMobSpawnerDisplayEntity(CreatureSpawner spawner);
+
+    public void setFireworkLifetime(Firework firework, int ticks) { // TODO: once minimum version is 1.19, remove from NMS
+        firework.setMaxLife(ticks);
     }
 
-    public void setFallingBlockType(FallingBlock entity, BlockData block) {
-        throw new UnsupportedOperationException();
+    public int getFireworkLifetime(Firework firework) { // TODO: once minimum version is 1.19, remove from NMS
+        return firework.getMaxLife();
     }
 
-    public EntityTag getMobSpawnerDisplayEntity(CreatureSpawner spawner) {
-        throw new UnsupportedOperationException();
-    }
+    public abstract int getInWaterTime(Zombie zombie);
 
-    public void setFireworkLifetime(Firework firework, int ticks) {
-        throw new UnsupportedOperationException();
-    }
+    public abstract void setInWaterTime(Zombie zombie, int ticks);
 
-    public int getFireworkLifetime(Firework firework) {
-        throw new UnsupportedOperationException();
-    }
-
-    public int getInWaterTime(Zombie zombie) {
-        throw new UnsupportedOperationException();
-    }
-
-    public void setInWaterTime(Zombie zombie, int ticks) {
-        throw new UnsupportedOperationException();
-    }
-
-    public void setTrackingRange(Entity entity, int range) {
-        throw new UnsupportedOperationException();
-    }
+    public abstract void setTrackingRange(Entity entity, int range);
 
     public abstract boolean isAggressive(Mob mob);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -417,7 +417,7 @@ public abstract class EntityHelper {
 
     public abstract void setLastHurtBy(LivingEntity mob, LivingEntity damager);
 
-    public abstract void setFallingBlockType(FallingBlock entity, BlockData block);
+    public abstract void setFallingBlockType(FallingBlock fallingBlock, BlockData block);
 
     public abstract EntityTag getMobSpawnerDisplayEntity(CreatureSpawner spawner);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -1598,10 +1598,10 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @returns ElementTag(Decimal)
         // @group location
         // @description
-        // Returns the entity's body yaw (separate from head yaw).
+        // Returns the entity's body yaw (separate from head yaw), only for living entities.
         // -->
         registerSpawnedOnlyTag(ElementTag.class, "body_yaw", (attribute, object) -> {
-            return new ElementTag(NMSHandler.entityHelper.getBaseYaw(object.getBukkitEntity()));
+            return new ElementTag(NMSHandler.entityHelper.getBaseYaw(object.getLivingEntity()));
         });
 
         // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -3781,7 +3781,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // This will not rotate the body at all. Most users should prefer <@link command look>.
         // -->
         if (mechanism.matches("head_angle") && mechanism.requireFloat()) {
-            NMSHandler.entityHelper.setHeadAngle(getBukkitEntity(), mechanism.getValue().asFloat());
+            NMSHandler.entityHelper.setHeadAngle(getLivingEntity(), mechanism.getValue().asFloat());
         }
 
         // <--[mechanism]
@@ -3819,7 +3819,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Sets whether the ghast entity should show the attacking face.
         // -->
         if (mechanism.matches("ghast_attacking") && mechanism.requireBoolean()) {
-            NMSHandler.entityHelper.setGhastAttacking(getBukkitEntity(), mechanism.getValue().asBoolean());
+            NMSHandler.entityHelper.setGhastAttacking((Ghast) getBukkitEntity(), mechanism.getValue().asBoolean());
         }
 
         // <--[mechanism]
@@ -3830,7 +3830,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Sets whether the enderman entity should be screaming angrily.
         // -->
         if (mechanism.matches("enderman_angry") && mechanism.requireBoolean()) {
-            NMSHandler.entityHelper.setEndermanAngry(getBukkitEntity(), mechanism.getValue().asBoolean());
+            NMSHandler.entityHelper.setEndermanAngry((Enderman) getBukkitEntity(), mechanism.getValue().asBoolean());
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -1598,7 +1598,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @returns ElementTag(Decimal)
         // @group location
         // @description
-        // Returns the entity's body yaw (separate from head yaw), only for living entities.
+        // Returns a living entity's body yaw (separate from head yaw).
         // -->
         registerSpawnedOnlyTag(ElementTag.class, "body_yaw", (attribute, object) -> {
             return new ElementTag(NMSHandler.entityHelper.getBaseYaw(object.getLivingEntity()));

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -406,9 +406,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public float getBaseYaw(Entity entity) {
-        net.minecraft.world.entity.Entity handle = ((CraftEntity) entity).getHandle();
-        return ((net.minecraft.world.entity.LivingEntity) handle).yBodyRot;
+    public float getBaseYaw(LivingEntity entity) {
+        return ((CraftLivingEntity) entity).getHandle().yBodyRot;
     }
 
     @Override

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -626,9 +626,9 @@ public class EntityHelperImpl extends EntityHelper {
     public static final MethodHandle FALLINGBLOCK_TYPE_SETTER = ReflectionHelper.getFinalSetterForFirstOfType(net.minecraft.world.entity.item.FallingBlockEntity.class, BlockState.class);
 
     @Override
-    public void setFallingBlockType(FallingBlock entity, BlockData block) {
+    public void setFallingBlockType(FallingBlock fallingBlock, BlockData block) {
         BlockState state = ((CraftBlockData) block).getState();
-        FallingBlockEntity nmsEntity = ((CraftFallingBlock) entity).getHandle();
+        FallingBlockEntity nmsEntity = ((CraftFallingBlock) fallingBlock).getHandle();
         try {
             FALLINGBLOCK_TYPE_SETTER.invoke(nmsEntity, state);
         }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -496,20 +496,20 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void setHeadAngle(Entity entity, float angle) {
+    public void setHeadAngle(LivingEntity entity, float angle) {
         net.minecraft.world.entity.LivingEntity handle = ((CraftLivingEntity) entity).getHandle();
         handle.yHeadRot = angle;
         handle.setYHeadRot(angle);
     }
 
     @Override
-    public void setGhastAttacking(Entity entity, boolean attacking) {
-        ((CraftGhast) entity).getHandle().setCharging(attacking);
+    public void setGhastAttacking(Ghast ghast, boolean attacking) {
+        ((CraftGhast) ghast).getHandle().setCharging(attacking);
     }
 
     @Override
-    public void setEndermanAngry(Entity entity, boolean angry) {
-        ((CraftEnderman) entity).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
+    public void setEndermanAngry(Enderman enderman, boolean angry) {
+        ((CraftEnderman) enderman).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
     }
 
     public static class FakeDamageSrc extends DamageSource { public DamageSource real; public FakeDamageSrc(DamageSource src) { super("fake"); real = src; } }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -438,9 +438,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public float getBaseYaw(Entity entity) {
-        net.minecraft.world.entity.Entity handle = ((CraftEntity) entity).getHandle();
-        return ((net.minecraft.world.entity.LivingEntity) handle).yBodyRot;
+    public float getBaseYaw(LivingEntity entity) {
+        return ((CraftLivingEntity) entity).getHandle().yBodyRot;
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -701,9 +701,9 @@ public class EntityHelperImpl extends EntityHelper {
     public static final MethodHandle FALLINGBLOCK_TYPE_SETTER = ReflectionHelper.getFinalSetterForFirstOfType(net.minecraft.world.entity.item.FallingBlockEntity.class, BlockState.class);
 
     @Override
-    public void setFallingBlockType(FallingBlock entity, BlockData block) {
+    public void setFallingBlockType(FallingBlock fallingBlock, BlockData block) {
         BlockState state = ((CraftBlockData) block).getState();
-        FallingBlockEntity nmsEntity = ((CraftFallingBlock) entity).getHandle();
+        FallingBlockEntity nmsEntity = ((CraftFallingBlock) fallingBlock).getHandle();
         try {
             FALLINGBLOCK_TYPE_SETTER.invoke(nmsEntity, state);
         }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -571,20 +571,20 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void setHeadAngle(Entity entity, float angle) {
+    public void setHeadAngle(LivingEntity entity, float angle) {
         net.minecraft.world.entity.LivingEntity handle = ((CraftLivingEntity) entity).getHandle();
         handle.yHeadRot = angle;
         handle.setYHeadRot(angle);
     }
 
     @Override
-    public void setGhastAttacking(Entity entity, boolean attacking) {
-        ((CraftGhast) entity).getHandle().setCharging(attacking);
+    public void setGhastAttacking(Ghast ghast, boolean attacking) {
+        ((CraftGhast) ghast).getHandle().setCharging(attacking);
     }
 
     @Override
-    public void setEndermanAngry(Entity entity, boolean angry) {
-        ((CraftEnderman) entity).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
+    public void setEndermanAngry(Enderman enderman, boolean angry) {
+        ((CraftEnderman) enderman).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
     }
 
     public static class FakeDamageSrc extends DamageSource { public DamageSource real; public FakeDamageSrc(DamageSource src) { super("fake"); real = src; } }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -587,15 +587,15 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void setHeadAngle(Entity entity, float angle) {
+    public void setHeadAngle(LivingEntity entity, float angle) {
         net.minecraft.world.entity.LivingEntity handle = ((CraftLivingEntity) entity).getHandle();
         handle.yHeadRot = angle;
         handle.setYHeadRot(angle);
     }
 
     @Override
-    public void setEndermanAngry(Entity entity, boolean angry) {
-        ((CraftEnderman) entity).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
+    public void setEndermanAngry(Enderman enderman, boolean angry) {
+        ((CraftEnderman) enderman).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
     }
 
     public static class FakeDamageSrc extends DamageSource { public DamageSource real; public FakeDamageSrc(DamageSource src) { super(null); real = src; } }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -722,9 +722,9 @@ public class EntityHelperImpl extends EntityHelper {
     public static final MethodHandle FALLINGBLOCK_TYPE_SETTER = ReflectionHelper.getFinalSetterForFirstOfType(net.minecraft.world.entity.item.FallingBlockEntity.class, BlockState.class);
 
     @Override
-    public void setFallingBlockType(FallingBlock entity, BlockData block) {
+    public void setFallingBlockType(FallingBlock fallingBlock, BlockData block) {
         BlockState state = ((CraftBlockData) block).getState();
-        FallingBlockEntity nmsEntity = ((CraftFallingBlock) entity).getHandle();
+        FallingBlockEntity nmsEntity = ((CraftFallingBlock) fallingBlock).getHandle();
         try {
             FALLINGBLOCK_TYPE_SETTER.invoke(nmsEntity, state);
         }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -450,9 +450,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public float getBaseYaw(Entity entity) {
-        net.minecraft.world.entity.Entity handle = ((CraftEntity) entity).getHandle();
-        return ((net.minecraft.world.entity.LivingEntity) handle).yBodyRot;
+    public float getBaseYaw(LivingEntity entity) {
+        return ((CraftLivingEntity) entity).getHandle().yBodyRot;
     }
 
     @Override
@@ -740,16 +739,6 @@ public class EntityHelperImpl extends EntityHelper {
         ServerLevel level = ((CraftWorld) spawner.getWorld()).getHandle();
         net.minecraft.world.entity.Entity nmsEntity = nmsSpawner.getSpawner().getOrCreateDisplayEntity(level, level.random, nmsSpawner.getBlockPos());
         return new EntityTag(nmsEntity.getBukkitEntity());
-    }
-
-    @Override
-    public void setFireworkLifetime(Firework firework, int ticks) {
-        ((CraftFirework) firework).getHandle().lifetime = ticks;
-    }
-
-    @Override
-    public int getFireworkLifetime(Firework firework) {
-        return ((CraftFirework) firework).getHandle().lifetime;
     }
 
     public static final Field ZOMBIE_INWATERTIME = ReflectionHelper.getFields(net.minecraft.world.entity.monster.Zombie.class).get(ReflectionMappingsInfo.Zombie_inWaterTime, int.class);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -205,11 +205,9 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public void stopWalking(Entity entity) {
-        net.minecraft.world.entity.Entity nmsEntity = ((CraftEntity) entity).getHandle();
-        if (!(nmsEntity instanceof Mob)) {
-            return;
+        if (((CraftEntity) entity).getHandle() instanceof Mob nmsMob) {
+            nmsMob.getNavigation().stop();
         }
-        ((Mob) nmsEntity).getNavigation().stop();
     }
 
     @Override
@@ -220,10 +218,9 @@ public class EntityHelperImpl extends EntityHelper {
         }
 
         final net.minecraft.world.entity.Entity nmsEntityFollower = ((CraftEntity) follower).getHandle();
-        if (!(nmsEntityFollower instanceof Mob)) {
+        if (!(nmsEntityFollower instanceof Mob nmsFollower)) {
             return;
         }
-        final Mob nmsFollower = (Mob) nmsEntityFollower;
         final PathNavigation followerNavigation = nmsFollower.getNavigation();
 
         UUID uuid = follower.getUniqueId();
@@ -384,8 +381,8 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public void sendHidePacket(Player pl, Entity entity) {
-        if (entity instanceof Player) {
-            pl.hidePlayer(Denizen.getInstance(), (Player) entity);
+        if (entity instanceof Player player) {
+            pl.hidePlayer(Denizen.getInstance(), player);
             return;
         }
         CraftPlayer craftPlayer = (CraftPlayer) pl;
@@ -405,8 +402,8 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public void sendShowPacket(Player pl, Entity entity) {
-        if (entity instanceof Player) {
-            pl.showPlayer(Denizen.getInstance(), (Player) entity);
+        if (entity instanceof Player player) {
+            pl.showPlayer(Denizen.getInstance(), player);
             return;
         }
         CraftPlayer craftPlayer = (CraftPlayer) pl;
@@ -426,7 +423,7 @@ public class EntityHelperImpl extends EntityHelper {
     public void rotate(Entity entity, float yaw, float pitch) {
         // If this entity is a real player instead of a player type NPC,
         // it will appear to be online
-        if (entity instanceof Player && ((Player) entity).isOnline()) {
+        if (entity instanceof Player player && player.isOnline()) {
             NetworkInterceptHelper.enable();
             float relYaw = (yaw - entity.getLocation().getYaw()) % 360;
             if (relYaw > 180) {
@@ -434,7 +431,7 @@ public class EntityHelperImpl extends EntityHelper {
             }
             final float actualRelYaw = relYaw;
             float relPitch = pitch - entity.getLocation().getPitch();
-            NMSHandler.packetHelper.sendRelativeLookPacket((Player) entity, actualRelYaw, relPitch);
+            NMSHandler.packetHelper.sendRelativeLookPacket(player, actualRelYaw, relPitch);
         }
         else if (entity instanceof LivingEntity) {
             if (entity instanceof EnderDragon) {
@@ -613,11 +610,11 @@ public class EntityHelperImpl extends EntityHelper {
         DamageSources sources = nmsSourceProvider == null ? getReusableDamageSources() : nmsSourceProvider.level().damageSources();
         DamageSource src = sources.generic();
         if (nmsSource != null) {
-            if (nmsSource instanceof net.minecraft.world.entity.player.Player) {
-                src = nmsSource.level().damageSources().playerAttack((net.minecraft.world.entity.player.Player) nmsSource);
+            if (nmsSource instanceof net.minecraft.world.entity.player.Player nmsPlayer) {
+                src = nmsSource.level().damageSources().playerAttack(nmsPlayer);
             }
-            else if (nmsSource instanceof net.minecraft.world.entity.LivingEntity) {
-                src = nmsSource.level().damageSources().mobAttack((net.minecraft.world.entity.LivingEntity) nmsSource);
+            else if (nmsSource instanceof net.minecraft.world.entity.LivingEntity nmsLivingEntity) {
+                src = nmsSource.level().damageSources().mobAttack(nmsLivingEntity);
             }
         }
         if (cause == null) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -681,9 +681,9 @@ public class EntityHelperImpl extends EntityHelper {
     public static final MethodHandle FALLINGBLOCK_TYPE_SETTER = ReflectionHelper.getFinalSetterForFirstOfType(net.minecraft.world.entity.item.FallingBlockEntity.class, BlockState.class);
 
     @Override
-    public void setFallingBlockType(FallingBlock entity, BlockData block) {
+    public void setFallingBlockType(FallingBlock fallingBlock, BlockData block) {
         BlockState state = ((CraftBlockData) block).getState();
-        FallingBlockEntity nmsEntity = ((CraftFallingBlock) entity).getHandle();
+        FallingBlockEntity nmsEntity = ((CraftFallingBlock) fallingBlock).getHandle();
         try {
             FALLINGBLOCK_TYPE_SETTER.invoke(nmsEntity, state);
         }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -450,9 +450,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public float getBaseYaw(Entity entity) {
-        net.minecraft.world.entity.Entity handle = ((CraftEntity) entity).getHandle();
-        return ((net.minecraft.world.entity.LivingEntity) handle).yBodyRot;
+    public float getBaseYaw(LivingEntity entity) {
+        return ((CraftLivingEntity) entity).getHandle().yBodyRot;
     }
 
     @Override
@@ -579,18 +578,18 @@ public class EntityHelperImpl extends EntityHelper {
     public void setTicksLived(Entity entity, int ticks) {
         // Bypass Spigot's must-be-at-least-1-tick requirement, as negative tick counts are useful
         ((CraftEntity) entity).getHandle().tickCount = ticks;
-        if (entity instanceof CraftFallingBlock) {
-            ((CraftFallingBlock) entity).getHandle().time = ticks;
+        if (entity instanceof CraftFallingBlock craftFallingBlock) {
+            craftFallingBlock.getHandle().time = ticks;
         }
-        else if (entity instanceof CraftItem) {
-            ((ItemEntity) ((CraftItem) entity).getHandle()).age = ticks;
+        else if (entity instanceof CraftItem craftItem) {
+            ((ItemEntity) craftItem.getHandle()).age = ticks;
         }
     }
 
     @Override
     public void setHeadAngle(Entity entity, float angle) {
         net.minecraft.world.entity.LivingEntity handle = ((CraftLivingEntity) entity).getHandle();
-        handle.yHeadRot = angle;
+        handle.yHeadRot = angle; // TODO: is this needed?
         handle.setYHeadRot(angle);
     }
 
@@ -740,16 +739,6 @@ public class EntityHelperImpl extends EntityHelper {
         ServerLevel level = ((CraftWorld) spawner.getWorld()).getHandle();
         net.minecraft.world.entity.Entity nmsEntity = nmsSpawner.getSpawner().getOrCreateDisplayEntity(level, level.random, nmsSpawner.getBlockPos());
         return new EntityTag(nmsEntity.getBukkitEntity());
-    }
-
-    @Override
-    public void setFireworkLifetime(Firework firework, int ticks) {
-        ((CraftFirework) firework).getHandle().lifetime = ticks;
-    }
-
-    @Override
-    public int getFireworkLifetime(Firework firework) {
-        return ((CraftFirework) firework).getHandle().lifetime;
     }
 
     public static final Field ZOMBIE_INWATERTIME = ReflectionHelper.getFields(net.minecraft.world.entity.monster.Zombie.class).get(ReflectionMappingsInfo.Zombie_inWaterTime, int.class);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -615,7 +615,7 @@ public class EntityHelperImpl extends EntityHelper {
             case ENTITY_ATTACK -> sources.mobAttack(nmsSource instanceof net.minecraft.world.entity.LivingEntity nmsLivingEntity ? nmsLivingEntity : null);
             case ENTITY_SWEEP_ATTACK -> src != sources.generic() ? src.sweep() : src;
             case PROJECTILE -> sources.thrown(nmsSource, nmsSource != null && nmsSource.getBukkitEntity() instanceof Projectile projectile
-                        && projectile.getShooter() instanceof Entity shooter ? ((CraftEntity) shooter).getHandle() : null);
+                        && projectile.getShooter() instanceof CraftEntity shooter ? shooter.getHandle() : null);
             case SUFFOCATION -> sources.inWall();
             case FALL -> sources.fall();
             case FIRE -> sources.inFire();
@@ -643,8 +643,7 @@ public class EntityHelperImpl extends EntityHelper {
             case SONIC_BOOM -> sources.sonicBoom(nmsSource);
             case WORLD_BORDER -> sources.outOfBorder();
             case KILL -> sources.genericKill();
-            //case SUICIDE ->
-            default -> new FakeDamageSrc(src);
+            case SUICIDE -> new FakeDamageSrc(src);
         };
     }
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -574,13 +574,13 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void setHeadAngle(Entity entity, float angle) {
+    public void setHeadAngle(LivingEntity entity, float angle) {
         ((CraftLivingEntity) entity).getHandle().setYHeadRot(angle);
     }
 
     @Override
-    public void setEndermanAngry(Entity entity, boolean angry) {
-        ((CraftEnderman) entity).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
+    public void setEndermanAngry(Enderman enderman, boolean angry) {
+        ((CraftEnderman) enderman).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
     }
 
     public static class FakeDamageSrc extends DamageSource { public DamageSource real; public FakeDamageSrc(DamageSource src) { super(null); real = src; } }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -609,69 +609,38 @@ public class EntityHelperImpl extends EntityHelper {
         if (cause == null) {
             return src;
         }
-        switch (cause) {
-            case CONTACT:
-                return sources.cactus();
-            case ENTITY_ATTACK:
-                return sources.mobAttack(nmsSource instanceof net.minecraft.world.entity.LivingEntity ? (net.minecraft.world.entity.LivingEntity) nmsSource : null);
-            case ENTITY_SWEEP_ATTACK:
-                if (src != sources.generic()) {
-                    src.sweep();
-                }
-                return src;
-            case PROJECTILE:
-                return sources.thrown(nmsSource, nmsSource != null && nmsSource.getBukkitEntity() instanceof Projectile
-                        && ((Projectile) nmsSource.getBukkitEntity()).getShooter() instanceof Entity ? ((CraftEntity) ((Projectile) nmsSource.getBukkitEntity()).getShooter()).getHandle() : null);
-            case SUFFOCATION:
-                return sources.inWall();
-            case FALL:
-                return sources.fall();
-            case FIRE:
-                return sources.inFire();
-            case FIRE_TICK:
-                return sources.onFire();
-            case MELTING:
-                return sources.melting;
-            case LAVA:
-                return sources.lava();
-            case DROWNING:
-                return sources.drown();
-            case BLOCK_EXPLOSION:
-                return sources.explosion(nmsSource instanceof TNTPrimed && ((TNTPrimed) nmsSource).getSource() instanceof net.minecraft.world.entity.LivingEntity ? (net.minecraft.world.entity.LivingEntity) ((TNTPrimed) nmsSource).getSource() : null, null);
-            case ENTITY_EXPLOSION:
-                return sources.explosion(nmsSource, null);
-            case VOID:
-                return sources.fellOutOfWorld();
-            case LIGHTNING:
-                return sources.lightningBolt();
-            case STARVATION:
-                return sources.starve();
-            case POISON:
-                return sources.poison;
-            case MAGIC:
-                return sources.magic();
-            case WITHER:
-                return sources.wither();
-            case FALLING_BLOCK:
-                return sources.fallingBlock(nmsSource);
-            case THORNS:
-                return sources.thorns(nmsSource);
-            case DRAGON_BREATH:
-                return sources.dragonBreath();
-            case CUSTOM:
-                return sources.generic();
-            case FLY_INTO_WALL:
-                return sources.flyIntoWall();
-            case HOT_FLOOR:
-                return sources.hotFloor();
-            case CRAMMING:
-                return sources.cramming();
-            case DRYOUT:
-                return sources.dryOut();
-            //case SUICIDE:
-            default:
-                return new FakeDamageSrc(src);
-        }
+        return switch (cause) {
+            case CONTACT -> sources.cactus();
+            case ENTITY_ATTACK -> sources.mobAttack(nmsSource instanceof net.minecraft.world.entity.LivingEntity nmsLivingEntity ? nmsLivingEntity : null);
+            case ENTITY_SWEEP_ATTACK -> src != sources.generic() ? src.sweep() : src;
+            case PROJECTILE -> sources.thrown(nmsSource, nmsSource != null && nmsSource.getBukkitEntity() instanceof Projectile projectile
+                        && projectile.getShooter() instanceof Entity shooter ? ((CraftEntity) shooter).getHandle() : null);
+            case SUFFOCATION -> sources.inWall();
+            case FALL -> sources.fall();
+            case FIRE -> sources.inFire();
+            case FIRE_TICK -> sources.onFire();
+            case MELTING -> sources.melting;
+            case LAVA -> sources.lava();
+            case DROWNING -> sources.drown();
+            case BLOCK_EXPLOSION -> sources.explosion(nmsSource instanceof TNTPrimed primedTNT && primedTNT.getSource() instanceof net.minecraft.world.entity.LivingEntity nmsLivingEntity ? nmsLivingEntity : null, null);
+            case ENTITY_EXPLOSION -> sources.explosion(nmsSource, null);
+            case VOID -> sources.fellOutOfWorld();
+            case LIGHTNING -> sources.lightningBolt();
+            case STARVATION -> sources.starve();
+            case POISON -> sources.poison;
+            case MAGIC -> sources.magic();
+            case WITHER -> sources.wither();
+            case FALLING_BLOCK -> sources.fallingBlock(nmsSource);
+            case THORNS -> sources.thorns(nmsSource);
+            case DRAGON_BREATH -> sources.dragonBreath();
+            case CUSTOM -> sources.generic();
+            case FLY_INTO_WALL -> sources.flyIntoWall();
+            case HOT_FLOOR -> sources.hotFloor();
+            case CRAMMING -> sources.cramming();
+            case DRYOUT -> sources.dryOut();
+            //case SUICIDE ->
+            default -> new FakeDamageSrc(src);
+        };
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -502,8 +502,7 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public boolean internalLook(Player player, Location at) {
-        ClientboundPlayerLookAtPacket packet = new ClientboundPlayerLookAtPacket(EntityAnchorArgument.Anchor.EYES, at.getX(), at.getY(), at.getZ());
-        PacketHelperImpl.send(player, packet);
+        PacketHelperImpl.send(player, new ClientboundPlayerLookAtPacket(EntityAnchorArgument.Anchor.EYES, at.getX(), at.getY(), at.getZ()));
         return true;
     }
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -675,14 +675,14 @@ public class EntityHelperImpl extends EntityHelper {
         ((CraftLivingEntity) mob).getHandle().setLastHurtByMob(((CraftLivingEntity) damager).getHandle());
     }
 
-    public static final MethodHandle FALLINGBLOCK_TYPE_SETTER = ReflectionHelper.getFinalSetterForFirstOfType(net.minecraft.world.entity.item.FallingBlockEntity.class, BlockState.class);
+    public static final Field FALLINGBLOCK_BLOCK_STATE = ReflectionHelper.getFields(FallingBlockEntity.class).getFirstOfType(BlockState.class);
 
     @Override
     public void setFallingBlockType(FallingBlock fallingBlock, BlockData block) {
         BlockState state = ((CraftBlockData) block).getState();
         FallingBlockEntity nmsEntity = ((CraftFallingBlock) fallingBlock).getHandle();
         try {
-            FALLINGBLOCK_TYPE_SETTER.invoke(nmsEntity, state);
+            FALLINGBLOCK_BLOCK_STATE.set(nmsEntity, state);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -577,9 +577,7 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public void setHeadAngle(Entity entity, float angle) {
-        net.minecraft.world.entity.LivingEntity handle = ((CraftLivingEntity) entity).getHandle();
-        handle.yHeadRot = angle; // TODO: is this needed?
-        handle.setYHeadRot(angle);
+        ((CraftLivingEntity) entity).getHandle().setYHeadRot(angle);
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -14,7 +14,6 @@ import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import io.netty.buffer.Unpooled;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.game.ClientboundMoveEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerLookAtPacket;
@@ -27,7 +26,6 @@ import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerPlayerConnection;
-import net.minecraft.server.players.PlayerList;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.CombatRules;
@@ -68,6 +66,7 @@ import org.bukkit.craftbukkit.v1_20_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_20_R1.entity.*;
 import org.bukkit.craftbukkit.v1_20_R1.event.CraftEventFactory;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_20_R1.util.CraftLocation;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -163,10 +162,9 @@ public class EntityHelperImpl extends EntityHelper {
     @Override
     public void forceInteraction(Player player, Location location) {
         CraftPlayer craftPlayer = (CraftPlayer) player;
-        BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         ((CraftBlock) location.getBlock()).getNMS().use(((CraftWorld) location.getWorld()).getHandle(),
                 craftPlayer != null ? craftPlayer.getHandle() : null, InteractionHand.MAIN_HAND,
-                new BlockHitResult(new Vec3(0, 0, 0), null, pos, false));
+                new BlockHitResult(new Vec3(0, 0, 0), null, CraftLocation.toBlockPosition(location), false));
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -746,6 +746,7 @@ public class EntityHelperImpl extends EntityHelper {
         ((CraftMob) mob).getHandle().setAggressive(aggressive);
     }
 
+    // Use reflection because Paper changes the method return type
     public static final MethodHandle PLAYERLIST_REMOVE = ReflectionHelper.getMethodHandle(PlayerList.class, "remove", ServerPlayer.class);
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -448,27 +448,25 @@ public class EntityHelperImpl extends EntityHelper {
     @Override
     public void look(Entity entity, float yaw, float pitch) {
         net.minecraft.world.entity.Entity handle = ((CraftEntity) entity).getHandle();
-        if (handle != null) {
-            handle.setYRot(yaw);
-            if (handle instanceof net.minecraft.world.entity.LivingEntity) {
-                net.minecraft.world.entity.LivingEntity livingHandle = (net.minecraft.world.entity.LivingEntity) handle;
-                while (yaw < -180.0F) {
-                    yaw += 360.0F;
-                }
-                while (yaw >= 180.0F) {
-                    yaw -= 360.0F;
-                }
-                livingHandle.yBodyRotO = yaw;
-                if (!(handle instanceof net.minecraft.world.entity.player.Player)) {
-                    livingHandle.setYBodyRot(yaw);
-                }
-                livingHandle.setYHeadRot(yaw);
-            }
-            handle.setXRot(pitch);
-        }
-        else {
+        if (handle == null) {
             Debug.echoError("Cannot set look direction for unspawned entity " + entity.getUniqueId());
+            return;
         }
+        handle.setYRot(yaw);
+        if (handle instanceof net.minecraft.world.entity.LivingEntity nmsLivingEntity) {
+            while (yaw < -180.0F) {
+                yaw += 360.0F;
+            }
+            while (yaw >= 180.0F) {
+                yaw -= 360.0F;
+            }
+            nmsLivingEntity.yBodyRotO = yaw;
+            if (!(handle instanceof net.minecraft.world.entity.player.Player)) {
+                nmsLivingEntity.setYBodyRot(yaw);
+            }
+            nmsLivingEntity.setYHeadRot(yaw);
+        }
+        handle.setXRot(pitch);
     }
 
     private static HitResult rayTrace(World world, Vector start, Vector end) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -26,6 +26,7 @@ import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerPlayerConnection;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.CombatRules;
@@ -746,6 +747,8 @@ public class EntityHelperImpl extends EntityHelper {
         ((CraftMob) mob).getHandle().setAggressive(aggressive);
     }
 
+    public static final MethodHandle PLAYERLIST_REMOVE = ReflectionHelper.getMethodHandle(PlayerList.class, "remove", ServerPlayer.class);
+
     @Override
     public void setUUID(Entity entity, UUID id) {
         try {
@@ -755,7 +758,7 @@ public class EntityHelperImpl extends EntityHelper {
             Level level = nmsEntity.level();
             DedicatedPlayerList playerList = ((CraftServer) Bukkit.getServer()).getHandle();
             if (nmsEntity instanceof ServerPlayer nmsPlayer) {
-                playerList.remove(nmsPlayer);
+                PLAYERLIST_REMOVE.invoke(playerList, nmsPlayer);
             }
             else {
                 nmsEntity.remove(net.minecraft.world.entity.Entity.RemovalReason.DISCARDED);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -385,17 +385,14 @@ public class EntityHelperImpl extends EntityHelper {
             pl.hidePlayer(Denizen.getInstance(), player);
             return;
         }
-        CraftPlayer craftPlayer = (CraftPlayer) pl;
-        ServerPlayer entityPlayer = craftPlayer.getHandle();
-        if (entityPlayer.connection != null && !craftPlayer.equals(entity)) {
-            ChunkMap tracker = ((ServerLevel) craftPlayer.getHandle().level()).getChunkSource().chunkMap;
-            net.minecraft.world.entity.Entity other = ((CraftEntity) entity).getHandle();
-            ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
+        ServerPlayer nmsPlayer = ((CraftPlayer) pl).getHandle();
+        if (nmsPlayer.connection != null && !pl.equals(entity)) {
+            ChunkMap.TrackedEntity entry = nmsPlayer.serverLevel().getChunkSource().chunkMap.entityMap.get(entity.getEntityId());
             if (entry != null) {
-                entry.removePlayer(entityPlayer);
+                entry.removePlayer(nmsPlayer);
             }
             if (Denizen.supportsPaper) { // Workaround for Paper issue
-                entityPlayer.connection.send(new ClientboundRemoveEntitiesPacket(other.getId()));
+                nmsPlayer.connection.send(new ClientboundRemoveEntitiesPacket(entity.getEntityId()));
             }
         }
     }
@@ -406,15 +403,12 @@ public class EntityHelperImpl extends EntityHelper {
             pl.showPlayer(Denizen.getInstance(), player);
             return;
         }
-        CraftPlayer craftPlayer = (CraftPlayer) pl;
-        ServerPlayer entityPlayer = craftPlayer.getHandle();
-        if (entityPlayer.connection != null && !craftPlayer.equals(entity)) {
-            ChunkMap tracker = ((ServerLevel) craftPlayer.getHandle().level()).getChunkSource().chunkMap;
-            net.minecraft.world.entity.Entity other = ((CraftEntity) entity).getHandle();
-            ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
+        ServerPlayer nmsPlayer = ((CraftPlayer) pl).getHandle();
+        if (nmsPlayer.connection != null && !pl.equals(entity)) {
+            ChunkMap.TrackedEntity entry = nmsPlayer.serverLevel().getChunkSource().chunkMap.entityMap.get(entity.getEntityId());
             if (entry != null) {
-                entry.removePlayer(entityPlayer);
-                entry.updatePlayer(entityPlayer);
+                entry.removePlayer(nmsPlayer);
+                entry.updatePlayer(nmsPlayer);
             }
         }
     }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -658,10 +658,9 @@ public class EntityHelperImpl extends EntityHelper {
         CraftEventFactory.blockDamage = sourceLoc == null ? null : sourceLoc.getBlock();
         try {
             DamageSource src = getSourceFor(nmsSource, cause, nmsTarget);
-            if (src instanceof FakeDamageSrc) {
-                src = ((FakeDamageSrc) src).real;
-                EntityDamageEvent ede = fireFakeDamageEvent(target, source, sourceLoc, cause, amount);
-                if (ede.isCancelled()) {
+            if (src instanceof FakeDamageSrc fakeDamageSrc) {
+                src = fakeDamageSrc.real;
+                if (fireFakeDamageEvent(target, source, sourceLoc, cause, amount).isCancelled()) {
                     return;
                 }
             }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -748,9 +748,6 @@ public class EntityHelperImpl extends EntityHelper {
         ((CraftMob) mob).getHandle().setAggressive(aggressive);
     }
 
-    public static final Field ENTITY_REMOVALREASON = ReflectionHelper.getFields(net.minecraft.world.entity.Entity.class).getFirstOfType(net.minecraft.world.entity.Entity.RemovalReason.class);
-    public static final MethodHandle PLAYERLIST_REMOVE = ReflectionHelper.getMethodHandle(PlayerList.class, "remove", ServerPlayer.class);
-
     @Override
     public void setUUID(Entity entity, UUID id) {
         try {
@@ -759,16 +756,16 @@ public class EntityHelperImpl extends EntityHelper {
             nmsEntity.getPassengers().forEach(net.minecraft.world.entity.Entity::stopRiding);
             Level level = nmsEntity.level();
             DedicatedPlayerList playerList = ((CraftServer) Bukkit.getServer()).getHandle();
-            if (nmsEntity instanceof ServerPlayer) {
-                PLAYERLIST_REMOVE.invoke(playerList, nmsEntity);
+            if (nmsEntity instanceof ServerPlayer nmsPlayer) {
+                playerList.remove(nmsPlayer);
             }
             else {
                 nmsEntity.remove(net.minecraft.world.entity.Entity.RemovalReason.DISCARDED);
             }
-            ENTITY_REMOVALREASON.set(nmsEntity, null);
+            nmsEntity.unsetRemoved();
             nmsEntity.setUUID(id);
-            if (nmsEntity instanceof ServerPlayer) {
-                playerList.placeNewPlayer(DenizenNetworkManagerImpl.getConnection((ServerPlayer) nmsEntity), (ServerPlayer) nmsEntity);
+            if (nmsEntity instanceof ServerPlayer nmsPlayer) {
+                playerList.placeNewPlayer(DenizenNetworkManagerImpl.getConnection(nmsPlayer), nmsPlayer);
             }
             else {
                 level.addFreshEntity(nmsEntity);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -123,8 +123,8 @@ public class EntityHelperImpl extends EntityHelper {
         if (target != null) {
             DamageSource source;
             net.minecraft.world.entity.Entity nmsTarget = ((CraftEntity) target).getHandle();
-            if (attacker instanceof Player) {
-                source = nmsTarget.level().damageSources().playerAttack(((CraftPlayer) attacker).getHandle());
+            if (attacker instanceof CraftPlayer playerAttacker) {
+                source = nmsTarget.level().damageSources().playerAttack(playerAttacker.getHandle());
             }
             else {
                 source = nmsTarget.level().damageSources().mobAttack(((CraftLivingEntity) attacker).getHandle());
@@ -132,10 +132,9 @@ public class EntityHelperImpl extends EntityHelper {
             if (nmsTarget.isInvulnerableTo(source)) {
                 return 0;
             }
-            if (!(nmsTarget instanceof net.minecraft.world.entity.LivingEntity)) {
+            if (!(nmsTarget instanceof net.minecraft.world.entity.LivingEntity livingTarget)) {
                 return damage;
             }
-            net.minecraft.world.entity.LivingEntity livingTarget = (net.minecraft.world.entity.LivingEntity) nmsTarget;
             damage = CombatRules.getDamageAfterAbsorb((float) damage, (float) livingTarget.getArmorValue(), (float) livingTarget.getAttributeValue(Attributes.ARMOR_TOUGHNESS));
             int enchantDamageModifier = EnchantmentHelper.getDamageProtection(livingTarget.getArmorSlots(), source);
             if (enchantDamageModifier > 0) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -638,6 +638,10 @@ public class EntityHelperImpl extends EntityHelper {
             case HOT_FLOOR -> sources.hotFloor();
             case CRAMMING -> sources.cramming();
             case DRYOUT -> sources.dryOut();
+            case FREEZE -> sources.freeze();
+            case SONIC_BOOM -> sources.sonicBoom(nmsSource);
+            case WORLD_BORDER -> sources.outOfBorder();
+            case KILL -> sources.genericKill();
             //case SUICIDE ->
             default -> new FakeDamageSrc(src);
         };

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -82,7 +82,7 @@ public class EntityHelperImpl extends EntityHelper {
 
     public static final MethodHandle ENTITY_ONGROUND_SETTER = ReflectionHelper.getFinalSetter(net.minecraft.world.entity.Entity.class, ReflectionMappingsInfo.Entity_onGround, boolean.class);
 
-    public static final EntityDataAccessor<Boolean> ENTITY_ENDERMAN_DATAWATCHER_SCREAMING = ReflectionHelper.getFieldValue(EnderMan.class, ReflectionMappingsInfo.EnderMan_DATA_CREEPY, null);
+    public static final EntityDataAccessor<Boolean> ENDERMAN_DATA_ACCESSOR_SCREAMING = ReflectionHelper.getFieldValue(EnderMan.class, ReflectionMappingsInfo.EnderMan_DATA_CREEPY, null);
 
     @Override
     public void setInvisible(Entity entity, boolean invisible) {
@@ -580,7 +580,7 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public void setEndermanAngry(Enderman enderman, boolean angry) {
-        ((CraftEnderman) enderman).getHandle().getEntityData().set(ENTITY_ENDERMAN_DATAWATCHER_SCREAMING, angry);
+        ((CraftEnderman) enderman).getHandle().getEntityData().set(ENDERMAN_DATA_ACCESSOR_SCREAMING, angry);
     }
 
     public static class FakeDamageSrc extends DamageSource { public DamageSource real; public FakeDamageSrc(DamageSource src) { super(null); real = src; } }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -41,6 +41,7 @@ import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.item.PrimedTnt;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.ClipContext;
@@ -622,7 +623,7 @@ public class EntityHelperImpl extends EntityHelper {
             case MELTING -> sources.melting;
             case LAVA -> sources.lava();
             case DROWNING -> sources.drown();
-            case BLOCK_EXPLOSION -> sources.explosion(nmsSource instanceof TNTPrimed primedTNT && primedTNT.getSource() instanceof net.minecraft.world.entity.LivingEntity nmsLivingEntity ? nmsLivingEntity : null, null);
+            case BLOCK_EXPLOSION -> nmsSource instanceof PrimedTnt primedTnt ? sources.explosion(primedTnt, primedTnt.getOwner()) : sources.explosion(null);
             case ENTITY_EXPLOSION -> sources.explosion(nmsSource, null);
             case VOID -> sources.fellOutOfWorld();
             case LIGHTNING -> sources.lightningBolt();


### PR DESCRIPTION
## Changes

- `setSneaking` - changed the param name (`player` -> `entity`), as it isn't necessarily one (e.g. doesn't look like the `sneak` command checks that).
- Updated to `instanceof` pattern matching/modern switch statments wherever relevant.
- `setSneaking` no longer re-grabs the `EntityHelper` instance when calling `setPose`, as it's already called on the relevant instance.
- Changed `getBaseYaw` and `setHeadAngle`'s param type to `LivingEntity`, as they were already casting to that internally (I.e. would exception out for anything that isn't a living entity).
- Changed `setGhastAttacking`'s param type to `Ghast`.
- Changed `setEndermanAngry`'s param type to `Enderman`.
- Changed some methods that were implemented on every version to `abstract`.
- Changed `setFallingBlockType`'s param name to `fallingBlock`.
- `get/setFireworkLifetime` now uses Spigot's API for that - the only changes are:
  - It limits the input to above `0`, which shouldn't be a problem?
  - It doesn't set it if the firework is already detonated, which should be fine as well afaik
- Changed `EntityTag.body_yaw`'s meta to specify it's living entity only.
- `getBaseYaw`'s impl now casts to `CraftLivingEntity` instead of casting to `CraftEntity` and then casting it's handle.

## 1.20 impl changes
Most impl changes were only made in the 1.20 impl, both for easier testing and as that's what eventually gets used anyway

- Renamed `ENTITY_ENDERMAN_DATAWATCHER_SCREAMING` to `ENDERMAN_DATA_ACCESSOR_SCREAMING`.
- Changed the early return to a normal `if` in `stopWalking`, as it was just one line and the early return was pretty redundant.
- Cleaned up `sendHide/ShowPacket`:
  - Renamed `ServerPlayer entityPlayer` to `nmsPlayer`.
  - Removed the `craftPlayer` variable in favor of directly doing the cast for `nmsPlayer`, using `pl` for the `equals` check, and using `nmsPlayer` to get the `ChunkMap` instead of calling `getHandle` on `craftPlayer` again.
  - Replaced `(ServerLevel) nmsPlayer#level` with `#serverLevel`.
  - Now uses `entity.getEntityId()` instead of getting the NMS entity from it and calling `Entity(NMS)#getId`.
- `look` now uses early return for a bit less nesting.
- Changed some places that constructed a packet into a field and then passed it to `send` to construct it directly in `send`.
- Removed the `LivingEntity(NMS).yHeadRot` field set from `setHeadAngle`, as `LivingEntity(NMS)#setYHeadRot` seems to always override it anyway (with either the same value or a modified one).
- Updated/cleaned up `getSourceFor`:
  - Fixed `BLOCK_EXPLOSION`'s handling - it was previously checking if the NMS entity is an instanceof the bukkit `TNTPrimed`, which would never pass; changed it to use the NMS `PrirmedTNT` class, and pass the proper params to `sources#explosion` (the TNT and it's creator).
  - Added the `FREEZE`, `SONIC_BOOM`, `WORLD_BORDER`, and `KILL` causes.
  - Replaced `default` with `case SUICIDE` (the only cause that doesn't have an NMS equivalent), so that the switch won't compile whenever it needs to be updated for new damage causes - this feels like a better practice and all, but lmk if it should be reverted.
- Removed the redundant `ede` (`EntityDamageEvent`) variable in `damage` in favor of directly using `fireFakeDamageEvent`'s result.
- Renamed `FALLINGBLOCK_TYPE_SETTER` to `FALLINGBLOCK_BLOCK_STATE`, and changed it from a `getFinalSetter` `MethodHandle` to a `Field`, as the NMS field it's changing isn't `final`.
- Removed `ENTITY_REMOVALREASON`, see below.
- Replaced reflectively setting the entity removal reason to `null` in `setUUID` with `Entity(NMS)#unsetRemoved` (which does just that) - let me know if there's any specific reason it was done that way.
- Add a comment to `PLAYERLIST_REMOVE` specifying why it's reflection instead of a direct method call.

## Notes

- Probably missing something, but what's `FakeDamageSrc` for? whenever it's used, all it seems to be doing is grabbing the real source from it - why not just return that?
- Is there any reason for the per-world `getEntity` method? the only place it's used is when iterating over all worlds in `EntityTag#getEntityForID`, which is exactly what `Bukkit#getEntity` does.
- Why does `getDamageTo` check `attacker.getEquipment().getItemInMainHand() != null`? that method's marked as `@NonNull` - is it some weird edge-case bug or something?