### PR TITLE
`EntityTag.visual_fire` property

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -177,6 +177,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityVillagerExperience.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVillagerLevel.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVisible.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityVisualFire.class, EntityTag.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             PropertyParser.registerProperty(EntityWidth.class, EntityTag.class);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVisualFire.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVisualFire.java
@@ -11,7 +11,7 @@ public class EntityVisualFire extends EntityProperty<ElementTag> {
     // @name visual_fire
     // @input ElementTag(Boolean)
     // @description
-    // Whether an entity has a fake fire effect. For actual fire, see <@link command burn> and <@link tag on_fire>.
+    // Whether an entity has a fake fire effect. For actual fire, see <@link command burn> and <@link tag EntityTag.on_fire>.
     // -->
 
     public static boolean describes(EntityTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVisualFire.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVisualFire.java
@@ -1,0 +1,46 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+
+public class EntityVisualFire extends EntityProperty<ElementTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name visual_fire
+    // @input ElementTag(Boolean)
+    // @description
+    // Whether an entity has a fake fire effect. For actual fire, see <@link command burn> and <@link tag on_fire>.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return true;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(getEntity().isVisualFire());
+    }
+
+    @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return !value.asBoolean();
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (mechanism.requireBoolean()) {
+            getEntity().setVisualFire(value.asBoolean());
+        }
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "visual_fire";
+    }
+
+    public static void register() {
+        autoRegister("visual_fire", EntityVisualFire.class, ElementTag.class, false);
+    }
+}


### PR DESCRIPTION
New property that returns whether an entity has a fake fire effect (for example, blazes have this effect whenever they are aggravated). Requested by zemenus on Discord.