### PR TITLE
Update for nullable spawner types, `editMeta` util

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -1255,13 +1255,14 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @mechanism LocationTag.spawner_type
         // @group world
         // @description
-        // Returns the type of entity spawned by a mob spawner.
+        // Returns the type of entity spawned by a mob spawner, if any.
         // -->
         tagProcessor.registerTag(EntityTag.class, "spawner_type", (attribute, object) -> {
-            if (!(object.getBlockStateForTag(attribute) instanceof CreatureSpawner)) {
+            if (!(object.getBlockStateForTag(attribute) instanceof CreatureSpawner spawner)) {
                 return null;
             }
-            return new EntityTag(DenizenEntityType.getByName(((CreatureSpawner) object.getBlockStateForTag(attribute)).getSpawnedType().name()));
+            EntityType spawnedType = spawner.getSpawnedType();
+            return spawnedType != null ? new EntityTag(spawnedType) : null;
         });
 
         // <--[tag]
@@ -4249,6 +4250,32 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 return biome != null ? new ElementTag(biome.getDownfallTypeAt(object)) : null;
             });
         }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name spawner_type
+        // @input EntityTag
+        // @description
+        // Sets the entity that a mob spawner will spawn.
+        // Provide no input to unset (only on 1.20 and above).
+        // @tags
+        // <LocationTag.spawner_type>
+        // -->
+        tagProcessor.registerMechanism("spawner_type", false, (object, mechanism) -> {
+            if (!(object.getBlockState() instanceof CreatureSpawner spawner)) {
+                mechanism.echoError("Mechanism 'LocationTag.spawner_type' is only valid for spawners.");
+                return;
+            }
+            if (mechanism.value == null && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                NMSHandler.blockHelper.makeBlockStateRaw(spawner); // Workaround for a Spigot bug - https://hub.spigotmc.org/jira/browse/SPIGOT-7446
+                spawner.setSpawnedType(null);
+                spawner.update();
+            }
+            else if (mechanism.requireObject(EntityTag.class)) {
+                NMSHandler.blockHelper.setSpawnerSpawnedType(spawner, mechanism.valueAsType(EntityTag.class));
+                spawner.update();
+            }
+        });
     }
 
     public static final ObjectTagProcessor<LocationTag> tagProcessor = new ObjectTagProcessor<>();
@@ -4329,21 +4356,6 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 return;
             }
             NMSHandler.blockHelper.setSpawnerCustomRules(spawner, skyMin.asInt(), skyMax.asInt(), blockMin.asInt(), blockMax.asInt());
-            spawner.update();
-        }
-
-        // <--[mechanism]
-        // @object LocationTag
-        // @name spawner_type
-        // @input EntityTag
-        // @description
-        // Sets the entity that a mob spawner will spawn.
-        // @tags
-        // <LocationTag.spawner_type>
-        // -->
-        if (mechanism.matches("spawner_type") && mechanism.requireObject(EntityTag.class) && getBlockState() instanceof CreatureSpawner) {
-            CreatureSpawner spawner = ((CreatureSpawner) getBlockState());
-            NMSHandler.blockHelper.setSpawnerSpawnedType(spawner, mechanism.valueAsType(EntityTag.class));
             spawner.update();
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4266,7 +4266,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 mechanism.echoError("Mechanism 'LocationTag.spawner_type' is only valid for spawners.");
                 return;
             }
