### PR TITLE
Cleanup simple packet handlers

### DIFF
--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/ActionBarEventPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/ActionBarEventPacketHandlers.java
@@ -16,10 +16,10 @@ public class ActionBarEventPacketHandlers {
     }
 
     public static ClientboundSetActionBarTextPacket processActionbarPacket(DenizenNetworkManagerImpl networkManager, ClientboundSetActionBarTextPacket actionbarPacket) {
-        if (!PlayerReceivesActionbarScriptEvent.instance.loaded) {
+        PlayerReceivesActionbarScriptEvent event = PlayerReceivesActionbarScriptEvent.instance;
+        if (!event.loaded) {
             return actionbarPacket;
         }
-        PlayerReceivesActionbarScriptEvent event = PlayerReceivesActionbarScriptEvent.instance;
         event.reset();
         Component actionbarText = actionbarPacket.getText();
         event.message = new ElementTag(FormattedTextHelper.stringify(Handler.componentToSpigot(actionbarText)), true);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/ActionBarEventPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/ActionBarEventPacketHandlers.java
@@ -7,8 +7,6 @@ import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
 
 public class ActionBarEventPacketHandlers {
@@ -17,29 +15,24 @@ public class ActionBarEventPacketHandlers {
         DenizenNetworkManagerImpl.registerPacketHandler(ClientboundSetActionBarTextPacket.class, ActionBarEventPacketHandlers::processActionbarPacket);
     }
 
-    public static Packet<ClientGamePacketListener> processActionbarPacket(DenizenNetworkManagerImpl networkManager, Packet<ClientGamePacketListener> packet) {
+    public static ClientboundSetActionBarTextPacket processActionbarPacket(DenizenNetworkManagerImpl networkManager, ClientboundSetActionBarTextPacket actionbarPacket) {
         if (!PlayerReceivesActionbarScriptEvent.instance.loaded) {
-            return packet;
+            return actionbarPacket;
         }
-        if (packet instanceof ClientboundSetActionBarTextPacket) {
-            ClientboundSetActionBarTextPacket actionbarPacket = (ClientboundSetActionBarTextPacket) packet;
-            PlayerReceivesActionbarScriptEvent event = PlayerReceivesActionbarScriptEvent.instance;
-            Component baseComponent = actionbarPacket.getText();
-            event.reset();
-            event.message = new ElementTag(FormattedTextHelper.stringify(Handler.componentToSpigot(baseComponent)));
-            event.rawJson = new ElementTag(Component.Serializer.toJson(baseComponent));
-            event.system = new ElementTag(false);
-            event.player = PlayerTag.mirrorBukkitPlayer(networkManager.player.getBukkitEntity());
-            event = (PlayerReceivesActionbarScriptEvent) event.triggerNow();
-            if (event.cancelled) {
-                return null;
-            }
-            if (event.modified) {
-                Component component = Handler.componentToNMS(event.altMessageDetermination);
-                ClientboundSetActionBarTextPacket newPacket = new ClientboundSetActionBarTextPacket(component);
-                return newPacket;
-            }
+        PlayerReceivesActionbarScriptEvent event = PlayerReceivesActionbarScriptEvent.instance;
+        event.reset();
+        Component actionbarText = actionbarPacket.getText();
+        event.message = new ElementTag(FormattedTextHelper.stringify(Handler.componentToSpigot(actionbarText)), true);
+        event.rawJson = new ElementTag(Component.Serializer.toJson(actionbarText), true);
+        event.system = new ElementTag(false);
+        event.player = PlayerTag.mirrorBukkitPlayer(networkManager.player.getBukkitEntity());
+        event = (PlayerReceivesActionbarScriptEvent) event.triggerNow();
+        if (event.cancelled) {
+            return null;
         }
-        return packet;
+        if (event.modified) {
+            return new ClientboundSetActionBarTextPacket(Handler.componentToNMS(event.altMessageDetermination));
+        }
+        return actionbarPacket;
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/BlockLightPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/BlockLightPacketHandlers.java
@@ -3,26 +3,25 @@ package com.denizenscript.denizen.nms.v1_20.impl.network.handlers.packet;
 import com.denizenscript.denizen.nms.abstracts.BlockLight;
 import com.denizenscript.denizen.nms.v1_20.impl.blocks.BlockLightImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkManagerImpl;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
 import net.minecraft.network.protocol.game.ClientboundLightUpdatePacket;
 
 public class BlockLightPacketHandlers {
 
     public static void registerHandlers() {
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundLightUpdatePacket.class, BlockLightPacketHandlers::processBlockLightForPacket);
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundBlockUpdatePacket.class, BlockLightPacketHandlers::processBlockLightForPacket);
+        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundLightUpdatePacket.class, BlockLightPacketHandlers::processLightUpdatePacket);
+        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundBlockUpdatePacket.class, BlockLightPacketHandlers::processBlockUpdatePacket);
     }
 
-    public static void processBlockLightForPacket(DenizenNetworkManagerImpl networkManager, Packet<?> packet) {
-        if (BlockLight.lightsByChunk.isEmpty()) {
-            return;
+    public static void processLightUpdatePacket(DenizenNetworkManagerImpl networkManager, ClientboundLightUpdatePacket lightUpdatePacket) {
+        if (!BlockLight.lightsByChunk.isEmpty()) {
+            BlockLightImpl.checkIfLightsBrokenByPacket(lightUpdatePacket, networkManager.player.level());
         }
-        if (packet instanceof ClientboundLightUpdatePacket) {
-            BlockLightImpl.checkIfLightsBrokenByPacket((ClientboundLightUpdatePacket) packet, networkManager.player.level());
-        }
-        else if (packet instanceof ClientboundBlockUpdatePacket) {
-            BlockLightImpl.checkIfLightsBrokenByPacket((ClientboundBlockUpdatePacket) packet, networkManager.player.level());
+    }
+
+    public static void processBlockUpdatePacket(DenizenNetworkManagerImpl networkManager, ClientboundBlockUpdatePacket blockUpdatePacket) {
+        if (!BlockLight.lightsByChunk.isEmpty()) {
+            BlockLightImpl.checkIfLightsBrokenByPacket(blockUpdatePacket, networkManager.player.level());
         }
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakePlayerPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakePlayerPacketHandlers.java
@@ -6,7 +6,6 @@ import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkM
 import net.minecraft.network.protocol.game.ClientboundAddPlayerPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
-import net.minecraft.world.entity.Entity;
 import org.bukkit.Bukkit;
 
 import java.util.List;
@@ -19,13 +18,7 @@ public class FakePlayerPacketHandlers {
 
     public static void processAddPlayerPacket(DenizenNetworkManagerImpl networkManager, ClientboundAddPlayerPacket addPlayerPacket) {
         int id = addPlayerPacket.getEntityId();
-        if (id != -1) {
-            processFakePlayerSpawn(networkManager, networkManager.player.level().getEntity(id));
-        }
-    }
-
-    public static void processFakePlayerSpawn(DenizenNetworkManagerImpl networkManager, Entity entity) {
-        if (entity instanceof EntityFakePlayerImpl fakePlayer) {
+        if (id != -1 && networkManager.player.level().getEntity(id) instanceof EntityFakePlayerImpl fakePlayer) {
             networkManager.send(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, fakePlayer));
             Bukkit.getScheduler().runTaskLater(NMSHandler.getJavaPlugin(),
                     () -> networkManager.send(new ClientboundPlayerInfoRemovePacket(List.of(fakePlayer.getUUID()))), 5);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakePlayerPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakePlayerPacketHandlers.java
@@ -3,37 +3,32 @@ package com.denizenscript.denizen.nms.v1_20.impl.network.handlers.packet;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.v1_20.impl.entities.EntityFakePlayerImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkManagerImpl;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundAddPlayerPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.minecraft.world.entity.Entity;
 import org.bukkit.Bukkit;
 
-import java.util.Collections;
+import java.util.List;
 
 public class FakePlayerPacketHandlers {
 
     public static void registerHandlers() {
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundAddPlayerPacket.class, FakePlayerPacketHandlers::processFakePlayerSpawnForPacket);
+        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundAddPlayerPacket.class, FakePlayerPacketHandlers::processAddPlayerPacket);
     }
 
-    public static void processFakePlayerSpawnForPacket(DenizenNetworkManagerImpl networkManager, Packet<?> packet) {
-        if (packet instanceof ClientboundAddPlayerPacket) {
-            int id = ((ClientboundAddPlayerPacket) packet).getEntityId();
-            if (id != -1) {
-                Entity e = networkManager.player.level().getEntity(id);
-                processFakePlayerSpawn(networkManager, e);
-            }
+    public static void processAddPlayerPacket(DenizenNetworkManagerImpl networkManager, ClientboundAddPlayerPacket addPlayerPacket) {
+        int id = addPlayerPacket.getEntityId();
+        if (id != -1) {
+            processFakePlayerSpawn(networkManager, networkManager.player.level().getEntity(id));
         }
     }
 
     public static void processFakePlayerSpawn(DenizenNetworkManagerImpl networkManager, Entity entity) {
-        if (entity instanceof EntityFakePlayerImpl) {
-            final EntityFakePlayerImpl fakePlayer = (EntityFakePlayerImpl) entity;
+        if (entity instanceof EntityFakePlayerImpl fakePlayer) {
             networkManager.send(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, fakePlayer));
             Bukkit.getScheduler().runTaskLater(NMSHandler.getJavaPlugin(),
-                    () -> networkManager.send(new ClientboundPlayerInfoRemovePacket(Collections.singletonList(fakePlayer.getUUID()))), 5);
+                    () -> networkManager.send(new ClientboundPlayerInfoRemovePacket(List.of(fakePlayer.getUUID()))), 5);
         }
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakePlayerPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakePlayerPacketHandlers.java
@@ -17,8 +17,7 @@ public class FakePlayerPacketHandlers {
     }
 
     public static void processAddPlayerPacket(DenizenNetworkManagerImpl networkManager, ClientboundAddPlayerPacket addPlayerPacket) {
-        int id = addPlayerPacket.getEntityId();
-        if (id != -1 && networkManager.player.level().getEntity(id) instanceof EntityFakePlayerImpl fakePlayer) {
+        if (networkManager.player.level().getEntity(addPlayerPacket.getEntityId()) instanceof EntityFakePlayerImpl fakePlayer) {
             networkManager.send(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, fakePlayer));
             Bukkit.getScheduler().runTaskLater(NMSHandler.getJavaPlugin(),
                     () -> networkManager.send(new ClientboundPlayerInfoRemovePacket(List.of(fakePlayer.getUUID()))), 5);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/HideParticlesPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/HideParticlesPacketHandlers.java
@@ -2,43 +2,30 @@ package com.denizenscript.denizen.nms.v1_20.impl.network.handlers.packet;
 
 import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkManagerImpl;
 import com.denizenscript.denizen.utilities.packets.HideParticles;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import net.minecraft.core.particles.ParticleOptions;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket;
 import org.bukkit.Particle;
 import org.bukkit.craftbukkit.v1_20_R1.CraftParticle;
 
-import java.util.HashSet;
+import java.util.Set;
 
 public class HideParticlesPacketHandlers {
 
     public static void registerHandlers() {
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundLevelParticlesPacket.class, HideParticlesPacketHandlers::processParticlesForPacket);
+        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundLevelParticlesPacket.class, HideParticlesPacketHandlers::processParticlesPacket);
     }
 
-    public static Packet<ClientGamePacketListener> processParticlesForPacket(DenizenNetworkManagerImpl networkManager, Packet<ClientGamePacketListener> packet) {
+    public static ClientboundLevelParticlesPacket processParticlesPacket(DenizenNetworkManagerImpl networkManager, ClientboundLevelParticlesPacket particlesPacket) {
         if (HideParticles.hidden.isEmpty()) {
-            return packet;
+            return particlesPacket;
         }
-        try {
-            if (packet instanceof ClientboundLevelParticlesPacket) {
-                HashSet<Particle> hidden = HideParticles.hidden.get(networkManager.player.getUUID());
-                if (hidden == null) {
-                    return packet;
-                }
-                ParticleOptions particle = ((ClientboundLevelParticlesPacket) packet).getParticle();
-                Particle bukkitParticle = CraftParticle.toBukkit(particle);
-                if (hidden.contains(bukkitParticle)) {
-                    return null;
-                }
-                return packet;
-            }
+        Set<Particle> hidden = HideParticles.hidden.get(networkManager.player.getUUID());
+        if (hidden == null) {
+            return particlesPacket;
         }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
+        Particle bukkitParticle = CraftParticle.toBukkit(particlesPacket.getParticle());
+        if (hidden.contains(bukkitParticle)) {
+            return null;
         }
-        return packet;
+        return particlesPacket;
     }
 }


### PR DESCRIPTION
## Actionbar event packet handlers

- Renamed `baseComponent` to `actionbarText`.
- Marked the message and raw json as plain-text.
- Removed redundant variables when returning the new packet in favor of constructing in-line.
- Updated the method to take in & return the proper packet type.
- Moved the variable for the script event to above the first if check & used it in that if check instead of getting the instance twice.

## Block light packet handlers

- Split it up into 2 methods for each packet type.
- Changed to `!BlockLight.lightsByChunk.isEmpty() -> call the method` instead of an (in this case redundant) early return.

## Fake players packet handlers

- Updated the method to take in & return the proper packet type.
- Removed `processFakePlayerSpawn` in favor of having the logic directly in the handler method.
- Replaced `Collections#singletonList` with `List#of`.
- ~~**Note:** is there a reason for the `id != -1` check? some internal Denizen thing?~~ removed it, seems to be legacy handling from when that packet had several other functions.

## Hide particles packet handlers

- Removed the redundant `ParticleOptions particle` variable in favor of using the return value directly.
- Updated the method to take in & return the proper packet type.