### PR TITLE
NPC matcher-switch

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCNavigationScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCNavigationScriptEvent.java
@@ -24,6 +24,8 @@ public class NPCNavigationScriptEvent extends BukkitScriptEvent implements Liste
     //
     // @Triggers when an NPC begins, finishes, or cancels navigating.
     //
+    // @Switch npc:<npc> to only process the event if the spawned NPC matches.
+    //
     // @Context
     // None
     //
@@ -33,6 +35,7 @@ public class NPCNavigationScriptEvent extends BukkitScriptEvent implements Liste
 
     public NPCNavigationScriptEvent() {
         registerCouldMatcher("npc begins|completes|cancels navigation");
+        registerSwitches("npc");
     }
 
     public NPCTag npc;
@@ -40,6 +43,9 @@ public class NPCNavigationScriptEvent extends BukkitScriptEvent implements Liste
 
     @Override
     public boolean matches(ScriptPath path) {
+        if (!path.tryObjectSwitch("npc", npc)) {
+            return false;
+        }
         if (!runInCheck(path, npc.getLocation())) {
             return false;
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCOpensScriptEvent.java
@@ -26,6 +26,8 @@ public class NPCOpensScriptEvent extends BukkitScriptEvent implements Listener {
     //
     // @Triggers when an NPC opens a door or gate.
     //
+    // @Switch npc:<npc> to only process the event if the spawned NPC matches.
+    //
     // @Context
     // <context.location> returns the location of the door or gate opened.
     //
@@ -35,6 +37,7 @@ public class NPCOpensScriptEvent extends BukkitScriptEvent implements Listener {
 
     public NPCOpensScriptEvent() {
         registerCouldMatcher("npc opens <block>");
+        registerSwitches("npc");
     }
 
     public NPCTag npc;
@@ -42,6 +45,9 @@ public class NPCOpensScriptEvent extends BukkitScriptEvent implements Listener {
 
     @Override
     public boolean matches(ScriptPath path) {
+        if (!path.tryObjectSwitch("npc", npc)) {
+            return false;
+        }
         if (!runInCheck(path, location)) {
             return false;
         }
@@ -58,10 +64,10 @@ public class NPCOpensScriptEvent extends BukkitScriptEvent implements Listener {
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCSpawnScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCSpawnScriptEvent.java
@@ -26,11 +26,11 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
     // @Triggers when an NPC spawns.
     //
     // @Switch npc:<npc> to only process the event if the spawned NPC matches.
-    // @Switch cause:<cause> to only process the event if the cause of the NPC's spawn matches. See <@link url https://jd.citizensnpcs.co/net/citizensnpcs/api/event/SpawnReason.html> for a list of causes.
+    // @Switch reason:<reason> to only process the event if the NPC's spawn reason matches. See <@link url https://jd.citizensnpcs.co/net/citizensnpcs/api/event/SpawnReason.html> for a list of reasons.
     //
     // @Context
     // <context.location> returns the location the entity will spawn at.
-    // <context.cause> returns the cause of the spawn.
+    // <context.reason> returns the reason of the spawn.
     //
     // @NPC Always.
     //
@@ -38,7 +38,7 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
 
     public NPCSpawnScriptEvent() {
         registerCouldMatcher("npc spawns");
-        registerSwitches("npc", "cause");
+        registerSwitches("npc", "reason");
     }
 
     public NPCTag npc;
@@ -50,7 +50,7 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
         if (!path.tryObjectSwitch("npc", npc)) {
             return false;
         }
-        if (!path.tryObjectSwitch("cause", new ElementTag(event.getReason()))) {
+        if (!path.tryObjectSwitch("reason", new ElementTag(event.getReason()))) {
             return false;
         }
         if (!runInCheck(path, location)) {
@@ -68,7 +68,7 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "location" -> location;
-            case "cause" -> new ElementTag(event.getReason());
+            case "reason" -> new ElementTag(event.getReason());
             default -> super.getContext(name);
         };
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCSpawnScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/npc/NPCSpawnScriptEvent.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import net.citizensnpcs.api.event.NPCSpawnEvent;
 import org.bukkit.event.EventHandler;
@@ -24,8 +25,12 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
     //
     // @Triggers when an NPC spawns.
     //
+    // @Switch npc:<npc> to only process the event if the spawned NPC matches.
+    // @Switch cause:<cause> to only process the event if the cause of the NPC's spawn matches. See <@link url https://jd.citizensnpcs.co/net/citizensnpcs/api/event/SpawnReason.html> for a list of causes.
+    //
     // @Context
     // <context.location> returns the location the entity will spawn at.
+    // <context.cause> returns the cause of the spawn.
     //
     // @NPC Always.
     //
@@ -33,6 +38,7 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
 
     public NPCSpawnScriptEvent() {
         registerCouldMatcher("npc spawns");
+        registerSwitches("npc", "cause");
     }
 
     public NPCTag npc;
@@ -41,10 +47,15 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
 
     @Override
     public boolean matches(ScriptPath path) {
+        if (!path.tryObjectSwitch("npc", npc)) {
+            return false;
+        }
+        if (!path.tryObjectSwitch("cause", new ElementTag(event.getReason()))) {
+            return false;
+        }
         if (!runInCheck(path, location)) {
             return false;
         }
-
         return super.matches(path);
     }
 
@@ -55,10 +66,11 @@ public class NPCSpawnScriptEvent extends BukkitScriptEvent implements Listener {
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "cause" -> new ElementTag(event.getReason());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler


### PR DESCRIPTION
# Add `npc:` entity matcher switches to NPC related events

## `npc spawns`
Adds the `npc:` switch to allow the use of a matcher such as `npc_flagged`. Also adds the `cause:` switch to match for the cause for convenience.

#### Note
**This is currently a draft PR because I think it will be nice to add consistency between the NPC events so they all can have the `npc:` matcher switch. I want to make sure did this right before I add support for the other events. If this PR should just be for this event only then let me know and I'll turn it into a normal PR.**

