### PR TITLE
Update disguise packet handler

### DIFF
--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PacketHelperImpl.java
@@ -386,7 +386,7 @@ public class PacketHelperImpl implements PacketHelper {
         ((CraftPlayer) player).getHandle().connection.send(packet);
     }
 
-    public <T> SynchedEntityData.DataValue<T> createEntityData(EntityDataAccessor<T> accessor, T value) {
+    public static <T> SynchedEntityData.DataValue<T> createEntityData(EntityDataAccessor<T> accessor, T value) {
         return new SynchedEntityData.DataValue<>(accessor.getId(), accessor.getSerializer(), value);
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
@@ -8,7 +8,6 @@ import com.denizenscript.denizen.scripts.commands.player.DisguiseCommand;
 import com.denizenscript.denizen.utilities.entity.EntityAttachmentHelper;
 import com.denizenscript.denizen.utilities.entity.FakeEntity;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.network.syncher.SynchedEntityData;
@@ -22,17 +21,25 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
 
 public class DisguisePacketHandlers {
 
     public static void registerHandlers() {
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundSetEntityDataPacket.class, DisguisePacketHandlers::processDisguiseForPacket);
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundUpdateAttributesPacket.class, DisguisePacketHandlers::processDisguiseForPacket);
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundAddPlayerPacket.class, DisguisePacketHandlers::processDisguiseForPacket);
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundAddEntityPacket.class, DisguisePacketHandlers::processDisguiseForPacket);
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundTeleportEntityPacket.class, DisguisePacketHandlers::processDisguiseForPacket);
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundMoveEntityPacket.Rot.class, DisguisePacketHandlers::processDisguiseForPacket);
-        DenizenNetworkManagerImpl.registerPacketHandler(ClientboundMoveEntityPacket.PosRot.class, DisguisePacketHandlers::processDisguiseForPacket);
+        registerPacketHandler(ClientboundSetEntityDataPacket.class, ClientboundSetEntityDataPacket::id, DisguisePacketHandlers::processEntityDataPacket);
+        registerPacketHandler(ClientboundUpdateAttributesPacket.class, ClientboundUpdateAttributesPacket::getEntityId, DisguisePacketHandlers::processAttributesPacket);
+        registerPacketHandler(ClientboundAddPlayerPacket.class, ClientboundAddPlayerPacket::getEntityId, DisguisePacketHandlers::sendDisguiseForPacket);
+        registerPacketHandler(ClientboundAddEntityPacket.class, ClientboundAddEntityPacket::getId, DisguisePacketHandlers::sendDisguiseForPacket);
+        registerPacketHandler(ClientboundTeleportEntityPacket.class, ClientboundTeleportEntityPacket::getId, DisguisePacketHandlers::processTeleportPacket);
+        registerPacketHandler(ClientboundMoveEntityPacket.Rot.class, (networkManager, moveEntityPacket) -> {
+            Entity entity = moveEntityPacket.getEntity(networkManager.player.level());
+            return entity != null ? entity.getId() : -1;
+        }, DisguisePacketHandlers::processMoveEntityRotPacket);
+        registerPacketHandler(ClientboundMoveEntityPacket.PosRot.class, (networkManager, moveEntityPacket) -> {
+            Entity entity = moveEntityPacket.getEntity(networkManager.player.level());
+            return entity != null ? entity.getId() : -1;
+        }, DisguisePacketHandlers::processMoveEntityPosRotPacket);
     }
 
     public static Field ENTITY_ID_PACKTELENT = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_id, int.class);
