### PR TITLE
Fix fake sign editors

### DIFF
--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
@@ -61,7 +61,10 @@ import org.bukkit.map.MapPalette;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public class PacketHelperImpl implements PacketHelper {
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
@@ -6,15 +6,11 @@ import com.denizenscript.denizen.nms.v1_20.Handler;
 import com.denizenscript.denizen.nms.v1_20.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_20.impl.SidebarImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkManagerImpl;
-import com.denizenscript.denizen.objects.LocationTag;
-import com.denizenscript.denizen.objects.MaterialTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizen.utilities.blocks.FakeBlock;
 import com.denizenscript.denizen.utilities.maps.MapImage;
+import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
 import com.denizenscript.denizencore.objects.core.ColorTag;
-import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import io.netty.buffer.Unpooled;
@@ -44,7 +40,6 @@ import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Team;
 import org.bukkit.EntityEffect;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
@@ -63,7 +58,10 @@ import org.bukkit.map.MapPalette;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public class PacketHelperImpl implements PacketHelper {
 
@@ -173,10 +171,8 @@ public class PacketHelperImpl implements PacketHelper {
 
     @Override
     public void showSignEditor(Player player, Location location) {
-        LocationTag fakeSign = new LocationTag(player.getLocation());
-        fakeSign.setY(0);
-        FakeBlock.showFakeBlockTo(Collections.singletonList(new PlayerTag(player)), fakeSign, new MaterialTag(Material.OAK_WALL_SIGN), new DurationTag(1), true);
-        BlockPos pos = new BlockPos(fakeSign.getBlockX(), 0, fakeSign.getBlockZ());
+        NetworkInterceptHelper.enable();
+        BlockPos pos = ((CraftPlayer) player).getHandle().blockPosition();
         DenizenNetworkManagerImpl.getNetworkManager(player).packetListener.fakeSignExpected = pos;
         send(player, new ClientboundOpenSignEditorPacket(pos, true));
     }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenPacketListenerImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenPacketListenerImpl.java
@@ -16,6 +16,8 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ServerPlayer;
 import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_20_R1.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_20_R1.util.CraftLocation;
 import org.bukkit.event.block.SignChangeEvent;
 
 import java.nio.charset.StandardCharsets;
@@ -100,13 +102,11 @@ public class DenizenPacketListenerImpl extends AbstractListenerPlayInImpl {
     @Override
     public void handleSignUpdate(ServerboundSignUpdatePacket packet) {
         if (fakeSignExpected != null && packet.getPos().equals(fakeSignExpected)) {
-            fakeSignExpected = null;
             PlayerChangesSignScriptEvent evt = (PlayerChangesSignScriptEvent) PlayerChangesSignScriptEvent.instance.clone();
             evt.material = new MaterialTag(org.bukkit.Material.OAK_WALL_SIGN);
             evt.location = new LocationTag(player.getBukkitEntity().getLocation());
-            LocationTag loc = evt.location.clone();
-            loc.setY(0);
-            evt.event = new SignChangeEvent(loc.getBlock(), player.getBukkitEntity(), packet.getLines());
+            evt.event = new SignChangeEvent(CraftBlock.at(player.level(), fakeSignExpected), player.getBukkitEntity(), packet.getLines());
+            fakeSignExpected = null;
             evt.fire(evt.event);
         }
         super.handleSignUpdate(packet);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenPacketListenerImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenPacketListenerImpl.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.nms.v1_20.impl.network.handlers;
 
 import com.denizenscript.denizen.events.player.PlayerChangesSignScriptEvent;
 import com.denizenscript.denizen.events.player.PlayerSteersEntityScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.v1_20.impl.network.packets.PacketInResourcePackStatusImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.network.packets.PacketInSteerVehicleImpl;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -9,7 +10,6 @@ import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.scripts.commands.entity.FakeEquipCommand;
 import com.denizenscript.denizen.utilities.packets.DenizenPacketHandler;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.nms.NMSHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
@@ -17,7 +17,6 @@ import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ServerPlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_20_R1.block.CraftBlock;
-import org.bukkit.craftbukkit.v1_20_R1.util.CraftLocation;
 import org.bukkit.event.block.SignChangeEvent;
 
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
Fixes `PacketHelperImpl(1.20)#showSignEditor` - was previously broken by tile-entity fake blocks being broken (which is still a present bug), but while trying to make a temporary workaround I found out Mojang has added some new client-side limitations, such as a distance check for 8 blocks.
Luckily they also added automatic fake sign editor handling:
```java
    @Override
    public void onSignEditorOpen(SignEditorOpenS2CPacket packet) {
        NetworkThreadUtils.forceMainThread(packet, this, this.client);
        BlockPos blockPos = packet.getPos();
        BlockEntity blockEntity = this.world.getBlockEntity(blockPos);
        if (blockEntity instanceof SignBlockEntity) {
            SignBlockEntity signBlockEntity = (SignBlockEntity)blockEntity;
            this.client.player.openEditSignScreen(signBlockEntity, packet.isFront());
        } else {
            BlockState blockState = this.world.getBlockState(blockPos);
            SignBlockEntity signBlockEntity2 = new SignBlockEntity(blockPos, blockState);
            signBlockEntity2.setWorld(this.world);
            this.client.player.openEditSignScreen(signBlockEntity2, packet.isFront());
        }
    }
```
Which we can use to simplify this logic a fair bit and remove the need for faking the sign.

## Changes

- Removed faking a sign, as this is now automatically handled client-side.
- ~~Now uses the player's unchanged location, as the client has distance checks now & the sign isn't actually changed client-side anymore so there's no reason to get a far away location.~~
- To find the location to open, it now starts at the player's location and checks the blocks below it (up to the client distance limit) to try and find a block without a sign; if it can't find one, it'll fake the lines on the furthest sign to be empty and open that.
- Added a `NetworkInterceptHelper#enable` call, as it access Denizen packet interception stuff for the sign change event, which would break on servers where it wasn't already enabled.
- Firing the sign change event for fake sign editors now gives the event a block based on the `fakeSignExpected` `BlockPos` (previously was just the player's location with y set to `0`, I assume to get the same location previously used when opening the fake editor?).