### PR TITLE
Fishing helper cleanup

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/FishingHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/FishingHelper.java
@@ -13,23 +13,13 @@ public interface FishingHelper {
 
     FishHook spawnHook(Location location, Player player);
 
-    default FishHook getHookFrom(Player player) {
-        throw new UnsupportedOperationException();
-    }
+    FishHook getHookFrom(Player player);
 
-    default void setNibble(FishHook hook, int ticks) {
-        throw new UnsupportedOperationException();
-    }
+    void setNibble(FishHook hook, int ticks);
 
-    default void setHookTime(FishHook hook, int ticks) {
-        throw new UnsupportedOperationException();
-    }
+    void setHookTime(FishHook hook, int ticks);
 
-    default int getLureTime(FishHook hook) {
-        throw new UnsupportedOperationException();
-    }
+    int getLureTime(FishHook hook);
 
-    default void setLureTime(FishHook hook, int ticks) {
-        throw new UnsupportedOperationException();
-    }
+    void setLureTime(FishHook hook, int ticks);
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/FishingHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/FishingHelperImpl.java
@@ -99,24 +99,24 @@ public class FishingHelperImpl implements FishingHelper {
         return getRandomReward(fishHook, BuiltInLootTables.FISHING_FISH);
     }
 
-    public static final Field FISHING_HOOK_NIBBLE_SETTER = ReflectionHelper.getFields(FishingHook.class).get(ReflectionMappingsInfo.FishingHook_nibble, int.class);
-    public static final Field FISHING_HOOK_LURE_TIME_SETTER = ReflectionHelper.getFields(FishingHook.class).get(ReflectionMappingsInfo.FishingHook_timeUntilLured, int.class);
-    public static final Field FISHING_HOOK_HOOK_TIME_SETTER = ReflectionHelper.getFields(FishingHook.class).get(ReflectionMappingsInfo.FishingHook_timeUntilHooked, int.class);
+    public static final Field FISHING_HOOK_NIBBLE = ReflectionHelper.getFields(FishingHook.class).get(ReflectionMappingsInfo.FishingHook_nibble, int.class);
+    public static final Field FISHING_HOOK_LURE_TIME = ReflectionHelper.getFields(FishingHook.class).get(ReflectionMappingsInfo.FishingHook_timeUntilLured, int.class);
+    public static final Field FISHING_HOOK_HOOK_TIME = ReflectionHelper.getFields(FishingHook.class).get(ReflectionMappingsInfo.FishingHook_timeUntilHooked, int.class);
 
     @Override
     public FishHook getHookFrom(Player player) {
-        FishingHook hook = ((CraftPlayer) player).getHandle().fishing;
-        if (hook == null) {
+        FishingHook nmsHook = ((CraftPlayer) player).getHandle().fishing;
+        if (nmsHook == null) {
             return null;
         }
-        return (FishHook) hook.getBukkitEntity();
+        return (FishHook) nmsHook.getBukkitEntity();
     }
 
     @Override
     public void setNibble(FishHook hook, int ticks) {
-        FishingHook nmsEntity = ((CraftFishHook) hook).getHandle();
+        FishingHook nmsHook = ((CraftFishHook) hook).getHandle();
         try {
-            FISHING_HOOK_NIBBLE_SETTER.setInt(nmsEntity, ticks);
+            FISHING_HOOK_NIBBLE.setInt(nmsHook, ticks);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -125,9 +125,9 @@ public class FishingHelperImpl implements FishingHelper {
 
     @Override
     public void setHookTime(FishHook hook, int ticks) {
-        FishingHook nmsEntity = ((CraftFishHook) hook).getHandle();
+        FishingHook nmsHook = ((CraftFishHook) hook).getHandle();
         try {
-            FISHING_HOOK_HOOK_TIME_SETTER.setInt(nmsEntity, ticks);
+            FISHING_HOOK_HOOK_TIME.setInt(nmsHook, ticks);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -136,9 +136,9 @@ public class FishingHelperImpl implements FishingHelper {
 
     @Override
     public int getLureTime(FishHook hook) {
-        FishingHook nmsEntity = ((CraftFishHook) hook).getHandle();
+        FishingHook nmsHook = ((CraftFishHook) hook).getHandle();
         try {
-            return FISHING_HOOK_LURE_TIME_SETTER.getInt(nmsEntity);
+            return FISHING_HOOK_LURE_TIME.getInt(nmsHook);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);
@@ -148,9 +148,9 @@ public class FishingHelperImpl implements FishingHelper {
 
     @Override
     public void setLureTime(FishHook hook, int ticks) {
-        FishingHook nmsEntity = ((CraftFishHook) hook).getHandle();
+        FishingHook nmsHook = ((CraftFishHook) hook).getHandle();
         try {
-            FISHING_HOOK_LURE_TIME_SETTER.setInt(nmsEntity, ticks);
+            FISHING_HOOK_LURE_TIME.setInt(nmsHook, ticks);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/FishingHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/FishingHelperImpl.java
@@ -14,7 +14,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.storage.loot.BuiltInLootTables;
-import net.minecraft.world.level.storage.loot.LootDataManager;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParam;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -68,15 +67,14 @@ public class FishingHelperImpl implements FishingHelper {
         return result != null ? CraftItemStack.asBukkitCopy(result) : null;
     }
 
-    public ItemStack getRandomReward(FishingHook hook, ResourceLocation key) {
-        ServerLevel worldServer = (ServerLevel) hook.level();
+    public ItemStack getRandomReward(FishingHook nmsHook, ResourceLocation key) {
+        ServerLevel nmsWorld = (ServerLevel) nmsHook.level();
         Map<LootContextParam<?>, Object> params = Maps.newIdentityHashMap();
-        params.put(LootContextParams.ORIGIN, new Vec3(hook.getX(), hook.getY(), hook.getZ()));
+        params.put(LootContextParams.ORIGIN, new Vec3(nmsHook.getX(), nmsHook.getY(), nmsHook.getZ()));
         params.put(LootContextParams.TOOL, new ItemStack(Items.FISHING_ROD));
-        LootParams playerFishEvent2 = new LootParams(worldServer, params, Maps.newHashMap(), 0);
-        LootDataManager registry = worldServer.getServer().getLootData();
-        List<ItemStack> itemStacks = registry.getLootTable(key).getRandomItems(playerFishEvent2);
-        return itemStacks.get(worldServer.random.nextInt(itemStacks.size()));
+        LootParams nmsLootParams = new LootParams(nmsWorld, params, Maps.newHashMap(), 0);
+        List<ItemStack> nmsItems = nmsWorld.getServer().getLootData().getLootTable(key).getRandomItems(nmsLootParams);
+        return nmsItems.get(nmsWorld.random.nextInt(nmsItems.size()));
     }
 
     @Override


### PR DESCRIPTION
## Changes

- Removed the default impl from some methods that were implemented on all versions.

## 1.20 implementation changes
Most changes were only made to the 1.20 impl for easier testing, and as that's what eventually gets used.

- `getResult` was updated to modern switch statements, and had the final `if` changed into a tern.
- `getRandomReward` had some renames, and removed the redundant `registry` variable (was only used once, so just moved it's method call into that).
- Made reflection constants `final` and removed the `_SETTER` suffix (some are used for both getting and setting, and `Field`s aren't specifically a setter in general).
- `getHookFrom`, `setNibble`, `setHookTime`, and `get/setLureTime` - renamed `FishingHook nmsEntity` to `nmsHook`.