@@ -44,37 +51,16 @@ public class DisguisePacketHandlers {
 
     private static boolean antiDuplicate = false;
 
-    public static Packet<ClientGamePacketListener> processDisguiseForPacket(DenizenNetworkManagerImpl networkManager, Packet<ClientGamePacketListener> packet) {
-        if (DisguiseCommand.disguises.isEmpty() || antiDuplicate) {
-            return packet;
-        }
-        try {
-            int entityID = -1;
-            if (packet instanceof ClientboundSetEntityDataPacket entityDataPacket) {
-                entityID = entityDataPacket.id();
-            }
-            if (packet instanceof ClientboundUpdateAttributesPacket updateAttributesPacket) {
-                entityID = updateAttributesPacket.getEntityId();
-            }
-            if (packet instanceof ClientboundAddPlayerPacket addPlayerPacket) {
-                entityID = addPlayerPacket.getEntityId();
-            }
-            else if (packet instanceof ClientboundAddEntityPacket addEntityPacket) {
-                entityID = addEntityPacket.getId();
-            }
-            else if (packet instanceof ClientboundTeleportEntityPacket teleportEntityPacket) {
-                entityID = teleportEntityPacket.getId();
-            }
-            else if (packet instanceof ClientboundMoveEntityPacket moveEntityPacket) {
-                Entity e = moveEntityPacket.getEntity(networkManager.player.level());
-                if (e != null) {
-                    entityID = e.getId();
-                }
-            }
-            if (entityID == -1) {
+    public static <T extends Packet<ClientGamePacketListener>> void registerPacketHandler(Class<T> packetType, ToIntFunction<T> idGetter, DisguisePacketHandler<T> handler) {
+        registerPacketHandler(packetType, (networkManager, packet) -> idGetter.applyAsInt(packet), handler);
+    }
+
+    public static <T extends Packet<ClientGamePacketListener>> void registerPacketHandler(Class<T> packetType, ToIntBiFunction<DenizenNetworkManagerImpl, T> idGetter, DisguisePacketHandler<T> handler) {
+        DenizenNetworkManagerImpl.registerPacketHandler(packetType, (networkManager, packet) -> {
+            if (DisguiseCommand.disguises.isEmpty() || antiDuplicate) {
                 return packet;
             }
-            Entity entity = networkManager.player.level().getEntity(entityID);
+            Entity entity = networkManager.player.level().getEntity(idGetter.applyAsInt(networkManager, packet));
             if (entity == null) {
                 return packet;
             }
@@ -93,81 +79,102 @@ public class DisguisePacketHandlers {
                 return packet;
             }
             if (NMSHandler.debugPackets) {
-                DenizenNetworkManagerImpl.doPacketOutput("DISGUISED packet " + packet.getClass().getName() + " for entity " + entityID + " to player " + networkManager.player.getScoreboardName());
+                DenizenNetworkManagerImpl.doPacketOutput("DISGUISED packet " + packet.getClass().getName() + " for entity " + entity.getId() + " to player " + networkManager.player.getScoreboardName());
             }
-            if (packet instanceof ClientboundSetEntityDataPacket metadataPacket) {
-                if (entityID == networkManager.player.getId()) {
-                    if (!disguise.shouldFake) {
-                        return packet;
-                    }
-                    List<SynchedEntityData.DataValue<?>> data = metadataPacket.packedItems();
-                    for (SynchedEntityData.DataValue<?> dataValue : data) {
-                        if (dataValue.id() == 0) { // Entity flags
-                            data = new ArrayList<>(data);
-                            data.remove(dataValue);
-                            byte flags = (byte) dataValue.value();
-                            flags |= 0x20; // Invisible flag
-                            data.add(new SynchedEntityData.DataValue(dataValue.id(), dataValue.serializer(), flags));
-                            ClientboundSetEntityDataPacket altPacket = new ClientboundSetEntityDataPacket(metadataPacket.id(), data);
-                            ClientboundSetEntityDataPacket updatedPacket = EntityMetadataPacketHandlers.getModifiedMetadataFor(networkManager, altPacket);
-                            return updatedPacket == null ? altPacket : updatedPacket;
-                        }
-                    }
-                }
-                else {
-                    List<SynchedEntityData.DataValue<?>> data = ((CraftEntity) disguise.toOthers.entity.entity).getHandle().getEntityData().getNonDefaultValues();
-                    return data != null ? new ClientboundSetEntityDataPacket(entityID, data) : null;
-                }
-                return packet;
+            try {
+                return handler.handle(networkManager, packet, disguise);
             }
-            else if (packet instanceof ClientboundUpdateAttributesPacket) {
-                FakeEntity fake = entityID == networkManager.player.getId() ? disguise.fakeToSelf : disguise.toOthers;
-                if (fake == null) {
-                    return packet;
-                }
-                if (fake.entity.entity instanceof LivingEntity) {
-                    return packet;
-                }
-                return null; // Non-living don't have attributes
+            catch (Exception e) {
+                antiDuplicate = false;
+                throw e; // "pass it" to the generic exception handling
             }
-            else if (packet instanceof ClientboundTeleportEntityPacket) {
-                if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
-                    ClientboundTeleportEntityPacket pOld = (ClientboundTeleportEntityPacket) packet;
-                    ClientboundTeleportEntityPacket pNew = new ClientboundTeleportEntityPacket(entity);
-                    ENTITY_ID_PACKTELENT.setInt(pNew, pOld.getId());
-                    POS_X_PACKTELENT.setDouble(pNew, pOld.getX());
-                    POS_Y_PACKTELENT.setDouble(pNew, pOld.getY());
-                    POS_Z_PACKTELENT.setDouble(pNew, pOld.getZ());
-                    YAW_PACKTELENT.setByte(pNew, EntityAttachmentHelper.adaptedCompressedAngle(pOld.getyRot(), 180));
-                    PITCH_PACKTELENT.setByte(pNew, pOld.getxRot());
-                    return pNew;
+        });
+    }
+
+    @FunctionalInterface
+    public interface DisguisePacketHandler<T extends Packet<ClientGamePacketListener>> {
+
+        T handle(DenizenNetworkManagerImpl networkManager, T packet, DisguiseCommand.TrackedDisguise disguise) throws Exception;
+    }
+
+    public static ClientboundSetEntityDataPacket processEntityDataPacket(DenizenNetworkManagerImpl networkManager, ClientboundSetEntityDataPacket entityDataPacket, DisguiseCommand.TrackedDisguise disguise) {
+        if (disguise.entity.getBukkitEntity().getEntityId() == networkManager.player.getId()) {
+            if (!disguise.shouldFake) {
+                return entityDataPacket;
+            }
+            List<SynchedEntityData.DataValue<?>> data = entityDataPacket.packedItems();
+            for (SynchedEntityData.DataValue<?> dataValue : data) {
+                if (dataValue.id() == 0) { // Entity flags
+                    data = new ArrayList<>(data);
+                    data.remove(dataValue);
+                    byte flags = (byte) dataValue.value();
+                    flags |= 0x20; // Invisible flag
+                    data.add(new SynchedEntityData.DataValue(dataValue.id(), dataValue.serializer(), flags));
+                    ClientboundSetEntityDataPacket altPacket = new ClientboundSetEntityDataPacket(entityDataPacket.id(), data);
+                    ClientboundSetEntityDataPacket updatedPacket = EntityMetadataPacketHandlers.getModifiedMetadataFor(networkManager, altPacket);
+                    return updatedPacket == null ? altPacket : updatedPacket;
                 }
             }
-            else if (packet instanceof ClientboundMoveEntityPacket) {
-                if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
-                    ClientboundMoveEntityPacket pOld = (ClientboundMoveEntityPacket) packet;
-                    ClientboundMoveEntityPacket pNew = null;
-                    if (packet instanceof ClientboundMoveEntityPacket.Rot) {
-                        pNew = new ClientboundMoveEntityPacket.Rot(entityID, EntityAttachmentHelper.adaptedCompressedAngle(pOld.getyRot(), 180), pOld.getxRot(), pOld.isOnGround());
-                    }
-                    else if (packet instanceof ClientboundMoveEntityPacket.PosRot) {
-                        pNew = new ClientboundMoveEntityPacket.PosRot(entityID, pOld.getXa(), pOld.getYa(), pOld.getZa(), EntityAttachmentHelper.adaptedCompressedAngle(pOld.getyRot(), 180), pOld.getxRot(), pOld.isOnGround());
-                    }
-                    if (pNew != null) {
-                        return pNew;
-                    }
-                    return packet;
-                }
-            }
-            antiDuplicate = true;
-            disguise.sendTo(List.of(new PlayerTag(networkManager.player.getUUID())));
-            antiDuplicate = false;
-            return null;
         }
-        catch (Throwable ex) {
-            antiDuplicate = false;
-            Debug.echoError(ex);
+        else {
+            List<SynchedEntityData.DataValue<?>> data = ((CraftEntity) disguise.toOthers.entity.entity).getHandle().getEntityData().getNonDefaultValues();
+            return data != null ? new ClientboundSetEntityDataPacket(disguise.entity.getBukkitEntity().getEntityId(), data) : null;
         }
-        return packet;
+        return entityDataPacket;
+    }
+
+    public static ClientboundUpdateAttributesPacket processAttributesPacket(DenizenNetworkManagerImpl networkManager, ClientboundUpdateAttributesPacket attributesPacket, DisguiseCommand.TrackedDisguise disguise) {
+        FakeEntity fake = disguise.entity.getBukkitEntity().getEntityId() == networkManager.player.getId() ? disguise.fakeToSelf : disguise.toOthers;
+        if (fake == null) {
+            return attributesPacket;
+        }
+        if (fake.entity.entity instanceof LivingEntity) {
+            return attributesPacket;
+        }
+        return null; // Non-living don't have attributes
+    }
+
+    public static ClientboundTeleportEntityPacket processTeleportPacket(DenizenNetworkManagerImpl networkManager, ClientboundTeleportEntityPacket teleportEntityPacket, DisguiseCommand.TrackedDisguise disguise) throws IllegalAccessException {
+        if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
+            ClientboundTeleportEntityPacket pNew = new ClientboundTeleportEntityPacket(((CraftEntity) disguise.entity.getBukkitEntity()).getHandle());
+            ENTITY_ID_PACKTELENT.setInt(pNew, teleportEntityPacket.getId());
+            POS_X_PACKTELENT.setDouble(pNew, teleportEntityPacket.getX());
+            POS_Y_PACKTELENT.setDouble(pNew, teleportEntityPacket.getY());
+            POS_Z_PACKTELENT.setDouble(pNew, teleportEntityPacket.getZ());
+            YAW_PACKTELENT.setByte(pNew, EntityAttachmentHelper.adaptedCompressedAngle(teleportEntityPacket.getyRot(), 180));
+            PITCH_PACKTELENT.setByte(pNew, teleportEntityPacket.getxRot());
+            return pNew;
+        }
+        sendDisguise(networkManager, disguise);
+        return null;
+    }
+
+
+    public static ClientboundMoveEntityPacket.Rot processMoveEntityRotPacket(DenizenNetworkManagerImpl networkManager, ClientboundMoveEntityPacket.Rot rotPacket, DisguiseCommand.TrackedDisguise disguise) {
+        if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
+            return new ClientboundMoveEntityPacket.Rot(disguise.entity.getBukkitEntity().getEntityId(), EntityAttachmentHelper.adaptedCompressedAngle(rotPacket.getyRot(), 180), rotPacket.getxRot(), rotPacket.isOnGround());
+        }
+        sendDisguise(networkManager, disguise);
+        return null;
+    }
+
+
+    public static ClientboundMoveEntityPacket.PosRot processMoveEntityPosRotPacket(DenizenNetworkManagerImpl networkManager, ClientboundMoveEntityPacket.PosRot posRotPacket, DisguiseCommand.TrackedDisguise disguise) {
+        if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
+            return new ClientboundMoveEntityPacket.PosRot(disguise.entity.getBukkitEntity().getEntityId(), posRotPacket.getXa(), posRotPacket.getYa(), posRotPacket.getZa(), EntityAttachmentHelper.adaptedCompressedAngle(posRotPacket.getyRot(), 180), posRotPacket.getxRot(), posRotPacket.isOnGround());
+        }
+        sendDisguise(networkManager, disguise);
+        return null;
+    }
+
+    public static <T extends Packet<ClientGamePacketListener>> T sendDisguiseForPacket(DenizenNetworkManagerImpl networkManager, T packet, DisguiseCommand.TrackedDisguise disguise) {
+        sendDisguise(networkManager, disguise);
+        return null;
+    }
+
+    public static void sendDisguise(DenizenNetworkManagerImpl networkManager, DisguiseCommand.TrackedDisguise disguise) {
+        antiDuplicate = true;
+        disguise.sendTo(List.of(new PlayerTag(networkManager.player.getUUID())));
+        antiDuplicate = false;
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
@@ -38,12 +38,12 @@ public class DisguisePacketHandlers {
         registerPacketHandler(ClientboundMoveEntityPacket.PosRot.class, ClientboundMoveEntityPacket::getEntity, DisguisePacketHandlers::processMoveEntityPosRotPacket);
     }
 
-    public static Field ENTITY_ID_PACKTELENT = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_id, int.class);
-    public static Field POS_X_PACKTELENT = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_x, double.class);
-    public static Field POS_Y_PACKTELENT = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_y, double.class);
-    public static Field POS_Z_PACKTELENT = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_z, double.class);
-    public static Field YAW_PACKTELENT = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_yRot, byte.class);
-    public static Field PITCH_PACKTELENT = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_xRot, byte.class);
+    public static final Field TELEPORT_PACKET_ENTITY_ID = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_id, int.class);
+    public static final Field TELEPORT_PACKET_X = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_x, double.class);
+    public static final Field TELEPORT_PACKET_Y = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_y, double.class);
+    public static final Field TELEPORT_PACKET_Z = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_z, double.class);
+    public static final Field TELEPORT_PACKET_YAW = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_yRot, byte.class);
+    public static final Field TELEPORT_PACKET_PITCH = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_xRot, byte.class);
 
     private static boolean antiDuplicate = false;
 
