### PR TITLE
Add `EntityTag.internal_data` mechanism

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.nms.interfaces;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import org.bukkit.Bukkit;
@@ -22,6 +23,7 @@ import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public abstract class EntityHelper {
@@ -447,6 +449,10 @@ public abstract class EntityHelper {
     }
 
     public void setStepHeight(Entity entity, float stepHeight) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
         throw new UnsupportedOperationException();
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -452,7 +452,7 @@ public abstract class EntityHelper {
         throw new UnsupportedOperationException();
     }
 
-    public void setInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
+    public void modifyInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
         throw new UnsupportedOperationException();
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -452,6 +452,10 @@ public abstract class EntityHelper {
         throw new UnsupportedOperationException();
     }
 
+    public int mapInternalEntityDataName(Entity entity, String name) {
+        throw new UnsupportedOperationException();
+    }
+
     public void modifyInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
         throw new UnsupportedOperationException();
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -3012,7 +3012,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                     }
                     internalData.put(new ElementTag(entry.getKey().str).asInt(), entry.getValue());
                 }
-                NMSHandler.entityHelper.setInternalEntityData(object.getBukkitEntity(), internalData);
+                NMSHandler.entityHelper.modifyInternalEntityData(object.getBukkitEntity(), internalData);
             });
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2990,6 +2990,30 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                     object.getLivingEntity().playHurtAnimation(value.asFloat());
                 }
             });
+
+            // <--[mechanism]
+            // @object EntityTag
+            // @name internal_data
+            // @input MapTag
+            // @description
+            // Modifies an entity's internal entity data as a map of data id to value.
+            // The values can be Denizen objects, and will be automatically converted to the relevant internal value.
+            // This is an advanced mechanism that directly controls an entity's data, with no verification/limitations on what's being set (other than basic type checking).
+            // You should almost always prefer using the appropriate mechanism/property instead of this, other than very specific special cases.
+            // See <@link url https://wiki.vg/Entity_metadata> for a documentation of different entity data values
+            // (note that it documents the values that eventually get sent to the client, so the input this expects might be slightly different in some cases).
+            // -->
+            tagProcessor.registerMechanism("internal_data", false, MapTag.class, (object, mechanism, input) -> {
+                Map<Integer, ObjectTag> internalData = new HashMap<>(input.size());
+                for (Map.Entry<StringHolder, ObjectTag> entry : input.entrySet()) {
+                    if (!ArgumentHelper.matchesInteger(entry.getKey().str)) {
+                        mechanism.echoError("Invalid internal data id '" + entry.getKey() + "': must be a number.");
+                        continue;
+                    }
+                    internalData.put(new ElementTag(entry.getKey().str).asInt(), entry.getValue());
+                }
+                NMSHandler.entityHelper.setInternalEntityData(object.getBukkitEntity(), internalData);
+            });
         }
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2996,11 +2996,12 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             // @name internal_data
             // @input MapTag
             // @description
-            // Modifies an entity's internal entity data as a map of data id to value.
+            // Modifies an entity's internal entity data as a map of data name to value.
             // The values can be Denizen objects, and will be automatically converted to the relevant internal value.
             // This is an advanced mechanism that directly controls an entity's data, with no verification/limitations on what's being set (other than basic type checking).
             // You should almost always prefer using the appropriate mechanism/property instead of this, other than very specific special cases.
