### PR TITLE
Add `play_hurt_animation` mech

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2963,6 +2963,30 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 NMSHandler.entityHelper.setPose(object.getBukkitEntity(), input.asEnum(Pose.class));
             }
         });
+
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+
+            // <--[mechanism]
+            // @object EntityTag
+            // @name play_hurt_animation
+            // @input ElementTag(Decimal)
+            // @description
+            // Plays a hurt animation that makes the entity flash red. When the entity is a player, you can change the direction the camera rotates.
+            // Damage direction is relative to the player, where 0 is in front, 90 is to the right, 180 is behind, and 270 is to the left.
+            // For versions 1.19 or below, use <@link command animate>.
+            // @example
+            // # The player's camera will rotate as if the player took damage from the right.
+            // - adjust <player> play_hurt_animation:90
+            // @example
+            // # This will flash the entity red as if it took damage.
+            // - adjust <[entity]> play_hurt_animation:0
+            // -->
+            registerSpawnedOnlyMechanism("play_hurt_animation", false, ElementTag.class, (object, mechanism, value) -> {
+                if (mechanism.requireFloat()) {
+                    object.getLivingEntity().playHurtAnimation(value.asFloat());
+                }
+            });
+        }
     }
 
     public EntityTag describe(TagContext context) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2971,11 +2971,11 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             // @name play_hurt_animation
             // @input ElementTag(Decimal)
             // @description
-            // Plays a hurt animation that makes the entity flash red. When the entity is a player, you can change the direction the camera rotates.
+            // Plays a hurt animation that makes the living entity flash red. When the entity is a player, you can change the direction the camera rotates.
             // Damage direction is relative to the player, where 0 is in front, 90 is to the right, 180 is behind, and 270 is to the left.
             // For versions 1.19 or below, use <@link command animate>.
             // @example
-            // # The player's camera will rotate as if the player took damage from the right.
+            // # The player's camera will rotate as if the player took damage from the right and the player will flash red.
             // - adjust <player> play_hurt_animation:90
             // @example
             // # This will flash the entity red as if it took damage.
@@ -2983,6 +2983,10 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             // -->
             registerSpawnedOnlyMechanism("play_hurt_animation", false, ElementTag.class, (object, mechanism, value) -> {
                 if (mechanism.requireFloat()) {
+                    if (!object.isLivingEntity()) {
+                        mechanism.echoError("The 'play_hurt_animation' mechanism only works for living entities!");
+                        return;
+                    }
                     object.getLivingEntity().playHurtAnimation(value.asFloat());
                 }
             });

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AnimateCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/AnimateCommand.java
@@ -57,6 +57,8 @@ public class AnimateCommand extends AbstractCommand {
     //
     // Note that the above list only applies where logical, EG 'WOLF_' animations only apply to wolves.
     //
+    // In versions 1.20+, to specify the direction of damage for the HURT animation, use <@link mechanism EntityTag.play_hurt_animation>
+    //
     // @Tags
     // None
     //


### PR DESCRIPTION
# `play_hurt_animation` mech

Flashes an entity red and can also rotate the player's camera in a specified direction.

Also add note in the `animate` command's meta about this mechanism being available to specify the damage direction for 1.20+

Tested on versions 1.20.1 and 1.19.4 (to be sure it won't be present and won't cause issues) 

Requested by [pigler](https://discord.com/channels/315163488085475337/1143616662260690947)