### PR TITLE
Translation fallback

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
@@ -234,7 +234,7 @@ public class TextTagBase {
                 }
             }
             StringBuilder output = new StringBuilder().append(ChatColor.COLOR_CHAR).append("[translate=").append(FormattedTextHelper.escape(translateText));
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && fallback != null) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && fallback != null) {
                 output.append(';').append(ChatColor.COLOR_CHAR).append("fallback=").append(FormattedTextHelper.escape(fallback.asString()));
             }
             if (with != null) {

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
@@ -1,7 +1,5 @@
 package com.denizenscript.denizen.tags.core;
 
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.properties.bukkit.BukkitElementExtensions;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
@@ -1,7 +1,11 @@
 package com.denizenscript.denizen.tags.core;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.properties.bukkit.BukkitElementExtensions;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ColorTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
@@ -9,7 +13,6 @@ import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.denizencore.tags.core.EscapeTagUtil;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import org.bukkit.ChatColor;
 
 public class TextTagBase {
@@ -180,41 +183,67 @@ public class TextTagBase {
         });
 
         // <--[tag]
-        // @attribute <&translate[<key>]>
+        // @attribute <&translate[key=<key>;(fallback=<fallback>);(with=<text>|...)]>
         // @returns ElementTag
         // @description
-        // Returns a special chat code that displays an autotranslated message.
-        // For example: - narrate "Reward: <&translate[item.minecraft.diamond_sword]>"
-        // Be warned that language keys change between Minecraft versions.
+        // Returns a special chat code that is read by the client to display an auto-translated message.
+        // "key" is the translation key.
+        // Optionally specify "fallback" as text to display when the client can't find a translation for the key.
+        // Optionally specify "with" as a list of input data for the translatable message (parts of the message that are dynamic).
+        // Be warned that language keys can change between Minecraft versions.
         // Note that this is a magic Denizen tool - refer to <@link language Denizen Text Formatting>.
         // You can use <@link tag ElementTag.strip_color> to convert the translated output to plain text (pre-translated).
+        // @example
+        // Narrates a translatable of a diamond sword's name.
+        // - narrate "Reward: <&translate[key=item.minecraft.diamond_sword]>"
+        // @example
+        // Narrates a translatable with some input data.
+        // - narrate <&translate[key=commands.give.success.single;with=32|<&translate[key=item.minecraft.diamond_sword].escaped>|<player.name.escaped>]>
+        // @example
+        // Narrates a custom translatable (from something like a resource pack), with a fallback in case it can't be translated.
+        // - narrate <&translate[key=my.custom.translation;fallback=Please use the resource pack!]>
         // -->
-        TagManager.registerTagHandler(ElementTag.class, "&translate", (attribute) -> { // Cannot be static due to hacked sub-tag
-            if (!attribute.hasParam()) {
-                return null;
+        TagManager.registerTagHandler(ElementTag.class, ObjectTag.class, "&translate", (attribute, param) -> { // Cannot be static due to hacked sub-tag
+            String translateText;
+            ElementTag fallback = null;
+            ListTag with = null;
+            MapTag translateMap = param.asType(MapTag.class, CoreUtilities.noDebugContext);
+            if (translateMap != null) {
+                ElementTag translateElement = translateMap.getRequiredObjectAs("key", ElementTag.class, attribute);
+                if (translateElement == null) {
+                    return null;
+                }
+                translateText = translateElement.asString();
+                fallback = translateMap.getElement("fallback");
+                with = translateMap.getObjectAs("with", ListTag.class, attribute.context);
             }
-            String translateText = attribute.getParam();
+            else {
+                BukkitImplDeprecations.translateLegacySyntax.warn(attribute.context);
+                translateText = param.toString();
 
-            // <--[tag]
-            // @attribute <&translate[<key>].with[<text>|...]>
-            // @returns ElementTag
-            // @description
-            // Returns a special chat code that displays an autotranslated message.
-            // Optionally, specify a list of escaped text values representing input data for the translatable message.
-            // Be aware that missing 'with' values will cause exceptions in your console.
-            // For example: - narrate "<&translate[commands.give.success.single].with[32|<&translate[item.minecraft.diamond_sword].escaped>|<player.name.escaped>]>"
-            // Be warned that language keys change between Minecraft versions.
-            // Note that this is a magic Denizen tool - refer to <@link language Denizen Text Formatting>.
-            // -->
-            StringBuilder with = new StringBuilder();
-            if (attribute.startsWith("with", 2)) {
-                ListTag withList = attribute.contextAsType(2, ListTag.class);
-                attribute.fulfill(1);
-                for (String str : withList) {
-                    with.append(";").append(FormattedTextHelper.escape(EscapeTagUtil.unEscape(str)));
+                // <--[tag]
+                // @attribute <&translate[<key>].with[<text>|...]>
+                // @returns ElementTag
+                // @deprecated Use '<&translate[key=<key>;with=<text>|...]>'.
+                // @description
+                // Deprecated in favor of <@link tag &translate>.
+                // -->
+                if (attribute.startsWith("with", 2)) {
+                    with = attribute.contextAsType(2, ListTag.class);
+                    attribute.fulfill(1);
                 }
             }
-            return new ElementTag(ChatColor.COLOR_CHAR + "[translate=" + FormattedTextHelper.escape(translateText) + with + "]");
+            StringBuilder output = new StringBuilder().append(ChatColor.COLOR_CHAR).append("[translate=").append(FormattedTextHelper.escape(translateText));
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && fallback != null) {
+                output.append(';').append(ChatColor.COLOR_CHAR).append("fallback=").append(FormattedTextHelper.escape(fallback.asString()));
+            }
+            if (with != null) {
+                for (String str : with) {
+                    output.append(';').append(FormattedTextHelper.escape(EscapeTagUtil.unEscape(str)));
+                }
+            }
+            output.append(']');
+            return new ElementTag(output.toString(), true);
         });
 
         // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/TextTagBase.java
@@ -234,7 +234,7 @@ public class TextTagBase {
                 }
             }
             StringBuilder output = new StringBuilder().append(ChatColor.COLOR_CHAR).append("[translate=").append(FormattedTextHelper.escape(translateText));
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && fallback != null) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && fallback != null) {
                 output.append(';').append(ChatColor.COLOR_CHAR).append("fallback=").append(FormattedTextHelper.escape(fallback.asString()));
             }
             if (with != null) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -291,7 +291,7 @@ public class BukkitImplDeprecations {
     public static Warning oldAgeLockedControls = new FutureWarning("oldAgeLockedControls", "Several old ways of controlling whether an entity's age is locked are deprecated in favor of the 'EntityTag.age_locked' tag/mech pair.");
 
     // Added 2023/10/04, deprecate officially by 2027
-    public static Warning translateLegacySyntax = new FutureWarning("translateLegacySyntax", "<&translate[...].with[...]> is deprecated in favor of the modern <&translate[key=...;with=...]> syntax");
+    public static Warning translateLegacySyntax = new FutureWarning("translateLegacySyntax", "<&translate[...].with[...]> is deprecated in favor of the modern <&translate[key=...;with=...]> syntax.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -290,6 +290,9 @@ public class BukkitImplDeprecations {
     // Added 2023/03/27, deprecate officially by 2026
     public static Warning oldAgeLockedControls = new FutureWarning("oldAgeLockedControls", "Several old ways of controlling whether an entity's age is locked are deprecated in favor of the 'EntityTag.age_locked' tag/mech pair.");
 
+    // Added 2023/10/04, deprecate officially by 2027
+    public static Warning translateLegacySyntax = new FutureWarning("translateLegacySyntax", "<&translate[...].with[...]> is deprecated in favor of the modern <&translate[key=...;with=...]> syntax");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Added on 2019/10/13

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -174,7 +174,7 @@ public class FormattedTextHelper {
         }
         else if (component instanceof TranslatableComponent translatableComponent) {
             builder.append(ChatColor.COLOR_CHAR).append("[translate=").append(escape(translatableComponent.getTranslate()));
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && translatableComponent.getFallback() != null) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && translatableComponent.getFallback() != null) {
                 builder.append(';').append(ChatColor.COLOR_CHAR).append("fallback=").append(escape(translatableComponent.getFallback()));
             }
             List<BaseComponent> with = translatableComponent.getWith();
@@ -470,7 +470,7 @@ public class FormattedTextHelper {
                 TranslatableComponent component = new TranslatableComponent();
                 List<String> innardParts = CoreUtilities.split(translatable, ';');
                 component.setTranslate(unescape(innardParts.get(0)));
-                if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && innardParts.size() > 1 && innardParts.get(1).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
+                if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && innardParts.size() > 1 && innardParts.get(1).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
                     component.setFallback(unescape(innardParts.remove(1).substring("&fallback=".length())));
                 }
                 for (int i = 1; i < innardParts.size(); i++) {
@@ -544,7 +544,7 @@ public class FormattedTextHelper {
                         else if (innardType.equals("translate")) {
                             TranslatableComponent component = new TranslatableComponent();
                             component.setTranslate(unescape(innardBase.get(1)));
-                            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && !innardParts.isEmpty() && innardParts.get(0).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
+                            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && !innardParts.isEmpty() && innardParts.get(0).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
                                 component.setFallback(unescape(innardParts.remove(0).substring("&fallback=".length())));
                             }
                             for (String extra : innardParts) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -174,7 +174,7 @@ public class FormattedTextHelper {
         }
         else if (component instanceof TranslatableComponent translatableComponent) {
             builder.append(ChatColor.COLOR_CHAR).append("[translate=").append(escape(translatableComponent.getTranslate()));
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && translatableComponent.getFallback() != null) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && translatableComponent.getFallback() != null) {
                 builder.append(';').append(ChatColor.COLOR_CHAR).append("fallback=").append(escape(translatableComponent.getFallback()));
             }
             List<BaseComponent> with = translatableComponent.getWith();
@@ -470,7 +470,7 @@ public class FormattedTextHelper {
                 TranslatableComponent component = new TranslatableComponent();
                 List<String> innardParts = CoreUtilities.split(translatable, ';');
                 component.setTranslate(unescape(innardParts.get(0)));
-                if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && innardParts.size() > 1 && innardParts.get(1).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
+                if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && innardParts.size() > 1 && innardParts.get(1).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
                     component.setFallback(unescape(innardParts.remove(1).substring("&fallback=".length())));
                 }
                 for (int i = 1; i < innardParts.size(); i++) {
@@ -544,7 +544,7 @@ public class FormattedTextHelper {
                         else if (innardType.equals("translate")) {
                             TranslatableComponent component = new TranslatableComponent();
                             component.setTranslate(unescape(innardBase.get(1)));
-                            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && !innardParts.isEmpty() && innardParts.get(0).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
+                            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && !innardParts.isEmpty() && innardParts.get(0).startsWith(ChatColor.COLOR_CHAR + "fallback=")) {
                                 component.setFallback(unescape(innardParts.remove(0).substring("&fallback=".length())));
                             }
                             for (String extra : innardParts) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.utilities;
 
-import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.properties.bukkit.BukkitElementExtensions;
@@ -447,7 +446,7 @@ public class FormattedTextHelper {
         return new BaseComponent[]{new TextComponent(str)};
     }
 
-    private static TranslatableComponent tryParseTranslatable(String str, ChatColor baseColor, boolean optimize) {
+    private static TranslatableComponent parseTranslatable(String str, ChatColor baseColor, boolean optimize) {
         TranslatableComponent component = new TranslatableComponent();
         if (!str.startsWith("map@")) {
             List<String> innardParts = CoreUtilities.split(str, ';');
@@ -503,7 +502,7 @@ public class FormattedTextHelper {
             }
             // Ensure compat with certain weird vanilla translate strings.
             if (str.startsWith(ChatColor.COLOR_CHAR + "[translate=") && str.indexOf(']') == str.length() - 1) {
-                return new BaseComponent[] {tryParseTranslatable(str.substring("&[translate=".length(), str.length() - 1), baseColor, optimize)};
+                return new BaseComponent[] {parseTranslatable(str.substring("&[translate=".length(), str.length() - 1), baseColor, optimize)};
             }
         }
         if (!optimize) {
@@ -567,7 +566,7 @@ public class FormattedTextHelper {
                             lastText.addExtra(component);
                         }
                         else if (innardType.equals("translate")) {
-                            lastText.addExtra(tryParseTranslatable(innards.substring("translate=".length()), baseColor, optimize));
+                            lastText.addExtra(parseTranslatable(innards.substring("translate=".length()), baseColor, optimize));
                         }
                         else if (innardType.equals("click") && innardParts.size() == 1) {
                             int endIndex = findEndIndexFor(str, "click", endBracket);


### PR DESCRIPTION
Adds support for the 1.19 translatable component fallbacks.

## Changes

- Updated the tag to modern `<&translate[key=<key>;(fallback=<fallback>);(with=<text>|...)]>` syntax.
- Tried explaining the fact that the translation is done client-side in the meta, to make what `fallback` does a bit more understandable.
- Moved the examples into proper `@example`'s, and updated for the new syntax.
- Made the tag take an `ObjectTag` as a param, instead of manually doing `!hasParam -> return null`.
- Changed the internal format for translatables to `&[translate=MapTag]`, with the map being the same as `&translate`'s input.

## Additions

- `BukkitImplDeprecations.translateLegacySyntax` - `FutureWarning` for the legacy `&translate` syntax.
- `FormattedTextHelper#parseTranslatable` - util method since there are 2 places with practically identical logic for parsing them.

## Notes

 - ~~Gave the fallback bit of the internal format for translatable components a prefix with the legacy color char, to make sure it's properly differentiated from the `with` values - let me know if there's a better way to approach this.~~
 - The feature was added in 1.19, but this is limited to 1.20+ because that's when Spigot updated the bundled Bungeecord chat version.
 - ~~Is there a reason the example for the tag `.escape`s all of the `with` values? seemed to work as expected without that, and I think the values' safety should be pretty much guaranteed in this case? as player names are pretty strict and the other is just another translatable - and either way they're passed through `FormattedTextHelper#escape` later.~~
 - Removed the `.escape`'s from the example for `with`, since the entire map is escaped later on, and it doesn't look like they're needed (I assume they were there for legacy list parsing reasons or something?) - all the old code did was immediately unescape them; the old `.with` sub-tag should still support that for back-support.
 - Not the biggest fan of the `startsWith("@map")` check in `FormattedTextHelper#parseTranslatable`, but don't think there's a cleaner way of doing that? maybe substring the raw object prefix and check if it starts with `[`? or some core method to avoid hard-coding that sort of check in?