### PR TITLE
Add `npcbossbar` command

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -55,6 +55,7 @@ public class BukkitCommandRegistry {
         registerCommand(ActionCommand.class);
         registerCommand(AnchorCommand.class);
         registerCommand(AssignmentCommand.class);
+        registerCommand(NPCBossBarCommand.class);
         registerCommand(BreakCommand.class);
         registerCommand(CreateCommand.class);
         registerCommand(DespawnCommand.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -1,19 +1,21 @@
 package com.denizenscript.denizen.scripts.commands;
 
-import com.denizenscript.denizen.scripts.commands.core.*;
+import com.denizenscript.denizen.scripts.commands.core.CooldownCommand;
+import com.denizenscript.denizen.scripts.commands.core.ResetCommand;
+import com.denizenscript.denizen.scripts.commands.core.ZapCommand;
 import com.denizenscript.denizen.scripts.commands.entity.*;
 import com.denizenscript.denizen.scripts.commands.item.*;
 import com.denizenscript.denizen.scripts.commands.npc.*;
 import com.denizenscript.denizen.scripts.commands.player.*;
 import com.denizenscript.denizen.scripts.commands.server.*;
 import com.denizenscript.denizen.scripts.commands.world.*;
-import com.denizenscript.denizencore.DenizenCore;
-import com.denizenscript.denizencore.utilities.CoreConfiguration;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
+import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.utilities.CoreConfiguration;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 
 public class BukkitCommandRegistry {
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
@@ -1,0 +1,116 @@
+package com.denizenscript.denizen.scripts.commands.npc;
+
+import com.denizenscript.denizen.objects.NPCTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import net.citizensnpcs.trait.versioned.BossBarTrait;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarFlag;
+import org.bukkit.boss.BarStyle;
+
+import java.util.List;
+
+public class NPCBossBarCommand extends AbstractCommand {
+
+    public NPCBossBarCommand() {
+        setName("npcbossbar");
+        setSyntax("npcbossbar (remove) (color:<color>) (options:<option>|...) (range:<#>) (style:<style>) (title:<title>) (progress:<progress>) (view_permission:<permission>) (visible:<true/false>)");
+        setRequiredArguments(1, 8);
+        autoCompile();
+    }
+
+    // <--[command]
+    // @Name npcbossbar
+    // @Syntax npcbossbar (remove) (color:<color>) (options:<option>|...) (range:<#>) (style:<style>) (title:<title>) (progress:<progress>) (view_permission:<permission>) (visible:<true/false>)
+    // @Required 1
+    // @Maximum 8
+    // @Short Controls an NPC's bossbar.
+    // @Group npc
+    //
+    // @Description
+    // Controls or removes the linked NPC's bossbar.
+    //
+    // Progress can be a number between 1 and 100 or 'health' to make it track the NPC's health.
+    // Placeholder API/Citizens placeholders are supported
+    //
+    // Optionally specify a range around the NPC where the bossbar is visible, and/or a permission required to view it.
+    //
+    // Valid colors: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarColor.html>.
+    // Valid styles: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarStyle.html>.
+    // Valid options: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarFlag.html>.
+    //
+    // @Usage
+    // # Makes the linked NPC's bossbar green, and changes its title.
+    // - npcbossbar color:green "title:This bossbar is green!"
+    //
+    // @Usage
+    // # Makes it so the linked NPC's bossbar can only be visible 5 blocks away from it.
+    // - npcbossbar range:5
+    //
+    // @Usage
+    // # Removes a specific NPC's bossbar.
+    // - npcbossbar remove npc:<[theNPC]>
+    // -->
+
+    @Override
+    public void addCustomTabCompletions(TabCompletionsBuilder tab) {
+        tab.addWithPrefix("color:", BarColor.values());
+        tab.addWithPrefix("options:", BarFlag.values());
+        tab.addWithPrefix("style:", BarStyle.values());
+    }
+
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("remove") boolean remove,
+                                   @ArgName("color") @ArgPrefixed @ArgDefaultNull BarColor color,
+                                   @ArgName("options") @ArgPrefixed @ArgDefaultNull @ArgSubType(BarFlag.class) List<BarFlag> options,
+                                   @ArgName("range") @ArgPrefixed @ArgDefaultNull ElementTag range,
+                                   @ArgName("style") @ArgPrefixed @ArgDefaultNull BarStyle style,
+                                   @ArgName("title") @ArgPrefixed @ArgDefaultNull String title,
+                                   @ArgName("progress") @ArgPrefixed @ArgDefaultNull String progress,
+                                   @ArgName("view_permission") @ArgPrefixed @ArgDefaultNull String viewPermission,
+                                   @ArgName("visible") @ArgPrefixed @ArgDefaultNull ElementTag visible) {
+        NPCTag npc = Utilities.getEntryNPC(scriptEntry);
+        if (npc == null) {
+            throw new InvalidArgumentsRuntimeException("Must have a linked NPC.");
+        }
+        if (remove) {
+            npc.getCitizen().removeTrait(BossBarTrait.class);
+            return;
+        }
+        BossBarTrait trait = npc.getCitizen().getOrAddTrait(BossBarTrait.class);
+        if (color != null) {
+            trait.setColor(color);
+        }
+        if (range != null) {
+            if (!range.isInt()) {
+                throw new InvalidArgumentsRuntimeException("Invalid number '" + range + "' specified for 'range'.");
+            }
+            trait.setRange(range.asInt());
+        }
+        if (options != null) {
+            trait.setFlags(options);
+        }
+        if (style != null) {
+            trait.setStyle(style);
+        }
+        if (title != null) {
+            trait.setTitle(title);
+        }
+        if (progress != null) {
+            trait.setTrackVariable(progress);
+        }
+        if (viewPermission != null) {
+            trait.setViewPermission(viewPermission.isEmpty() ? null : viewPermission);
+        }
+        if (visible != null) {
+            if (!visible.isBoolean()) {
+                throw new InvalidArgumentsRuntimeException("Invalid boolean '" + visible + "' specified for 'visible'.");
+            }
+            trait.setVisible(visible.asBoolean());
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
@@ -41,6 +41,7 @@ public class NPCBossBarCommand extends AbstractCommand {
     // Placeholder API/Citizens placeholders are supported
     //
     // Optionally specify a range around the NPC where the bossbar is visible, and/or a permission required to view it.
+    // Input an empty view permission to remove it ('view_permission:').
     //
     // Valid colors: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarColor.html>.
     // Valid styles: <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarStyle.html>.

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
@@ -6,7 +6,10 @@ import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgSubType;
 import net.citizensnpcs.trait.versioned.BossBarTrait;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarFlag;

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
@@ -38,7 +38,7 @@ public class NPCBossBarCommand extends AbstractCommand {
     // Controls or removes the linked NPC's bossbar.
     //
     // Progress can be a number between 1 and 100 or 'health' to make it track the NPC's health.
-    // Placeholder API/Citizens placeholders are supported
+    // Placeholder API/Citizens placeholders are supported.
     //
     // Optionally specify a range around the NPC where the bossbar is visible, and/or a permission required to view it.
     // Input an empty view permission to remove it ('view_permission:').
@@ -65,6 +65,7 @@ public class NPCBossBarCommand extends AbstractCommand {
         tab.addWithPrefix("color:", BarColor.values());
         tab.addWithPrefix("options:", BarFlag.values());
         tab.addWithPrefix("style:", BarStyle.values());
+        tab.add("progress:health");
     }
 
     public static void autoExecute(ScriptEntry scriptEntry,

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/NPCBossBarCommand.java
@@ -31,7 +31,7 @@ public class NPCBossBarCommand extends AbstractCommand {
     // @Syntax npcbossbar (remove) (color:<color>) (options:<option>|...) (range:<#>) (style:<style>) (title:<title>) (progress:<progress>) (view_permission:<permission>) (visible:<true/false>)
     // @Required 1
     // @Maximum 8
-    // @Short Controls an NPC's bossbar.
+    // @Short Controls or removes the linked NPC's bossbar.
     // @Group npc
     //
     // @Description

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/BossBarCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/BossBarCommand.java
@@ -1,14 +1,14 @@
 package com.denizenscript.denizen.scripts.commands.server;
 
 import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import com.denizenscript.denizencore.scripts.commands.generator.*;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarFlag;

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/BossBarCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/BossBarCommand.java
@@ -1,14 +1,14 @@
 package com.denizenscript.denizen.scripts.commands.server;
 
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
-import com.denizenscript.denizencore.scripts.commands.generator.*;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarFlag;


### PR DESCRIPTION
## Additions

- `npcbossbar` - a command to configure an NPC's bossbar trait.

## Notes

- Not sure if `progress` is the best name there? as `health`/placeholders are a valid input as well, and `progress:health` is a little weird.