### PR TITLE
Adds the BlockShearEntityEvent

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -73,6 +73,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(BlockGrowsScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockIgnitesScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockPhysicsScriptEvent.class);
+        ScriptEvent.registerScriptEvent(BlockShearEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockSpreadsScriptEvent.class);
         ScriptEvent.registerScriptEvent(BrewingStandFueledScriptEvent.class);
         ScriptEvent.registerScriptEvent(BrewsScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockShearEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockShearEntityScriptEvent.java
@@ -1,0 +1,77 @@
+package com.denizenscript.denizen.events.block;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockShearEntityEvent;
+
+public class BlockShearEntityScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // <block> shears <entity>
+    //
+    // @Group Block
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a dispenser shears a nearby sheep.
+    //
+    // @Context
+    // <context.location> returns a LocationTag of the dispenser.
+    // <context.tool> returns an ItemTag of the item used to shear the entity.
+    // <context.entity> returns an EntityTag of the sheared entity.
+    //
+    // -->
+
+    public BlockShearEntityScriptEvent() {
+        registerCouldMatcher("<block> shears <entity>");
+    }
+
+    public LocationTag location;
+    public ItemTag tool;
+    public MaterialTag material;
+    public EntityTag entity;
+    public BlockShearEntityEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!path.tryArgObject(0, material)) {
+            return false;
+        }
+        if (!path.tryArgObject(2, entity)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "location" -> location;
+            case "tool" -> tool;
+            case "entity" -> entity;
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void onShear(BlockShearEntityEvent event) {
+        location = new LocationTag(event.getBlock().getLocation());
+        tool = new ItemTag(event.getTool());
+        material = new MaterialTag(event.getBlock());
+        entity = new EntityTag(event.getEntity());
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockShearEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockShearEntityScriptEvent.java
@@ -36,7 +36,6 @@ public class BlockShearEntityScriptEvent extends BukkitScriptEvent implements Li
     }
 
     public LocationTag location;
-    public ItemTag tool;
     public MaterialTag material;
     public EntityTag entity;
     public BlockShearEntityEvent event;
@@ -59,7 +58,7 @@ public class BlockShearEntityScriptEvent extends BukkitScriptEvent implements Li
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "location" -> location;
-            case "tool" -> tool;
+            case "tool" -> new ItemTag(event.getTool());
             case "entity" -> entity;
             default -> super.getContext(name);
         };
@@ -68,7 +67,6 @@ public class BlockShearEntityScriptEvent extends BukkitScriptEvent implements Li
     @EventHandler
     public void onShear(BlockShearEntityEvent event) {
         location = new LocationTag(event.getBlock().getLocation());
-        tool = new ItemTag(event.getTool());
         material = new MaterialTag(event.getBlock());
         entity = new EntityTag(event.getEntity());
         this.event = event;

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockShearEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockShearEntityScriptEvent.java
@@ -25,9 +25,9 @@ public class BlockShearEntityScriptEvent extends BukkitScriptEvent implements Li
     // @Triggers when a dispenser shears a nearby sheep.
     //
     // @Context
-    // <context.location> returns a LocationTag of the dispenser.
-    // <context.tool> returns an ItemTag of the item used to shear the entity.
-    // <context.entity> returns an EntityTag of the sheared entity.
+    // <context.location> returns the LocationTag of the dispenser.
+    // <context.tool> returns the ItemTag of the item used to shear the entity.
+    // <context.entity> returns the EntityTag of the sheared entity.
     //
     // -->
 


### PR DESCRIPTION
# Tag additions

Adds the `<context.location>` tag, which returns the LocationTag of the dispenser.
Adds the `<context.tool>` tag, which returns the ItemTag of the item used to shear the entity.
Adds the `<context.entity>` tag, which returns the EntityTag of the sheared entity.

Requested by [oguzhan5585](https://discord.com/channels/315163488085475337/1143631533991800983).