### PR TITLE
Fix client-side mem leak due to sidebar

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/Sidebar.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/Sidebar.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.nms.abstracts;
 
+import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.entity.Player;
 
@@ -22,15 +23,31 @@ public abstract class Sidebar {
     }
 
     public static final int MAX_LENGTH = 15;
+    public static final String[] firstIds = new String[MAX_LENGTH];
+    public static final String[] secondIds = new String[MAX_LENGTH];
+
+    static {
+        for (int i = 0; i < MAX_LENGTH; i++) {
+            firstIds[i] = Utilities.generateRandomColors(8);
+            secondIds[i] = Utilities.generateRandomColors(8);
+        }
+    }
+
     protected final Player player;
     protected String title;
     protected String[] lines = new String[MAX_LENGTH];
     protected int[] scores = new int[MAX_LENGTH];
+    protected String[] currentIds = null;
     public int setCount = 0;
 
     public Sidebar(Player player) {
         this.player = player;
         setTitle("");
+    }
+
+    public String[] getIds() {
+        currentIds = currentIds == firstIds ? secondIds : firstIds;
+        return currentIds;
     }
 
     public String getTitle() {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/SidebarImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/SidebarImpl.java
@@ -1,10 +1,9 @@
 package com.denizenscript.denizen.nms.v1_20.impl;
 
+import com.denizenscript.denizen.nms.abstracts.Sidebar;
 import com.denizenscript.denizen.nms.v1_20.Handler;
 import com.denizenscript.denizen.nms.v1_20.helpers.PacketHelperImpl;
-import com.denizenscript.denizen.nms.abstracts.Sidebar;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
-import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.api.ChatColor;
 import net.minecraft.network.chat.MutableComponent;

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/SidebarImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/SidebarImpl.java
@@ -65,12 +65,13 @@ public class SidebarImpl extends Sidebar {
         List<PlayerTeam> oldTeams = generatedTeams;
         generatedTeams = new ArrayList<>();
         PacketHelperImpl.send(player, new ClientboundSetObjectivePacket(this.obj1, 0));
+        String[] ids = getIds();
         for (int i = 0; i < this.lines.length; i++) {
             String line = this.lines[i];
             if (line == null) {
                 break;
             }
-            String lineId = Utilities.generateRandomColors(8);
+            String lineId = ids[i];
             PlayerTeam team = new PlayerTeam(dummyScoreboard, lineId);
             team.getPlayers().add(lineId);
             team.setPlayerPrefix(Handler.componentToNMS(FormattedTextHelper.parse(line, ChatColor.WHITE)));


### PR DESCRIPTION
The packet-based sidebar system was using random Ids every single time it sent over a line, which ended up causing issues client-side as it's map storing that kept getting bigger and bigger (see the [Discord thread](https://discord.com/channels/315163488085475337/1125805170291396639) for more info).
This fixes that by having 2 preset arrays of Ids and switching between them every update call - that way the Ids are still different each time, but are constant.

## Additions

- `Sidebar.first/secondIds` - static string arrays containing `MAX_LENGTH` random ids.
- `Sidebar.currentIds` - a sidebar's current ids, used to know whether the first or second ones should be used.
- `Sidebar#getIds` - returns either the first or second ids, switching between them every call.

## Changes

- `SidebarImpl(1.20)#sendUpdates` - changed to use the new `Sidebar#getIds` for line ids instead of generating a random one every time.

## Notes

- This might be a bit of a hack-fix as that entire code feels messy (which is probably just Mojang having a weird system for this), but It fixes the client-side issues (and has been tested with multiple clients at the same time/updating sidebars).
- Currently only implemented for `1.20` - not sure if the issue is even present on older versions, can test & potentially backport further if you want me to, but all the testing in the Discord thread was done on 1.20 as far as I can see.