### PR TITLE
Add offthread_repeat arg to relative teleport command

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.nms.interfaces;
 
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
+import com.denizenscript.denizen.scripts.commands.entity.TeleportCommand;
 import com.denizenscript.denizen.utilities.maps.MapImage;
 import com.denizenscript.denizencore.objects.core.ColorTag;
 import org.bukkit.Bukkit;
@@ -148,6 +149,10 @@ public interface PacketHelper {
     void sendBrand(Player player, String brand);
 
     default void sendCollectItemEntity(Player player, Entity taker, Entity item, int amount) {
+        throw new UnsupportedOperationException();
+    }
+
+    default void sendRelativePositionPacket(Player player, double x, double y, double z, float yaw, float pitch, List<TeleportCommand.Relative> relativeMovement) {
         throw new UnsupportedOperationException();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
@@ -31,16 +31,16 @@ public class TeleportCommand extends AbstractCommand {
     public TeleportCommand() {
         setName("teleport");
         setSyntax("teleport (<entity>|...) [<location>] (cause:<cause>) (entity_options:<option>|...) (relative) (relative_axes:<axis>|...) (offthread_repeat:<#>) (offthread_yaw) (offthread_pitch)");
-        setRequiredArguments(1, 7);
+        setRequiredArguments(1, 9);
         isProcedural = false;
         autoCompile();
     }
 
     // <--[command]
     // @Name Teleport
-    // @Syntax teleport (<entity>|...) [<location>] (cause:<cause>) (entity_options:<option>|...) (relative) (relative_axes:<axis>|...) (offthread_repeat:<#>)
+    // @Syntax teleport (<entity>|...) [<location>] (cause:<cause>) (entity_options:<option>|...) (relative) (relative_axes:<axis>|...) (offthread_repeat:<#>) (offthread_yaw) (offthread_pitch)
     // @Required 1
-    // @Maximum 7
+    // @Maximum 9
     // @Short Teleports the entity(s) to a new location.
     // @Synonyms tp
     // @Group entity

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
@@ -186,9 +186,10 @@ public class TeleportCommand extends AbstractCommand {
                     pitch = location.getPitch();
                 }
                 List<Relative> finalRelativeAxes = relativeAxes;
+                NMSHandler.packetHelper.sendRelativePositionPacket(player, x, y, z, yaw, pitch, finalRelativeAxes);
                 DenizenCore.runAsync(() -> {
                     try {
-                        for (int i = 0; i < times; i++) {
+                        for (int i = 0; i < times - 1; i++) {
                             Thread.sleep(ms);
                             NMSHandler.packetHelper.sendRelativePositionPacket(player, x, y, z, yaw, pitch, finalRelativeAxes);
                         }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
@@ -7,8 +7,11 @@ import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
+import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
@@ -16,7 +19,9 @@ import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizencore.utilities.Deprecations;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.citizensnpcs.trait.CurrentLocation;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.util.Vector;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,17 +30,17 @@ public class TeleportCommand extends AbstractCommand {
 
     public TeleportCommand() {
         setName("teleport");
-        setSyntax("teleport (<entity>|...) [<location>] (cause:<cause>) (entity_options:<option>|...) (relative) (relative_axes:<axis>|...)");
-        setRequiredArguments(1, 6);
+        setSyntax("teleport (<entity>|...) [<location>] (cause:<cause>) (entity_options:<option>|...) (relative) (relative_axes:<axis>|...) (offthread_repeat:<#>)");
+        setRequiredArguments(1, 7);
         isProcedural = false;
         autoCompile();
     }
 
     // <--[command]
     // @Name Teleport
-    // @Syntax teleport (<entity>|...) [<location>] (cause:<cause>) (entity_options:<option>|...) (relative) (relative_axes:<axis>|...)
+    // @Syntax teleport (<entity>|...) [<location>] (cause:<cause>) (entity_options:<option>|...) (relative) (relative_axes:<axis>|...) (offthread_repeat:<#>)
     // @Required 1
-    // @Maximum 6
+    // @Maximum 7
     // @Short Teleports the entity(s) to a new location.
     // @Synonyms tp
     // @Group entity
@@ -50,6 +55,7 @@ public class TeleportCommand extends AbstractCommand {
     // Optionally specify "relative" to use relative teleportation (Paper only). This is primarily useful only for players, but available for all entities.
     // Relative teleports are smoother for the client when teleporting over short distances.
     // Optionally, you may use "relative_axes:" to specify a set of axes to move relative on (and other axes will be treated as absolute), as any of "X", "Y", "Z", "YAW", "PITCH".
+    // Optionally, you may use "offthread_repeat:" with the relative arg to smooth out the teleport with a specified number of extra async packets sent within a single tick.
     //
     // Optionally, specify additional teleport options using the 'entity_options:' arguments (Paper only).
     // This allows things like retaining an open inventory when teleporting - see the links below for more information.
@@ -104,7 +110,8 @@ public class TeleportCommand extends AbstractCommand {
                                    @ArgPrefixed @ArgName("cause") @ArgDefaultText("plugin") PlayerTeleportEvent.TeleportCause cause,
                                    @ArgName("entity_options") @ArgPrefixed @ArgDefaultNull @ArgSubType(EntityState.class) List<EntityState> entityOptions,
                                    @ArgName("relative_axes") @ArgPrefixed @ArgDefaultNull @ArgSubType(Relative.class) List<Relative> relativeAxes,
-                                   @ArgName("relative") boolean relative) {
+                                   @ArgName("relative") boolean relative,
+                                   @ArgName("offthread_repeat") @ArgDefaultNull @ArgPrefixed ElementTag offthreadRepeats) {
         if (locationRaw == null) { // Compensate for legacy "- teleport <loc>" default fill
             locationRaw = entityList;
             entityList = Utilities.entryDefaultEntity(scriptEntry, true);
@@ -147,6 +154,31 @@ public class TeleportCommand extends AbstractCommand {
                 NMSHandler.entityHelper.snapPositionTo(entity.getBukkitEntity(), location.toVector());
                 NMSHandler.entityHelper.look(entity.getBukkitEntity(), location.getYaw(), location.getPitch());
                 return;
+            }
+            if (offthreadRepeats != null && relativeAxes != null && entity.isPlayer()) {
+                NetworkInterceptHelper.enable();
+                int times = offthreadRepeats.asInt() + 1;
+                int ms = 50 / times;
+                Player player = entity.getPlayer();
+                Vector increment = location.clone().subtract(player.getLocation()).toVector().multiply(1.0 / times);
+                double x = relativeAxes.contains(Relative.X) ? increment.getX() : location.getX();
+                double y = relativeAxes.contains(Relative.Y) ? increment.getY() : location.getY();
+                double z = relativeAxes.contains(Relative.Z) ? increment.getZ() : location.getZ();
+                float yaw = relativeAxes.contains(Relative.YAW) ? 0 : location.getYaw();
+                float pitch = relativeAxes.contains(Relative.PITCH) ? 0 : location.getPitch();
+                List<Relative> finalRelativeAxes = relativeAxes;
+                DenizenCore.runAsync(() -> {
+                    try {
+                        for (int i = 0; i < times; i++) {
+                            Thread.sleep(ms);
+                            NMSHandler.packetHelper.sendRelativePositionPacket(player, x, y, z, yaw, pitch, finalRelativeAxes);
+                        }
+                    }
+                    catch (Throwable ex) {
+                        Debug.echoError(ex);
+                    }
+                });
+                continue;
             }
             if (entityOptions != null || relativeAxes != null) {
                 PaperAPITools.instance.teleport(entity.getBukkitEntity(), location, cause, entityOptions, relativeAxes);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizen.nms.v1_20.Handler;
 import com.denizenscript.denizen.nms.v1_20.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_20.impl.SidebarImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkManagerImpl;
+import com.denizenscript.denizen.scripts.commands.entity.TeleportCommand;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.maps.MapImage;
@@ -61,10 +62,7 @@ import org.bukkit.map.MapPalette;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 public class PacketHelperImpl implements PacketHelper {
 
@@ -376,10 +374,35 @@ public class PacketHelperImpl implements PacketHelper {
         send(player, new ClientboundTakeItemEntityPacket(item.getEntityId(), taker.getEntityId(), amount));
     }
 
+    public RelativeMovement toNmsRelativeMovement(TeleportCommand.Relative relative) {
+        return switch (relative) {
+            case X -> RelativeMovement.X;
+            case Y -> RelativeMovement.Y;
+            case Z -> RelativeMovement.Z;
+            case YAW -> RelativeMovement.Y_ROT;
+            case PITCH -> RelativeMovement.X_ROT;
+        };
+    }
+
+    @Override
+    public void sendRelativePositionPacket(Player player, double x, double y, double z, float yaw, float pitch, List<TeleportCommand.Relative> relativeAxis) {
+        Set<RelativeMovement> relativeMovements;
+        if (relativeAxis == null) {
+            relativeMovements = RelativeMovement.ALL;
+        }
+        else {
+            relativeMovements = EnumSet.noneOf(RelativeMovement.class);
+            for (TeleportCommand.Relative relative : relativeAxis) {
+                relativeMovements.add(toNmsRelativeMovement(relative));
+            }
+        }
+        ClientboundPlayerPositionPacket packet = new ClientboundPlayerPositionPacket(x, y, z, yaw, pitch, relativeMovements, 0);
+        DenizenNetworkManagerImpl.getNetworkManager(player).oldManager.channel.writeAndFlush(packet);
+    }
+
     @Override
     public void sendRelativeLookPacket(Player player, float yaw, float pitch) {
-        ClientboundPlayerPositionPacket packet = new ClientboundPlayerPositionPacket(0, 0, 0, yaw, pitch, RelativeMovement.ALL, 0);
-        DenizenNetworkManagerImpl.getNetworkManager(player).oldManager.channel.writeAndFlush(packet);
+        sendRelativePositionPacket(player, 0, 0, 0, yaw, pitch, null);
     }
 
     public static void send(Player player, Packet<?> packet) {


### PR DESCRIPTION
Tested and results posted in discord
https://discord.com/channels/315163488085475337/1148788161565163541/1148788161565163541

Not pictured in videos is specifying the list of relative axes, it defaults to all. When a flag is not set, the packet expects a full location in the world. When a flag is set, it turns it into a relative delta. 

I didn't impl yaw/pitch - while it might be nice to have them, I had a feeling it would lead to problems where you unintentionally lose the yaw/pitch by doing things like `.center`. These can be offthreaded via the look command if someone needs both

This is 5am so please let me know if I did any weird stuff in this PR