@@ -121,12 +121,12 @@ public class DisguisePacketHandlers {
     public static ClientboundTeleportEntityPacket processTeleportPacket(DenizenNetworkManagerImpl networkManager, ClientboundTeleportEntityPacket teleportEntityPacket, DisguiseCommand.TrackedDisguise disguise) throws IllegalAccessException {
         if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
             ClientboundTeleportEntityPacket pNew = new ClientboundTeleportEntityPacket(((CraftEntity) disguise.entity.getBukkitEntity()).getHandle());
-            ENTITY_ID_PACKTELENT.setInt(pNew, teleportEntityPacket.getId());
-            POS_X_PACKTELENT.setDouble(pNew, teleportEntityPacket.getX());
-            POS_Y_PACKTELENT.setDouble(pNew, teleportEntityPacket.getY());
-            POS_Z_PACKTELENT.setDouble(pNew, teleportEntityPacket.getZ());
-            YAW_PACKTELENT.setByte(pNew, EntityAttachmentHelper.adaptedCompressedAngle(teleportEntityPacket.getyRot(), 180));
-            PITCH_PACKTELENT.setByte(pNew, teleportEntityPacket.getxRot());
+            TELEPORT_PACKET_ENTITY_ID.setInt(pNew, teleportEntityPacket.getId());
+            TELEPORT_PACKET_X.setDouble(pNew, teleportEntityPacket.getX());
+            TELEPORT_PACKET_Y.setDouble(pNew, teleportEntityPacket.getY());
+            TELEPORT_PACKET_Z.setDouble(pNew, teleportEntityPacket.getZ());
+            TELEPORT_PACKET_YAW.setByte(pNew, EntityAttachmentHelper.adaptedCompressedAngle(teleportEntityPacket.getyRot(), 180));
+            TELEPORT_PACKET_PITCH.setByte(pNew, teleportEntityPacket.getxRot());
             return pNew;
         }
         sendDisguise(networkManager, disguise);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
@@ -129,8 +129,7 @@ public class DisguisePacketHandlers {
             TELEPORT_PACKET_PITCH.setByte(pNew, teleportEntityPacket.getxRot());
             return pNew;
         }
-        sendDisguise(networkManager, disguise);
-        return null;
+        return sendDisguiseForPacket(networkManager, teleportEntityPacket, disguise);
     }
 
 
