### PR TITLE
`LocationTag.sherds` tag + mech pair

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4261,7 +4261,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // Returns a decorated pot's sherds as a map of sides to <@link objecttype MaterialTag>s of the sherds.
             // The map will always contain every side, with a brick being the default value for when a side has no sherd.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
-            // Valid sherd materials are either a brick or any pottery sherds.
+            // Valid sherd materials are either a brick or any pottery sherd.
             // @example
             // # Tells the player if they're looking at a pot that has any sherds.
             // - if <player.cursor_on.sherds.values.contains_match[!brick].if_null[false]>:
@@ -4288,7 +4288,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // Sets a decorated pot's sherds, input is a map of sides to <@link objecttype MaterialTag>s of the sherds.
             // You only need to specify the sides you want to set, and the default value (for removing a side's sherd) is a brick.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
-            // Valid materials are either a brick or any pottery sherds.
+            // Valid materials are either a brick or any pottery sherd.
             // @tags
             // <LocationTag.sherds>
             // @example

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4295,7 +4295,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // # Sets a decorated pot's left side to a random sherd.
             // - adjust <[potLocation]> sherds:[left=<server.vanilla_tagged_materials[decorated_pot_sherds].random>]
             // @example
-            // # Clears a decorated pot's sherds.
+            // # Removes a decorated pot's sherds.
             // - adjust <[potLocation]> sherds:[left=brick;right=brick;front=brick;back=brick]
             // -->
             tagProcessor.registerMechanism("sherds", false, MapTag.class, (object, mechanism, input) -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4259,7 +4259,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @mechanism LocationTag.sherds
             // @description
             // Returns a decorated pot's sherds as a map of sides to <@link objecttype MaterialTag>s of the sherds.
-            // The map will always contain every side, with a brick being the default value for when nothing is set.
+            // The map will always contain every side, with a brick being the default value for when a side has no sherds.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
             // Valid sherd materials are either a brick or pottery sherds.
             // @example
@@ -4286,7 +4286,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @input MapTag
             // @description
             // Sets a decorated pot's sherds, input is a map of sides to <@link objecttype MaterialTag>s of the sherds.
-            // You only need to specify the sides you want to set, and the default value (for resetting a side) is a brick.
+            // You only need to specify the sides you want to set, and the default value (for removing a side's sherd) is a brick.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
             // Valid materials are either a brick or pottery sherds.
             // @tags

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4258,7 +4258,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @returns MapTag
             // @mechanism LocationTag.sherds
             // @description
-            // Returns a decorated pot's sherds as a map of a side to a MaterialTag of the sherd.
+            // Returns a decorated pot's sherds as a map of sides to <@link objecttype MaterialTag>s of the sherds.
             // The map will always contain every side, with a brick being the default value for when nothing is set.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
             // Valid sherd materials are either a brick or pottery sherds.
@@ -4285,7 +4285,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @name sherds
             // @input MapTag
             // @description
-            // Sets a decorated pot's sherds, as a map of sides to <@link objecttype MaterialTag>s of the sherds.
+            // Sets a decorated pot's sherds, input is a map of sides to <@link objecttype MaterialTag>s of the sherds.
             // You only need to specify the sides you want to set, and the default value (for resetting a side) is a brick.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
             // Valid materials are either a brick or pottery sherds.

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4291,6 +4291,12 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // Valid materials are either a brick or any pottery sherds.
             // @tags
             // <LocationTag.sherds>
+            // @example
+            // # Sets a decorated pot's left side to a random sherd.
+            // - adjust <[potLocation]> sherds:[left=<server.vanilla_tagged_materials[decorated_pot_sherds].random>]
+            // @example
+            // # Clears a decorated pot's sherds.
+            // - adjust <[potLocation]> sherds:[left=brick;right=brick;front=brick;back=brick]
             // -->
             tagProcessor.registerMechanism("sherds", false, MapTag.class, (object, mechanism, input) -> {
                 if (!(object.getBlockState() instanceof DecoratedPot decoratedPot)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4259,9 +4259,9 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @mechanism LocationTag.sherds
             // @description
             // Returns a decorated pot's sherds as a map of sides to <@link objecttype MaterialTag>s of the sherds.
-            // The map will always contain every side, with a brick being the default value for when a side has no sherds.
+            // The map will always contain every side, with a brick being the default value for when a side has no sherd.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
-            // Valid sherd materials are either a brick or pottery sherds.
+            // Valid sherd materials are either a brick or any pottery sherds.
             // @example
             // # Tells the player if they're looking at a pot that has any sherds.
             // - if <player.cursor_on.sherds.values.contains_match[!brick].if_null[false]>:
@@ -4288,7 +4288,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // Sets a decorated pot's sherds, input is a map of sides to <@link objecttype MaterialTag>s of the sherds.
             // You only need to specify the sides you want to set, and the default value (for removing a side's sherd) is a brick.
             // Valid sides are: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/DecoratedPot.Side.html>.
-            // Valid materials are either a brick or pottery sherds.
+            // Valid materials are either a brick or any pottery sherds.
             // @tags
             // <LocationTag.sherds>
             // -->


### PR DESCRIPTION
## Additions

- `LocationTag.sherds` 1.20+ tag + mech pair - controls a decorated pot's sherds as a map of sides to materials.