-            if (mechanism.value == null && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (!mechanism.hasValue() && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
                 NMSHandler.blockHelper.makeBlockStateRaw(spawner); // Workaround for a Spigot bug - https://hub.spigotmc.org/jira/browse/SPIGOT-7446
                 spawner.setSpawnedType(null);
                 spawner.update();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4267,7 +4267,6 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 return;
             }
             if (!mechanism.hasValue() && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
-                NMSHandler.blockHelper.makeBlockStateRaw(spawner); // Workaround for a Spigot bug - https://hub.spigotmc.org/jira/browse/SPIGOT-7446
                 spawner.setSpawnedType(null);
                 spawner.update();
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
@@ -45,7 +45,7 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
         MusicInstrument instrument = value != null ? MusicInstrument.getByKey(Utilities.parseNamespacedKey(value.asString())) : null;
         if (value != null && instrument == null) {
-            mechanism.echoError("Invalid instrument specified: " + value);
+            mechanism.echoError("Invalid instrument: " + value);
             return;
         }
         editMeta(MusicInstrumentMeta.class, meta -> meta.setInstrument(instrument));

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
@@ -16,7 +16,9 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     // @input ElementTag
     // @description
     // A goat horn's instrument, if any.
+    // Goat horns will default to playing "ponder_goat_horn" when the instrument is unset, although this is effectively random and shouldn't be relied on.
     // Valid instruments are: admire_goat_horn, call_goat_horn, dream_goat_horn, feel_goat_horn, ponder_goat_horn, seek_goat_horn, sing_goat_horn, yearn_goat_horn.
+    // For the mechanism: provide no input to unset the instrument.
     // @example
     // # This can narrate: "This horn has the ponder_goat_horn instrument!"
     // - narrate "This horn has the <player.item_in_hand.instrument> instrument!"
@@ -27,7 +29,7 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     // -->
 
     public static boolean describes(ItemTag item) {
-        return item.getBukkitMaterial() == Material.GOAT_HORN;
+        return item.getItemMeta() instanceof MusicInstrumentMeta;
     }
 
     @Override
@@ -41,9 +43,9 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(value.asString()));
-        if (instrument == null) {
-            mechanism.echoError("Invalid horn instrument: '" + value + "'!");
+        MusicInstrument instrument = value != null ? MusicInstrument.getByKey(Utilities.parseNamespacedKey(value.asString())) : null;
+        if (value != null && instrument == null) {
+            mechanism.echoError("Invalid instrument specified: " + value);
             return;
         }
         editMeta(MusicInstrumentMeta.class, meta -> meta.setInstrument(instrument));
@@ -55,6 +57,6 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     }
 
     public static void register() {
-        autoRegister("instrument", ItemInstrument.class, ElementTag.class, false);
+        autoRegisterNullable("instrument", ItemInstrument.class, ElementTag.class, false);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInstrument.java
@@ -15,9 +15,8 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     // @name instrument
     // @input ElementTag
     // @description
-    // Sets the instrument of a goat horn.
-    // Here is a list of valid instruments: admire_goat_horn, call_goat_horn, dream_goat_horn, feel_goat_horn, ponder_goat_horn, seek_goat_horn, sing_goat_horn, yearn_goat_horn.
-    // Instruments added by datapacks, plugins, etc. are also valid as a namespaced key.
+    // A goat horn's instrument, if any.
+    // Valid instruments are: admire_goat_horn, call_goat_horn, dream_goat_horn, feel_goat_horn, ponder_goat_horn, seek_goat_horn, sing_goat_horn, yearn_goat_horn.
     // @example
     // # This can narrate: "This horn has the ponder_goat_horn instrument!"
     // - narrate "This horn has the <player.item_in_hand.instrument> instrument!"
@@ -33,7 +32,7 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
 
     @Override
     public ElementTag getPropertyValue() {
-        MusicInstrument instrument = getMusicInstrument();
+        MusicInstrument instrument = ((MusicInstrumentMeta) getItemMeta()).getInstrument();
         if (instrument != null) {
             return new ElementTag(Utilities.namespacedKeyToString(instrument.getKey()));
         }
@@ -41,29 +40,18 @@ public class ItemInstrument extends ItemProperty<ElementTag> {
     }
 
     @Override
-    public void setPropertyValue(ElementTag param, Mechanism mechanism) {
-        MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(param.asString()));
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        MusicInstrument instrument = MusicInstrument.getByKey(Utilities.parseNamespacedKey(value.asString()));
         if (instrument == null) {
-            mechanism.echoError("Invalid horn instrument: '" + param.asString() + "'!");
+            mechanism.echoError("Invalid horn instrument: '" + value + "'!");
             return;
         }
-        setMusicInstrument(instrument);
+        editMeta(MusicInstrumentMeta.class, meta -> meta.setInstrument(instrument));
     }
 
     @Override
     public String getPropertyId() {
         return "instrument";
-    }
-
-    public MusicInstrument getMusicInstrument() {
-        MusicInstrumentMeta itemMeta = (MusicInstrumentMeta) getItemMeta();
-        return itemMeta.getInstrument();
-    }
-
-    public void setMusicInstrument(MusicInstrument instrument) {
-        MusicInstrumentMeta itemMeta = (MusicInstrumentMeta) getItemMeta();
-        itemMeta.setInstrument(instrument);
-        setItemMeta(itemMeta);
     }
 
     public static void register() {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemProperty.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemProperty.java
@@ -8,6 +8,8 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.function.Consumer;
+
 public abstract class ItemProperty<TData extends ObjectTag> extends ObjectProperty<ItemTag, TData> {
 
     public MaterialTag getMaterialTag() {
@@ -32,5 +34,11 @@ public abstract class ItemProperty<TData extends ObjectTag> extends ObjectProper
 
     public void setItemMeta(ItemMeta meta) {
         object.setItemMeta(meta);
+    }
+
+    public <T extends ItemMeta> void editMeta(Class<T> metaType, Consumer<T> editor) {
+        T meta = metaType.cast(getItemMeta());
+        editor.accept(meta);
+        setItemMeta(meta);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemProperty.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemProperty.java
@@ -37,7 +37,7 @@ public abstract class ItemProperty<TData extends ObjectTag> extends ObjectProper
     }
 
     public <T extends ItemMeta> void editMeta(Class<T> metaType, Consumer<T> editor) {
-        T meta = metaType.cast(getItemMeta());
+        T meta = (T) getItemMeta();
         editor.accept(meta);
         setItemMeta(meta);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.objects.properties.item;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizencore.objects.Mechanism;
@@ -16,6 +18,7 @@ public class ItemSpawnerType extends ItemProperty<EntityTag> {
     // @description
     // The entity type a spawner item will spawn, if any.
     // For the mechanism: provide no input to unset the type.
+    // Note that the type can only be unset on 1.20 and above.
     // -->
 
     public static boolean describes(ItemTag item) {
@@ -30,6 +33,10 @@ public class ItemSpawnerType extends ItemProperty<EntityTag> {
 
     @Override
     public void setPropertyValue(EntityTag entity, Mechanism mechanism) {
+        if (entity == null && NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
+            mechanism.echoError("must have input of type 'EntityTag', but none was given.");
+            return;
+        }
         editMeta(BlockStateMeta.class, meta -> {
             CreatureSpawner spawner = (CreatureSpawner) meta.getBlockState();
             spawner.setSpawnedType(entity != null ? entity.getBukkitEntityType() : null);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
@@ -19,7 +19,7 @@ public class ItemSpawnerType extends ItemProperty<EntityTag> {
     // -->
 
     public static boolean describes(ItemTag item) {
-        return item.getItemMeta() instanceof BlockStateMeta blockStateMeta && blockStateMeta.getBlockState() instanceof CreatureSpawner;
+        return item.getItemMeta() instanceof BlockStateMeta meta && meta.getBlockState() instanceof CreatureSpawner;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
@@ -24,8 +24,8 @@ public class ItemSpawnerType extends ItemProperty<EntityTag> {
 
     @Override
     public EntityTag getPropertyValue() {
-        EntityType spawnerType = ((CreatureSpawner) ((BlockStateMeta) getItemMeta()).getBlockState()).getSpawnedType();
-        return spawnerType != null ? new EntityTag(spawnerType) : null;
+        EntityType spawnedType = ((CreatureSpawner) ((BlockStateMeta) getItemMeta()).getBlockState()).getSpawnedType();
+        return spawnedType != null ? new EntityTag(spawnedType) : null;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSpawnerType.java
@@ -3,73 +3,38 @@ package com.denizenscript.denizen.objects.properties.item;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
 import org.bukkit.block.CreatureSpawner;
+import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.meta.BlockStateMeta;
 
-public class ItemSpawnerType implements Property {
+public class ItemSpawnerType extends ItemProperty<EntityTag> {
 
-    public static boolean describes(ObjectTag item) {
-        return item instanceof ItemTag
-                && ((ItemTag) item).getItemMeta() instanceof BlockStateMeta
-                && ((BlockStateMeta) ((ItemTag) item).getItemMeta()).getBlockState() instanceof CreatureSpawner;
-    }
+    // <--[property]
+    // @object ItemTag
+    // @name spawner_type
+    // @input EntityTag
+    // @description
+    // The entity type a spawner item will spawn, if any.
+    // For the mechanism: provide no input to unset the type.
+    // -->
 
-    public static ItemSpawnerType getFrom(ObjectTag _item) {
-        if (!describes(_item)) {
-            return null;
-        }
-        else {
-            return new ItemSpawnerType((ItemTag) _item);
-        }
-    }
-
-    public static final String[] handledTags = new String[] {
-            "spawner_type"
-    };
-
-    public static final String[] handledMechs = new String[] {
-            "spawner_type"
-    };
-
-    public ItemSpawnerType(ItemTag _item) {
-        item = _item;
-    }
-
-    ItemTag item;
-
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
-
-        // <--[tag]
-        // @attribute <ItemTag.spawner_type>
-        // @returns EntityTag
-        // @mechanism ItemTag.spawner_type
-        // @group properties
-        // @description
-        // Returns the spawn type for a spawner block item.
-        // -->
-        if (attribute.startsWith("spawner_type")) {
-            BlockStateMeta meta = (BlockStateMeta) item.getItemMeta();
-            CreatureSpawner state = (CreatureSpawner) meta.getBlockState();
-            return new EntityTag(state.getSpawnedType())
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+    public static boolean describes(ItemTag item) {
+        return item.getItemMeta() instanceof BlockStateMeta blockStateMeta && blockStateMeta.getBlockState() instanceof CreatureSpawner;
     }
 
     @Override
-    public String getPropertyString() {
-        BlockStateMeta meta = (BlockStateMeta) item.getItemMeta();
-        CreatureSpawner state = (CreatureSpawner) meta.getBlockState();
-        return state.getSpawnedType().name();
+    public EntityTag getPropertyValue() {
+        EntityType spawnerType = ((CreatureSpawner) ((BlockStateMeta) getItemMeta()).getBlockState()).getSpawnedType();
+        return spawnerType != null ? new EntityTag(spawnerType) : null;
+    }
+
+    @Override
+    public void setPropertyValue(EntityTag entity, Mechanism mechanism) {
+        editMeta(BlockStateMeta.class, meta -> {
+            CreatureSpawner spawner = (CreatureSpawner) meta.getBlockState();
+            spawner.setSpawnedType(entity != null ? entity.getBukkitEntityType() : null);
+            meta.setBlockState(spawner);
+        });
     }
 
     @Override
@@ -77,24 +42,7 @@ public class ItemSpawnerType implements Property {
         return "spawner_type";
     }
 
-    @Override
-    public void adjust(Mechanism mechanism) {
-
-        // <--[mechanism]
-        // @object ItemTag
-        // @name spawner_type
-        // @input EntityTag
-        // @description
-        // Sets the spawn type of a spawner block item.
-        // @tags
-        // <ItemTag.spawner_type>
-        // -->
-        if (mechanism.matches("spawner_type") && mechanism.requireObject(EntityTag.class)) {
-            BlockStateMeta meta = (BlockStateMeta) item.getItemMeta();
-            CreatureSpawner state = (CreatureSpawner) meta.getBlockState();
-            state.setSpawnedType(mechanism.valueAsType(EntityTag.class).getBukkitEntityType());
-            meta.setBlockState(state);
-            item.setItemMeta(meta);
-        }
+    public static void register() {
+        autoRegisterNullable("spawner_type", ItemSpawnerType.class, EntityTag.class, false);
     }
 }


### PR DESCRIPTION
## Changes

- Updated `ItemSpawnerType` to modern property format, and changed it to account for the spawner type being nullable internally on 1.20+ (previously just threw an NPE), including support for setting it to null in the mechanism.
- Updated `LocationTag.spawner_type` for the type being nullable, including updating the mech to modern registration.
~~This also includes a workaround (`makeBlockStateRaw`) for setting it to null in the mechanism due to a Spigot bug - I have already opened an issue @ Spigot for this~~ this has since been fixed.
- _**(Unrelated cleanup)**_ Cleaned up `ItemInstrument`:
  - Removed the `allows custom instruments` from the meta, as Spigot uses hard-coded ones :/
  - The meta now makes sense for both the tag & mech.
  - Documented it being nullable, and how Minecraft defaults to `ponder` when unset (which is effectively random because it's based on the internal order of stuff - it grabs the first entry from the horn instruments tag/the instrument registry).
  - Added support for setting it to null.
  - Removed `getMusicInstrument` in favor of just getting it directly.
  - Removed `setMusicInstrument` in favor of the new `ItemProperty#editMeta`.
  - Changed `setPropertyValue`'s param name to match the usual one (`param` -> `value`).
  - Removed a redundant `ElementTag#asString` call in `setPropertyValue`'s error message, and slightly cleaned it up.
  - Changed `describes` into a `instanceof` check instead of a material check.

## Additions

- `ItemProperty#editMeta(Class metaType, Consumer editor)` - a util method to avoid boilerplate `get/setItemMeta` calls & casts.