@@ -138,8 +137,7 @@ public class DisguisePacketHandlers {
         if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
             return new ClientboundMoveEntityPacket.Rot(disguise.entity.getBukkitEntity().getEntityId(), EntityAttachmentHelper.adaptedCompressedAngle(rotPacket.getyRot(), 180), rotPacket.getxRot(), rotPacket.isOnGround());
         }
-        sendDisguise(networkManager, disguise);
-        return null;
+        return sendDisguiseForPacket(networkManager, rotPacket, disguise);
     }
 
 
@@ -147,18 +145,13 @@ public class DisguisePacketHandlers {
         if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
             return new ClientboundMoveEntityPacket.PosRot(disguise.entity.getBukkitEntity().getEntityId(), posRotPacket.getXa(), posRotPacket.getYa(), posRotPacket.getZa(), EntityAttachmentHelper.adaptedCompressedAngle(posRotPacket.getyRot(), 180), posRotPacket.getxRot(), posRotPacket.isOnGround());
         }
-        sendDisguise(networkManager, disguise);
-        return null;
+        return sendDisguiseForPacket(networkManager, posRotPacket, disguise);
     }
 
     public static <T extends Packet<ClientGamePacketListener>> T sendDisguiseForPacket(DenizenNetworkManagerImpl networkManager, T packet, DisguiseCommand.TrackedDisguise disguise) {
-        sendDisguise(networkManager, disguise);
-        return null;
-    }
-
-    public static void sendDisguise(DenizenNetworkManagerImpl networkManager, DisguiseCommand.TrackedDisguise disguise) {
         antiDuplicate = true;
         disguise.sendTo(List.of(new PlayerTag(networkManager.player.getUUID())));
         antiDuplicate = false;
+        return null;
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
@@ -19,8 +19,8 @@ import org.bukkit.entity.LivingEntity;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.ToIntFunction;
@@ -59,18 +59,15 @@ public class DisguisePacketHandlers {
             if (entity == null) {
                 return packet;
             }
-            HashMap<UUID, DisguiseCommand.TrackedDisguise> playerMap = DisguiseCommand.disguises.get(entity.getUUID());
+            Map<UUID, DisguiseCommand.TrackedDisguise> playerMap = DisguiseCommand.disguises.get(entity.getUUID());
             if (playerMap == null) {
                 return packet;
             }
             DisguiseCommand.TrackedDisguise disguise = playerMap.get(networkManager.player.getUUID());
             if (disguise == null) {
                 disguise = playerMap.get(null);
-                if (disguise == null) {
-                    return packet;
-                }
             }
-            if (!disguise.isActive) {
+            if (disguise == null || !disguise.isActive) {
                 return packet;
             }
             if (NMSHandler.debugPackets) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
@@ -114,14 +114,8 @@ public class DisguisePacketHandlers {
     }
 
     public static ClientboundUpdateAttributesPacket processAttributesPacket(DenizenNetworkManagerImpl networkManager, ClientboundUpdateAttributesPacket attributesPacket, DisguiseCommand.TrackedDisguise disguise) {
-        FakeEntity fake = disguise.entity.getBukkitEntity().getEntityId() == networkManager.player.getId() ? disguise.fakeToSelf : disguise.toOthers;
-        if (fake == null) {
-            return attributesPacket;
-        }
-        if (fake.entity.entity instanceof LivingEntity) {
-            return attributesPacket;
-        }
-        return null; // Non-living don't have attributes
+        FakeEntity fake = attributesPacket.getEntityId() == networkManager.player.getId() ? disguise.fakeToSelf : disguise.toOthers;
+        return fake == null || fake.entity.entity instanceof LivingEntity ? attributesPacket : null; // Non-living entities don't have attributes
     }
 
     public static ClientboundTeleportEntityPacket processTeleportPacket(DenizenNetworkManagerImpl networkManager, ClientboundTeleportEntityPacket teleportEntityPacket, DisguiseCommand.TrackedDisguise disguise) throws IllegalAccessException {


### PR DESCRIPTION
## Changes

- Made `PacketHelperImpl#createEntityData` static.
- Improved naming for reflection constants.
- Made reflection constants `final`.
- Split all separate packets being handled into separate methods, with a few changes:
  - Entity data packet:
    - Now gets the id used to check whether the packet is about the player directly from the packet (as there isn't a variable to use anymore).
    - Removed the redundant `List<DataValue> data` variable in favor of accessing `#packedItems` directly.
    - Since `data` isn't a thing anymore it just creates a new list called `newData` if it finds the value it needs to modify.
    - Now uses `PacketHelperImpl#createEntityData` instead of using the `DataValue` constructor directly - it feels a bit cleaner & doesn't require type erasure/unchecked casts, but lmk if you want me to revert that.
    - Now returns the modified packet as-is instead of manually calling the entity data packet handler on it, as the new system automatically runs all packet handlers for a packet.
  - Attributes packet:
    - Now gets the id directly from the packet (as there isn't a variable to use anymore).
    - Replaced the 2 `if -> return`s with a single tern, as they were pretty simple and this felt cleaner.
  - Movement packet processing has been split into 2 separate methods for the separate sub-types, both because generics said so and because it's still technically cleaner.


## Additions

- Added a new `registerPacketHandler` method that handles the generic disguise logic (checking if there are any disguises, getting the entity, getting the disguise, etc.), and then runs a `DisguisePacketHandler`.
The method takes in a `Packet, Level -> Entity` function, with an overload that takes in a `Packet -> Int (entity ID)` function, that way all packets can be cleanly registered in.
- `DisguisePacketHandler`, a functional interface for disguise packet handlers (takes in a tracked disguise).
- `sendDisguiseForPacket`, sends the disguise for a packet and blocks it (returns null) - used as the handler method for when all that's needed is sending the disguise, and is used in other handlers which send a disguise.

## Notes

- Currently the entity metadata packet handler is after the disguise packet handler (which mimics the existing/old behavior), but it might make more sense to have the disguise packet handler come after that, so that you can't accidently make a disguised player visible?
- Is there any reason the teleport entity packet reflectively sets _everything_? as far as I can see it could either:
  - Keep everything as-is but not set the ID, as it should already have the right ID from the disguised entity being passed in the constructor.
  - Copy the old teleport packet and just change the yaw.