-            // See <@link url https://wiki.vg/Entity_metadata> for a documentation of different entity data values
+            // See <@link url https://github.com/DenizenScript/Denizen/blob/dev/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityDataNameMapper.java#L50> for all the available names (and their respective ids),
+            // And <@link url https://wiki.vg/Entity_metadata> for a documentation of what each id is.
             // (note that it documents the values that eventually get sent to the client, so the input this expects might be slightly different in some cases).
             // -->
             tagProcessor.registerMechanism("internal_data", false, MapTag.class, (object, mechanism, input) -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -3006,11 +3006,12 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             tagProcessor.registerMechanism("internal_data", false, MapTag.class, (object, mechanism, input) -> {
                 Map<Integer, ObjectTag> internalData = new HashMap<>(input.size());
                 for (Map.Entry<StringHolder, ObjectTag> entry : input.entrySet()) {
-                    if (!ArgumentHelper.matchesInteger(entry.getKey().str)) {
-                        mechanism.echoError("Invalid internal data id '" + entry.getKey() + "': must be a number.");
+                    int id = NMSHandler.entityHelper.mapInternalEntityDataName(object.getBukkitEntity(), entry.getKey().low);
+                    if (id == -1) {
+                        mechanism.echoError("Invalid internal data key: " + entry.getKey());
                         continue;
                     }
-                    internalData.put(new ElementTag(entry.getKey().str).asInt(), entry.getValue());
+                    internalData.put(id, entry.getValue());
                 }
                 NMSHandler.entityHelper.modifyInternalEntityData(object.getBukkitEntity(), internalData);
             });

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
@@ -111,7 +111,6 @@ public class ReflectionMappingsInfo {
     public static String ClientboundLevelChunkPacketDataBlockEntityInfo_y = "b";
 
     // net.minecraft.network.protocol.syncher.SynchedEntityData
-
     public static String SynchedEntityData_itemsById = "e";
 
     // net.minecraft.world.entity.projectile.FishingHook

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/ReflectionMappingsInfo.java
@@ -110,6 +110,10 @@ public class ReflectionMappingsInfo {
     public static String ClientboundLevelChunkPacketDataBlockEntityInfo_packedXZ = "a";
     public static String ClientboundLevelChunkPacketDataBlockEntityInfo_y = "b";
 
+    // net.minecraft.network.protocol.syncher.SynchedEntityData
+
+    public static String SynchedEntityData_itemsById = "e";
+
     // net.minecraft.world.entity.projectile.FishingHook
     public static String FishingHook_nibble = "j";
     public static String FishingHook_timeUntilLured = "k";

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityDataNameMapper.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityDataNameMapper.java
@@ -1,0 +1,448 @@
+package com.denizenscript.denizen.nms.v1_20.helpers;
+
+
+import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.ambient.Bat;
+import net.minecraft.world.entity.animal.*;
+import net.minecraft.world.entity.animal.axolotl.Axolotl;
+import net.minecraft.world.entity.animal.camel.Camel;
+import net.minecraft.world.entity.animal.frog.Frog;
+import net.minecraft.world.entity.animal.goat.Goat;
+import net.minecraft.world.entity.animal.horse.AbstractChestedHorse;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.animal.horse.Horse;
+import net.minecraft.world.entity.animal.horse.Llama;
+import net.minecraft.world.entity.animal.sniffer.Sniffer;
+import net.minecraft.world.entity.boss.enderdragon.EndCrystal;
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import net.minecraft.world.entity.boss.wither.WitherBoss;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.entity.decoration.Painting;
+import net.minecraft.world.entity.item.PrimedTnt;
+import net.minecraft.world.entity.monster.*;
+import net.minecraft.world.entity.monster.hoglin.Hoglin;
+import net.minecraft.world.entity.monster.piglin.AbstractPiglin;
+import net.minecraft.world.entity.monster.piglin.Piglin;
+import net.minecraft.world.entity.monster.warden.Warden;
+import net.minecraft.world.entity.npc.AbstractVillager;
+import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.*;
+import net.minecraft.world.entity.raid.Raider;
+import net.minecraft.world.entity.vehicle.AbstractMinecart;
+import net.minecraft.world.entity.vehicle.Boat;
+import net.minecraft.world.entity.vehicle.MinecartCommandBlock;
+import net.minecraft.world.entity.vehicle.MinecartFurnace;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EntityDataNameMapper {
+
+    public static final Map<Class<? extends Entity>, Map<String, Integer>> entityDataNames = new HashMap<>();
+
+    public static void registerDataName(Class<? extends Entity> entityClass, int id, String name) {
+        entityDataNames.computeIfAbsent(entityClass, k -> new HashMap<>()).put(name, id);
+    }
+
+    static {
+        // Entity
+        registerDataName(Entity.class, 0, "entity_flags");
+        registerDataName(Entity.class, 1, "air_ticks");
+        registerDataName(Entity.class, 2, "custom_name");
+        registerDataName(Entity.class, 3, "custom_name_visible");
+        registerDataName(Entity.class, 4, "silent");
+        registerDataName(Entity.class, 5, "no_gravity");
+        registerDataName(Entity.class, 6, "pose");
+        registerDataName(Entity.class, 7, "frozen_ticks");
+
+        // Interaction
+        registerDataName(Interaction.class, 8, "width");
+        registerDataName(Interaction.class, 9, "height");
+        registerDataName(Interaction.class, 10, "responsive");
+
+        // Display
+        registerDataName(Display.class, 8, "interpolation_delay");
+        registerDataName(Display.class, 9, "interpolation_duration");
+        registerDataName(Display.class, 10, "translation");
+        registerDataName(Display.class, 11, "scale");
+        registerDataName(Display.class, 12, "left_rotation");
+        registerDataName(Display.class, 13, "right_rotation");
+        registerDataName(Display.class, 14, "billboard");
+        registerDataName(Display.class, 15, "brightness");
+        registerDataName(Display.class, 16, "view_range");
+        registerDataName(Display.class, 17, "shadow_radius");
+        registerDataName(Display.class, 18, "shadow_strength");
+        registerDataName(Display.class, 19, "width");
+        registerDataName(Display.class, 20, "height");
+        registerDataName(Display.class, 21, "glow_color");
+
+        // Block display
+        registerDataName(Display.BlockDisplay.class, 22, "material");
+
+        // Item display
+        registerDataName(Display.ItemDisplay.class, 22, "item");
+        registerDataName(Display.ItemDisplay.class, 23, "model_transform");
+
+        // Text display
+        registerDataName(Display.TextDisplay.class, 22, "text");
+        registerDataName(Display.TextDisplay.class, 23, "line_width");
+        registerDataName(Display.TextDisplay.class, 24, "background_color");
+        registerDataName(Display.TextDisplay.class, 25, "text_opacity");
+        registerDataName(Display.TextDisplay.class, 26, "text_display_flags");
+
+        // Thrown item projectile
+        registerDataName(ThrowableProjectile.class, 8, "item");
+
+        // Eye of ender
+        registerDataName(EyeOfEnder.class, 8, "item");
+
+        // Falling block
+        registerDataName(FireworkRocketEntity.class, 8, "spawn_position");
+
+        // Area effect cloud
+        registerDataName(AreaEffectCloud.class, 8, "radius");
+        registerDataName(AreaEffectCloud.class, 9, "color");
+        registerDataName(AreaEffectCloud.class, 10, "waiting");
+        registerDataName(AreaEffectCloud.class, 11, "particle");
+
+        // Fishing hook
+        registerDataName(FishingHook.class, 8, "hooked_entity_id");
+        registerDataName(FishingHook.class, 9, "catchable");
+
+        // Abstract arrow
+        registerDataName(AbstractArrow.class, 8, "abstract_arrow_flags");
+        registerDataName(AbstractArrow.class, 9, "piercing_level");
+
+        // Arrow
+        registerDataName(Arrow.class, 10, "color");
+
+        // Thrown trident
+        registerDataName(ThrownTrident.class, 10, "loyalty_level");
+        registerDataName(ThrownTrident.class, 11, "enchantment_glint");
+
+        // Boat
+        registerDataName(Boat.class, 8, "shaking_ticks");
+        registerDataName(Boat.class, 9, "shaking_direction");
+        registerDataName(Boat.class, 10, "damage_taken");
+        registerDataName(Boat.class, 11, "type");
+        registerDataName(Boat.class, 12, "left_paddle_moving");
+        registerDataName(Boat.class, 13, "right_paddle_moving");
+        registerDataName(Boat.class, 14, "bubble_shaking_ticks");
+
+        // End crystal
+        registerDataName(EndCrystal.class, 8, "beam_target");
+        registerDataName(EndCrystal.class, 9, "showing_bottom");
+
+        // Small fireball
+        registerDataName(SmallFireball.class, 8, "item");
+
+        // Fireball
+        registerDataName(Fireball.class, 8, "item");
+
+        // Wither skull
+        registerDataName(WitherSkull.class, 8, "invulnerable");
+
+        // Firework rocket
+        registerDataName(FireworkRocketEntity.class, 8, "item");
+        registerDataName(FireworkRocketEntity.class, 9, "shooter_id");
+        registerDataName(FireworkRocketEntity.class, 10, "shot_at_angle");
+
+        // Item frame
+        registerDataName(ItemFrame.class, 8, "item");
+        registerDataName(ItemFrame.class, 9, "rotation");
+
+        // Painting
+        registerDataName(Painting.class, 8, "painting_variant");
+
+        // Living entity
+        registerDataName(LivingEntity.class, 8, "living_entity_flags");
+        registerDataName(LivingEntity.class, 9, "health");
+        registerDataName(LivingEntity.class, 10, "potion_effect_color");
+        registerDataName(LivingEntity.class, 11, "is_potion_effect_ambient");
+        registerDataName(LivingEntity.class, 12, "arrows_in_body");
+        registerDataName(LivingEntity.class, 13, "bee_stingers_in_body");
+        registerDataName(LivingEntity.class, 14, "bed_location");
+
+        // Player
+        registerDataName(Player.class, 15, "additional_hearts");
+        registerDataName(Player.class, 16, "score");
+        registerDataName(Player.class, 17, "skin_parts");
+        registerDataName(Player.class, 18, "main_hand");
+        registerDataName(Player.class, 19, "left_shoulder_entity");
+        registerDataName(Player.class, 20, "right_shoulder_entity");
+
+        // Armor stand
+        registerDataName(ArmorStand.class, 15, "armor_stand_flags");
+        registerDataName(ArmorStand.class, 16, "head_rotation");
+        registerDataName(ArmorStand.class, 17, "body_rotation");
+        registerDataName(ArmorStand.class, 18, "left_arm_rotation");
+        registerDataName(ArmorStand.class, 19, "right_arm_rotation");
+        registerDataName(ArmorStand.class, 20, "left_leg_rotation");
+        registerDataName(ArmorStand.class, 21, "right_leg_rotation");
+
+        // Mob
+        registerDataName(Mob.class, 15, "mob_flags");
+
+        // Bat flags
+        registerDataName(Bat.class, 16, "bat_flags");
+
+        // Dolphin
+        registerDataName(Dolphin.class, 16, "treasure_location");
+        registerDataName(Dolphin.class, 17, "has_fish");
+        registerDataName(Dolphin.class, 18, "moisture_level");
+
+        // Abstract Fish
+        registerDataName(AbstractFish.class, 16, "from_bucket");
+
+        // PufferFish
+        registerDataName(Pufferfish.class, 17, "puff_state");
+
+        // Tropical fish
+        registerDataName(TropicalFish.class, 17, "variant");
+
+        // Ageable mob
+        registerDataName(AgeableMob.class, 16, "is_baby");
+
+        // Sniffer
+        registerDataName(Sniffer.class, 17, "sniffer_state");
+        registerDataName(Sniffer.class, 18, "finish_dig_time");
+
+        // Abstract horse
+        registerDataName(AbstractHorse.class, 17, "horse_flags");
+
+        // Horse
+        registerDataName(Horse.class, 18, "variant");
+
+        // Camel
+        registerDataName(Camel.class, 18, "is_dashing");
+        registerDataName(Camel.class, 19, "last_pose_change");
+
+        // Chested horse
+        registerDataName(AbstractChestedHorse.class, 18, "has_chest");
+
+        // Llama
+        registerDataName(Llama.class, 19, "strength");
+        registerDataName(Llama.class, 20, "carpet_color");
+        registerDataName(Llama.class, 21, "variant");
+
+        // Axolotl
+        registerDataName(Axolotl.class, 17, "variant");
+        registerDataName(Axolotl.class, 18, "playing_dead");
+        registerDataName(Axolotl.class, 19, "from_bucket");
+
+        // Bee
+        registerDataName(Bee.class, 17, "bee_flags");
+        registerDataName(Bee.class, 18, "anger_time");
+
+        // Fox
+        registerDataName(Fox.class, 17, "type");
+        registerDataName(Fox.class, 18, "fox_flags");
+        registerDataName(Fox.class, 19, "first_trusted_uuid");
+        registerDataName(Fox.class, 20, "second_trusted_uuid");
+
+        // Frog
+        registerDataName(Frog.class, 17, "variant");
+        registerDataName(Frog.class, 18, "target_id");
+
+        // Ocelot
+        registerDataName(Ocelot.class, 17, "is_trusting");
+
+        // Panda
+        registerDataName(Panda.class, 17, "ask_for_bamboo_timer");
+        registerDataName(Panda.class, 18, "sneeze_timer");
+        registerDataName(Panda.class, 19, "eat_timer");
+        registerDataName(Panda.class, 20, "main_gene");
+        registerDataName(Panda.class, 21, "hidden_gene");
+        registerDataName(Panda.class, 22, "panda_flags");
+
+        // Pig
+        registerDataName(Pig.class, 17, "has_saddle");
+        registerDataName(Pig.class, 18, "boost_ticks");
+
+        // Rabbit
+        registerDataName(Rabbit.class, 17, "type");
+
+        // Turtle
+        registerDataName(Turtle.class, 17, "home_location");
+        registerDataName(Turtle.class, 18, "has_egg");
+        registerDataName(Turtle.class, 19, "laying_egg");
+        registerDataName(Turtle.class, 20, "travel_location");
+        registerDataName(Turtle.class, 21, "going_home");
+        registerDataName(Turtle.class, 20, "traveling");
+
+        // Polar bear
+        registerDataName(PolarBear.class, 17, "standing_up");
+
+        // Hoglin
+        registerDataName(Hoglin.class, 17, "immune_to_zombification");
+
+        // Mooshroom
+        registerDataName(MushroomCow.class, 17, "variant");
+
+        // Sheep
+        registerDataName(Sheep.class, 17, "sheep_wool_flags");
+
+        // Strider
+        registerDataName(Strider.class, 17, "boost_ticks");
+        registerDataName(Strider.class, 18, "shaking");
+        registerDataName(Strider.class, 19, "has_saddle");
+
+        // Tamable animal
+        registerDataName(TamableAnimal.class, 17, "tamable_animal_flags");
+        registerDataName(TamableAnimal.class, 18, "owner");
+
+        // Cat
+        registerDataName(Cat.class, 19, "variant");
+        registerDataName(Cat.class, 20, "lying");
+        registerDataName(Cat.class, 20, "relaxed");
+        registerDataName(Cat.class, 21, "collar_color");
+
+        // Wolf
+        registerDataName(Wolf.class, 19, "begging");
+        registerDataName(Wolf.class, 20, "collar_color");
+        registerDataName(Wolf.class, 21, "anger_time");
+
+        // Parrot
+        registerDataName(Parrot.class, 19, "variant");
+
+        // Abstract villager
+        registerDataName(AbstractVillager.class, 17, "head_shake_ticks");
+
+        // Villager
+        registerDataName(Villager.class, 18, "villager_data");
+
+        // Iron golem
+        registerDataName(IronGolem.class, 16, "iron_golem_flags");
+
+        // Snow golem
+        registerDataName(SnowGolem.class, 16, "snow_golem_pumpkin_flags");
+
+        // Shulker
+        registerDataName(Shulker.class, 16, "attach_face");
+        registerDataName(Shulker.class, 17, "attachment_location");
+        registerDataName(Shulker.class, 18, "peek");
+        registerDataName(Shulker.class, 19, "color");
+
+        // Base piglin
+        registerDataName(AbstractPiglin.class, 16, "immune_to_zombification");
+
+        // Piglin
+        registerDataName(Piglin.class, 17, "is_baby");
+        registerDataName(Piglin.class, 18, "charging_crossbow");
+        registerDataName(Piglin.class, 19, "dancing");
+
+        // Blaze
+        registerDataName(Blaze.class, 16, "blaze_flags");
+
+        // Creeper
+        registerDataName(Creeper.class, 16, "state");
+        registerDataName(Creeper.class, 17, "charged");
+        registerDataName(Creeper.class, 18, "ignited");
+
+        // Goat
+        registerDataName(Goat.class, 17, "screaming");
+        registerDataName(Goat.class, 18, "has_left_horn");
+        registerDataName(Goat.class, 19, "has_right_horn");
+
+        // Guardian
+        registerDataName(Guardian.class, 16, "spikes_retracted");
+        registerDataName(Guardian.class, 17, "target_id");
+
+        // Raider
+        registerDataName(Raider.class, 16, "celebrating");
+
+        // Pillager
+        registerDataName(Pillager.class, 17, "charging_crossbow");
+
+        // Spellcaster illager
+        registerDataName(SpellcasterIllager.class, 17, "spell");
+
+        // Witch
+        registerDataName(Witch.class, 17, "drinking_potion");
+
+        // Vex
+        registerDataName(Vex.class, 16, "vex_flags");
+
+        // Spider
+        registerDataName(Spider.class, 16, "spider_flags");
+
+        // Warden
+        registerDataName(Warden.class, 16, "anger_level");
+
+        // Wither
+        registerDataName(WitherBoss.class, 16, "center_head_target");
+        registerDataName(WitherBoss.class, 17, "left_head_target");
+        registerDataName(WitherBoss.class, 18, "right_head_target");
+        registerDataName(WitherBoss.class, 19, "invulnerable_time");
+
+        // Zoglin
+        registerDataName(Zoglin.class, 16, "is_baby");
+
+        // Zombie
+        registerDataName(Zombie.class, 16, "is_baby");
+        registerDataName(Zombie.class, 17, "type"); // Unused
+        registerDataName(Zombie.class, 18, "converting_in_water");
+
+        // Zombie villager
+        registerDataName(ZombieVillager.class, 19, "is_converting");
+        registerDataName(ZombieVillager.class, 20, "villager_data");
+
+        // Enderman
+        registerDataName(EnderMan.class, 16, "carried_block");
+        registerDataName(EnderMan.class, 17, "screaming");
+        registerDataName(EnderMan.class, 18, "staring");
+
+        // Ender dragon
+        registerDataName(EnderDragon.class, 16, "phase");
+
+        // Ghast
+        registerDataName(Ghast.class, 16, "attacking");
+
+        // Phantom
+        registerDataName(Phantom.class, 16, "size");
+
+        // Slime
+        registerDataName(Slime.class, 16, "size");
+
+        // Abstract minecart
+        registerDataName(AbstractMinecart.class, 8, "shaking_ticks");
+        registerDataName(AbstractMinecart.class, 9, "shaking_direction");
+        registerDataName(AbstractMinecart.class, 10, "damage_taken");
+        registerDataName(AbstractMinecart.class, 11, "display_block_id");
+        registerDataName(AbstractMinecart.class, 12, "display_block_y");
+        registerDataName(AbstractMinecart.class, 13, "show_display_block");
+
+        // Minecraft furnace
+        registerDataName(MinecartFurnace.class, 14, "has_fuel");
+
+        // Minecraft command block
+        registerDataName(MinecartCommandBlock.class, 14, "command");
+        registerDataName(MinecartCommandBlock.class, 15, "last_output");
+
+        // Primed TNT
+        registerDataName(PrimedTnt.class, 8, "fuse_ticks");
+    }
+
+    public static int getIdForName(Class<? extends Entity> entityClass, String name) {
+        Class<?> currentClass = entityClass;
+        int id = getIdFromClass(currentClass, name);
+        while (id == -1) {
+            currentClass = currentClass.getSuperclass();
+            if (currentClass == Object.class) {
+                break;
+            }
+            id = getIdFromClass(currentClass, name);
+        }
+        return id;
+    }
+
+    private static int getIdFromClass(Class<?> entityClass, String name) {
+        Map<String, Integer> nameToId = entityDataNames.get(entityClass);
+        if (nameToId != null) {
+            return nameToId.getOrDefault(name, -1);
+        }
+        return -1;
+    }
+}

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityDataNameMapper.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityDataNameMapper.java
@@ -1,6 +1,8 @@
 package com.denizenscript.denizen.nms.v1_20.helpers;
 
 
+import com.denizenscript.denizencore.objects.ArgumentHelper;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ambient.Bat;
 import net.minecraft.world.entity.animal.*;
@@ -440,9 +442,10 @@ public class EntityDataNameMapper {
 
     private static int getIdFromClass(Class<?> entityClass, String name) {
         Map<String, Integer> nameToId = entityDataNames.get(entityClass);
-        if (nameToId != null) {
-            return nameToId.getOrDefault(name, -1);
+        int id = nameToId != null ? nameToId.getOrDefault(name, -1) : -1;
+        if (id == -1 && ArgumentHelper.matchesInteger(name)) {
+            id = new ElementTag(name).asInt();
         }
-        return -1;
+        return id;
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -10,9 +10,12 @@ import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkM
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.commands.core.ReflectionSetCommand;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.game.ClientboundMoveEntityPacket;
@@ -20,6 +23,7 @@ import net.minecraft.network.protocol.game.ClientboundPlayerLookAtPacket;
 import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
 import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.dedicated.DedicatedPlayerList;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerEntity;
@@ -795,5 +799,22 @@ public class EntityHelperImpl extends EntityHelper {
     @Override
     public void setStepHeight(Entity entity, float stepHeight) {
         ((CraftEntity) entity).getHandle().setMaxUpStep(stepHeight);
+    }
+
+    @Override
+    public void setInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
+        SynchedEntityData nmsEntityData = ((CraftEntity) entity).getHandle().getEntityData();
+        Int2ObjectMap<SynchedEntityData.DataItem<Object>> dataItemsById = ReflectionHelper.getFieldValue(SynchedEntityData.class, ReflectionMappingsInfo.SynchedEntityData_itemsById, nmsEntityData);
+        for (Map.Entry<Integer, ObjectTag> entry : internalData.entrySet()) {
+            SynchedEntityData.DataItem<Object> dataItem = dataItemsById.get(entry.getKey().intValue());
+            if (dataItem == null) {
+                Debug.echoError("Invalid internal data id '" + entry.getKey() + "': couldn't be matched to any internal data for entity of type '" + entity.getType() + "'.");
+                continue;
+            }
+            Object converted = ReflectionSetCommand.convertObjectTypeFor(dataItem.getValue().getClass(), entry.getValue());
+            if (converted != null) {
+                nmsEntityData.set(dataItem.getAccessor(), converted);
+            }
+        }
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -802,6 +802,11 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
+    public int mapInternalEntityDataName(Entity entity, String name) {
+        return EntityDataNameMapper.getIdForName(((CraftEntity) entity).getHandle().getClass(), name);
+    }
+
+    @Override
     public void modifyInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
         SynchedEntityData nmsEntityData = ((CraftEntity) entity).getHandle().getEntityData();
         Int2ObjectMap<SynchedEntityData.DataItem<Object>> dataItemsById = ReflectionHelper.getFieldValue(SynchedEntityData.class, ReflectionMappingsInfo.SynchedEntityData_itemsById, nmsEntityData);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -802,7 +802,7 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void setInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
+    public void modifyInternalEntityData(Entity entity, Map<Integer, ObjectTag> internalData) {
         SynchedEntityData nmsEntityData = ((CraftEntity) entity).getHandle().getEntityData();
         Int2ObjectMap<SynchedEntityData.DataItem<Object>> dataItemsById = ReflectionHelper.getFieldValue(SynchedEntityData.class, ReflectionMappingsInfo.SynchedEntityData_itemsById, nmsEntityData);
         for (Map.Entry<Integer, ObjectTag> entry : internalData.entrySet()) {


### PR DESCRIPTION
## Additions

- `EntityHelper#modifyInternalEntityData(Entity, Map<Integer, ObjectTag>)` - modifies an entity's internal data by id, currently only implemented on 1.20.
- `EntityHelper#mapInternalEntityDataName(Entity, String) -> int` - maps a string name to an internal entity data id, currently only implemented on 1.20.
- `EntityDataNameMapper` - class in the NMS module that contains name -> id mappings for internal entity data, and logic to convert names -> ids based on entity types.
- `EntityTag.internal_data` mechanism - modifies an entity's internal data (using the above methods).
- Added several Denizen -> NMS object conversions, registered in the NMS `Handler`'s constructor.
- `Handler(1.20)#registerConversion` - util method to register conversions from a specific Denizen type to a specific Java type.
- `ReflectionMappingsInfo.SynchedEntityData_itemsById` - mappings info used in the new `EntityHelper#modifyInternalEntityData`.

## Notes

- `Handler#registerConversion` should probably be moved to core as a generic util for conversions, let me know if you want me to just directly push it and update the PR or do that in the future.
- `EntityDataNameMapper` can technically be in the main module, but that'd be a bit more work on the handling (since Spigot uses interfaces instead of classes) & these are technically a per-version thing, as they can change in Minecraft updates - but it isn't _impossible_, so let me know if I should try doing that.
- The check for invalid entity id in `EntityHelper(1.20)#modifyInternalEntityData` is technically redundant now because it will only ever get valid ones from the string -> name mappings, but I'd say it's still useful incase of the mappings not being updated to changes; let me know if that should be removed though - even if it's gone there would still be an `NPE` in case of outdated mappings.