### PR TITLE
Fix metadata command not updating self

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -668,7 +668,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
     }
 
     public <T extends Entity> T as(Class<T> entityClass) {
-        return entityClass.cast(getBukkitEntity());
+        return (T) getBukkitEntity();
     }
 
     public Projectile getProjectile() {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -667,6 +667,10 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         return entity instanceof Player && !isNPC();
     }
 
+    public <T extends Entity> T as(Class<T> entityClass) {
+        return entityClass.cast(getBukkitEntity());
+    }
+
     public Projectile getProjectile() {
         return (Projectile) entity;
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/EntityMetadataCommandHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/EntityMetadataCommandHelper.java
@@ -104,8 +104,9 @@ public record EntityMetadataCommandHelper(Predicate<Entity> getter, BiConsumer<E
                     }
                     else {
                         for (PlayerTag player : forPlayers) {
-                            playerMap.remove(player.getUUID());
-                            playersToUpdate.add(player.getUUID());
+                            if (playerMap.remove(player.getUUID()) != null) {
+                                playersToUpdate.add(player.getUUID());
+                            }
                         }
                         if (playerMap.isEmpty()) {
                             packetOverrides.remove(target.getUUID());
@@ -118,6 +119,9 @@ public record EntityMetadataCommandHelper(Predicate<Entity> getter, BiConsumer<E
                         if (playersToUpdate.contains(player.getUniqueId())) {
                             NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(player, target.getBukkitEntity());
                         }
+                    }
+                    if (playersToUpdate.contains(target.getUUID()) && target.isPlayer()) {
+                        NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(target.as(Player.class), target.getBukkitEntity());
                     }
                 }
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/EntityMetadataCommandHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/EntityMetadataCommandHelper.java
@@ -120,7 +120,7 @@ public record EntityMetadataCommandHelper(Predicate<Entity> getter, BiConsumer<E
                             NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(player, target.getBukkitEntity());
                         }
                     }
-                    if (playersToUpdate.contains(target.getUUID()) && target.isPlayer()) {
+                    if (playersToUpdate.contains(target.getUUID())) {
                         NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(target.as(Player.class), target.getBukkitEntity());
                     }
                 }


### PR DESCRIPTION
`EntityMetadataCommandHelper` wasn't sending update packets to players when resetting their own fake glow, as they aren't part of the internal `seenBy` set used by `EntityHelper#getPlayersThatSee`.
Reported on [Discord](https://discord.com/channels/315163488085475337/1126754444202213466).

## Changes

- Add a `toUpdate.contains(target) -> send update` check to `EntityMetadataCommandHelper`'s resetting code, see explanation above.
- Fixed a minor edge-case where inputting players who don't have a fake state set into `for:` would still send them an update packet.

## Additions

- `EntityTag#as(Class entityClass)` util to avoid boilerplate methods/messier casting - was going to add a `getPlayerUnchecked` style method to avoid `getPlayer`'s unnecessary (in that case) checks, but thought we might as well add a more generic method at that point - let me know what do you think about the naming(/the method itself), could maybe be `asUnchecked` or something.