### PR TITLE
`BiomeTag.(water_)fog_color` tag + mech

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
@@ -85,6 +85,22 @@ public abstract class BiomeNMS {
 
     public abstract void setFoliageColor(int color);
 
+    public int getFogColor() {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setFogColor(int color) {
+        throw new UnsupportedOperationException();
+    }
+
+    public int getWaterFogColor() {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setWaterFogColor(int color) {
+        throw new UnsupportedOperationException();
+    }
+
     public abstract void setTo(Block block);
 
     public ColorTag getColor(int x, int y) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -341,6 +341,34 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
                 return new ElementTag(object.biome.hasDownfall());
             });
 
+            // <--[tag]
+            // @attribute <BiomeTag.fog_color>
+            // @returns ColorTag
+            // @mechanism BiomeTag.fog_color
+            // @description
+            // Returns the biome's fog color, which is visible when outside water (see also <@link tag BiomeTag.water_fog_color>).
+            // @example
+            // # Sends the player a message in their current biome's fog color.
+            // - narrate "You are currently seeing fog that looks like <&color[<player.location.biome.fog_color>]>this!"
+            // -->
+            tagProcessor.registerTag(ColorTag.class, "fog_color", (attribute, object) -> {
+                return ColorTag.fromRGB(object.biome.getFogColor());
+            });
+
+            // <--[tag]
+            // @attribute <BiomeTag.water_fog_color>
+            // @returns ColorTag
+            // @mechanism BiomeTag.water_fog_color
+            // @description
+            // Returns the biome's water fog color, which is visible when underwater (see also <@link tag BiomeTag.fog_color>).
+            // @example
+            // # Sends the player a message in their current biome's water fog color.
+            // - narrate "If you are underwater, everything looks like <&color[<player.location.biome.water_fog_color>]>this!"
+            // -->
+            tagProcessor.registerTag(ColorTag.class, "water_fog_color", (attribute, object) -> {
+                return ColorTag.fromRGB(object.biome.getWaterFogColor());
+            });
+
             // <--[mechanism]
             // @object BiomeTag
             // @name has_downfall
@@ -358,6 +386,40 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
                 if (mechanism.requireBoolean()) {
                     object.biome.setHasDownfall(input.asBoolean());
                 }
+            });
+
+            // <--[mechanism]
+            // @object BiomeTag
+            // @name fog_color
+            // @input ColorTag
+            // @description
+            // Sets the biome's fog color, which is visible when outside water (see also <@link mechanism BiomeTag.water_fog_color>).
+            // @tags
+            // <BiomeTag.fog_color>
+            // @example
+            // # Makes the plains biome's fog color red permanently, using a server start event to keep it applied.
+            // on server start:
+            // - adjust <biome[plains]> fog_color:red
+            // -->
+            tagProcessor.registerMechanism("fog_color", false, ColorTag.class, (object, mechanism, input) -> {
+                object.biome.setFogColor(input.asRGB());
+            });
+
+            // <--[mechanism]
+            // @object BiomeTag
+            // @name water_fog_color
+            // @input ColorTag
+            // @description
+            // Sets the biome's water fog color, which is visible when underwater (see also <@link mechanism BiomeTag.fog_color>).
+            // @tags
+            // <BiomeTag.water_fog_color>
+            // @example
+            // # Makes the plains biome's water fog color fuchsia permanently, using a server start event to keep it applied.
+            // on server start:
+            // - adjust <biome[plains]> water_fog_color:fuchsia
+            // -->
+            tagProcessor.registerMechanism("water_fog_color", false, ColorTag.class, (object, mechanism, input) -> {
+                object.biome.setWaterFogColor(input.asRGB());
             });
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -371,25 +371,6 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
 
             // <--[mechanism]
             // @object BiomeTag
-            // @name has_downfall
-            // @input ElementTag(Boolean)
-            // @description
-            // Sets whether the biome has downfall (rain/snow).
-            // @tags
-            // <BiomeTag.has_downfall>
-            // @example
-            // # Disables downfall for the plains biome permanently, using a server start event to keep it applied.
-            // on server start:
-            // - adjust <biome[plains]> has_downfall:false
-            // -->
-            tagProcessor.registerMechanism("has_downfall", false, ElementTag.class, (object, mechanism, input) -> {
-                if (mechanism.requireBoolean()) {
-                    object.biome.setHasDownfall(input.asBoolean());
-                }
-            });
-
-            // <--[mechanism]
-            // @object BiomeTag
             // @name fog_color
             // @input ColorTag
             // @description
