### PR TITLE
Update instrument meta

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
@@ -16,14 +16,15 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     // @input ElementTag
     // @description
     // Sets the instrument of a goat horn.
-    // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
+    // Here is a list of valid instruments: admire_goat_horn, call_goat_horn, dream_goat_horn, feel_goat_horn, ponder_goat_horn, seek_goat_horn, sing_goat_horn, yearn_goat_horn.
+    // Instruments added by datapacks, plugins, etc. are also valid as a namespaced key.
     // @example
-    // # This can narrate: "This horn has the ponder instrument!"
+    // # This can narrate: "This horn has the ponder_goat_horn instrument!"
     // - narrate "This horn has the <player.item_in_hand.instrument> instrument!"
     // @example
-    // # Forces the player's held item to play seek instead of whatever it played before.
+    // # Forces the player's held item to play seek_goat_horn instead of whatever it played before.
     // # Would break if the player isn't holding a goat horn.
-    // - inventory adjust slot:hand instrument:seek
+    // - inventory adjust slot:hand instrument:seek_goat_horn
     // -->
 
     public static boolean describes(ItemTag item) {
@@ -34,16 +35,14 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     public ElementTag getPropertyValue() {
         MusicInstrument instrument = getMusicInstrument();
         if (instrument != null) {
-            String key = Utilities.namespacedKeyToString(instrument.getKey()).replace("_goat_horn", "");
-            return new ElementTag(key);
+            return new ElementTag(Utilities.namespacedKeyToString(instrument.getKey()));
         }
         return null;
     }
 
     @Override
     public void setPropertyValue(ElementTag param, Mechanism mechanism) {
-        String key = param.asString().endsWith("_goat_horn") ? param.asString() : param.asString().concat("_goat_horn");
-        MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(key));
+        MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString()));
         if (instrument == null) {
             mechanism.echoError("Invalid horn instrument: '" + param.asString() + "'!");
             return;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
@@ -17,6 +17,13 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     // @description
     // Sets the instrument of a goat horn.
     // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
+    // @example
+    // # This can narrate: "This horn has the ponder instrument!"
+    // - narrate "This horn has the <player.item_in_hand.instrument> instrument!"
+    // @example
+    // # Forces the player's held item to play seek instead of whatever it played before.
+    // # Would break if the player isn't holding a goat horn.
+    // - inventory adjust slot:hand instrument:seek
     // -->
 
     public static boolean describes(ItemTag item) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
@@ -17,13 +17,6 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     // @description
     // Sets the instrument of a goat horn.
     // For a list of possible instruments, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/MusicInstrument.html>.
-    // @example
-    // # This can narrate: "This horn has the ponder_goat_horn instrument!"
-    // - narrate "This horn has the <player.item_in_hand.instrument> instrument!"
-    // @example
-    // # Forces the player's held item to play seek_goat_horn instead of whatever it played before.
-    // # Would break if the player isn't holding a goat horn.
-    // - inventory adjust slot:hand instrument:seek_goat_horn
     // -->
 
     public static boolean describes(ItemTag item) {
@@ -34,19 +27,21 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     public ElementTag getPropertyValue() {
         MusicInstrument instrument = getMusicInstrument();
         if (instrument != null) {
-            return new ElementTag(Utilities.namespacedKeyToString(instrument.getKey()));
+            String key = Utilities.namespacedKeyToString(instrument.getKey()).replace("_goat_horn", "");
+            return new ElementTag(key);
         }
         return null;
     }
 
     @Override
     public void setPropertyValue(ElementTag param, Mechanism mechanism) {
-        MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString()));
+        String key = param.asString().endsWith("_goat_horn") ? param.asString() : param.asString().concat("_goat_horn");
+        MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(key));
         if (instrument == null) {
-            mechanism.echoError("Invalid horn instrument: '" + param.asString() + "'! Instrument names should be like this: 'seek_goat_horn'.");
+            mechanism.echoError("Invalid horn instrument: '" + param.asString() + "'!");
             return;
         }
-        setMusicInstrument(MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString())));
+        setMusicInstrument(instrument);
     }
 
     @Override


### PR DESCRIPTION

### Updates the meta to add a list of valid inputs/outputs instead of relying on names Spigot came up with. Following [Aya's advice](https://discord.com/channels/315163488085475337/1011496047811506227/1131656474792300584).

Meta inconsistency pointed out by [Icecapade](https://discord.com/channels/315163488085475337/1127318524084359188)

---

~~### Change input and output for goat horn instruments to match meta~~

~~For goat horn instrument, the [meta](https://meta.denizenscript.com/Docs/Tags/itemtag.instrument) for it links to the spigot java docs where the field names follow the pattern of `SEEK`, `PONDER`, `DREAM`, etc. However, the namespaced keys for them follow the pattern of `seek_goat_horn`, `ponder_goat_horn`, `dream_goat_horn`, etc.~~

~~This PR allows the input of either `seek` or `seek_goat_horn` and will now have the tag return `seek` instead of `seek_goat_horn`.~~

~~This is a very minor breaking change as users who check for the tag result will have to go back and change the names slightly. Any inputs will stay the same however. If this is a problem, let me know and we can discuss how to make it right.~~