### PR TITLE
Patch time_lived for xp orbs

### DIFF
--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
@@ -53,6 +53,9 @@ public class ReflectionMappingsInfo {
     // net.minecraft.server.level.ThreadedLevelLightEngine$TaskType
     public static String ThreadedLevelLightEngineTaskType_PRE_UPDATE = "a";
 
+    // net.minecraft.world.entity.ExperienceOrb
+    public static String ExperienceOrb_age = "g";
+
     // net.minecraft.world.entity.item.ItemEntity
     public static String ItemEntity_DATA_ITEM = "c";
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -561,6 +561,8 @@ public class EntityHelperImpl extends EntityHelper {
         ((CraftEntity) entity).getHandle().setBoundingBox(new AABB(box.getMinX(), box.getMinY(), box.getMinZ(), box.getMaxX(), box.getMaxY(), box.getMaxZ()));
     }
 
+    public static final Field EXPERIENCE_ORB_AGE = ReflectionHelper.getFields(net.minecraft.world.entity.ExperienceOrb.class).get(ReflectionMappingsInfo.ExperienceOrb_age, int.class);
+
     @Override
     public void setTicksLived(Entity entity, int ticks) {
         // Bypass Spigot's must-be-at-least-1-tick requirement, as negative tick counts are useful
@@ -570,6 +572,14 @@ public class EntityHelperImpl extends EntityHelper {
         }
         else if (entity instanceof CraftItem craftItem) {
             ((ItemEntity) craftItem.getHandle()).age = ticks;
+        }
+        else if (entity instanceof CraftExperienceOrb craftExperienceOrb) {
+            try {
+                EXPERIENCE_ORB_AGE.setInt(craftExperienceOrb.getHandle(), ticks);
+            }
+            catch (Throwable ex) {
+                Debug.echoError(ex);
+            }
         }
     }
 


### PR DESCRIPTION
xp orbs use another special snowflake var to track their time lived. works exactly like the others. tested on a clean 1.20.1 server