@@ -420,6 +401,25 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
             // -->
             tagProcessor.registerMechanism("water_fog_color", false, ColorTag.class, (object, mechanism, input) -> {
                 object.biome.setWaterFogColor(input.asRGB());
+            });
+
+            // <--[mechanism]
+            // @object BiomeTag
+            // @name has_downfall
+            // @input ElementTag(Boolean)
+            // @description
+            // Sets whether the biome has downfall (rain/snow).
+            // @tags
+            // <BiomeTag.has_downfall>
+            // @example
+            // # Disables downfall for the plains biome permanently, using a server start event to keep it applied.
+            // on server start:
+            // - adjust <biome[plains]> has_downfall:false
+            // -->
+            tagProcessor.registerMechanism("has_downfall", false, ElementTag.class, (object, mechanism, input) -> {
+                if (mechanism.requireBoolean()) {
+                    object.biome.setHasDownfall(input.asBoolean());
+                }
             });
         }
 

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/ReflectionMappingsInfo.java
@@ -61,6 +61,8 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.world.level.biome.BiomeSpecialEffects
     public static String BiomeSpecialEffects_foliageColorOverride = "f";
+    public static String BiomeSpecialEffects_fogColor = "b";
+    public static String BiomeSpecialEffects_waterFogColor = "d";
 
     // net.minecraft.network.Connection
     public static String Connection_receiving = "k";

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
@@ -136,12 +136,27 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     @Override
     public void setFoliageColor(int color) {
-        try {
-            ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_foliageColorOverride, biomeHolder.value().getSpecialEffects(), Optional.of(color));
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-        }
+        ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_foliageColorOverride, biomeHolder.value().getSpecialEffects(), Optional.of(color));
+    }
+
+    @Override
+    public int getFogColor() {
+        return biomeHolder.value().getFogColor();
+    }
+
+    @Override
+    public void setFogColor(int color) {
+        ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_fogColor, biomeHolder.value().getSpecialEffects(), color);
+    }
+
+    @Override
+    public int getWaterFogColor() {
+        return biomeHolder.value().getWaterFogColor();
+    }
+
+    @Override
+    public void setWaterFogColor(int color) {
+        ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_waterFogColor, biomeHolder.value().getSpecialEffects(), color);
     }
 
     private List<EntityType> getSpawnableEntities(MobCategory creatureType) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
@@ -64,6 +64,8 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.world.level.biome.BiomeSpecialEffects
     public static String BiomeSpecialEffects_foliageColorOverride = "f";
+    public static String BiomeSpecialEffects_fogColor = "b";
+    public static String BiomeSpecialEffects_waterFogColor = "d";
 
     // net.minecraft.network.Connection
     public static String Connection_receiving = "k";

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
@@ -136,12 +136,27 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     @Override
     public void setFoliageColor(int color) {
-        try {
-            ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_foliageColorOverride, biomeHolder.value().getSpecialEffects(), Optional.of(color));
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-        }
+        ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_foliageColorOverride, biomeHolder.value().getSpecialEffects(), Optional.of(color));
+    }
+
+    @Override
+    public int getFogColor() {
+        return biomeHolder.value().getFogColor();
+    }
+
+    @Override
+    public void setFogColor(int color) {
+        ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_fogColor, biomeHolder.value().getSpecialEffects(), color);
+    }
+
+    @Override
+    public int getWaterFogColor() {
+        return biomeHolder.value().getWaterFogColor();
+    }
+
+    @Override
+    public void setWaterFogColor(int color) {
+        ReflectionHelper.setFieldValue(BiomeSpecialEffects.class, ReflectionMappingsInfo.BiomeSpecialEffects_waterFogColor, biomeHolder.value().getSpecialEffects(), color);
     }
 
     private List<EntityType> getSpawnableEntities(MobCategory creatureType) {


### PR DESCRIPTION
Requested on [Discord](https://discord.com/channels/315163488085475337/1099366174250242138).
## Additions

- `BiomeNMS#get/setFogColor` - controls a biome's fog color as an RGB int, implemented on 1.19 and 1.20.
- `BiomeNMS#get/setWaterFogColor` - controls a biome's water fog color as an RGB int, implemented on 1.19 and 1.20.
- `BiomeTag.fog_color` tag + mechanism pair - controls a biome's fog color, on 1.19+.
- `BiomeTag.water_fog_color` tag + mechanism pair - controls a biome's water fog color, on 1.19+.

## Changes

- **_(Unrelated minor cleanup)_** removed the redundant `try/catch` around `ReflectionHelper#setFieldValue` in `BiomeNMSImpl(1.19/1.20)#setFoliageColor`.