### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
@@ -71,7 +71,7 @@ public class PaperPlayerExtensions {
         // @description
         // Sends a fake operator level to the client, enabling clientside op-required features like the debug gamemode hotkey (F3+F4).
         // Input should be a number from 0 to 4, 0 indicating not op and 4 indicating maximum level op.
-        // The input number value corresponds to "op-permission-level" in the server.properties. See also <@link url https://minecraft.fandom.com/wiki/Permission_level>
+        // The input number value corresponds to "op-permission-level" in the server.properties. See also <@link url https://minecraft.wiki/w/Permission_level>
         // This will be reset when a player rejoins, changes world, has their real op status changed, ...
         // -->
         PlayerTag.registerOnlineOnlyMechanism("fake_op_level", ElementTag.class, (object, mechanism, input) -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -45,7 +45,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
     // @description
     // A BiomeTag represents a world biome type. Vanilla biomes are globally available, however some biomes are world-specific when added by datapacks.
     //
-    // A list of all vanilla biomes can be found at <@link url https://minecraft.fandom.com/wiki/Biome#Biome_IDs>.
+    // A list of all vanilla biomes can be found at <@link url https://minecraft.wiki/w/Biome#Biome_IDs>.
     //
     // BiomeTags without a specific world will work as though they are in the server's default world.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EnchantmentTag.java
@@ -40,7 +40,7 @@ public class EnchantmentTag implements ObjectTag, FlaggableObject {
     //
     // @description
     // An EnchantmentTag represents an item enchantment abstractly (the enchantment itself, like 'sharpness', which *can be* applied to an item, as opposed to the specific reference to an enchantment on a specific item).
-    // For enchantment names, check <@link url https://minecraft.fandom.com/wiki/Enchanting#Summary_of_enchantments>. Note spaces should swapped to underscores, so for example "Aqua Affinity" becomes "aqua_affinity".
+    // For enchantment names, check <@link url https://minecraft.wiki/w/Enchanting#Summary_of_enchantments>. Note spaces should swapped to underscores, so for example "Aqua Affinity" becomes "aqua_affinity".
     //
     // This object type is flaggable.
     // Flags on this object type will be stored in the server saves file, under special sub-key "__enchantments"

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -1276,7 +1276,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @attribute <EntityTag.vanilla_tags>
         // @returns ListTag
         // @description
-        // Returns a list of vanilla tags that apply to this entity type. See also <@link url https://minecraft.fandom.com/wiki/Tag>.
+        // Returns a list of vanilla tags that apply to this entity type. See also <@link url https://minecraft.wiki/w/Tag>.
         // -->
         tagProcessor.registerTag(ListTag.class, "vanilla_tags", (attribute, object) -> {
             HashSet<String> tags = VanillaTagHelper.tagsByEntity.get(object.getBukkitEntityType());
@@ -2750,7 +2750,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @returns ElementTag(Boolean)
         // @description
         // Returns whether this fish hook is in open water. Fish hooks in open water can catch treasure.
-        // See <@link url https://minecraft.fandom.com/wiki/Fishing> for more info.
+        // See <@link url https://minecraft.wiki/w/Fishing> for more info.
         // -->
         registerSpawnedOnlyTag(ElementTag.class, "fish_hook_in_open_water", (attribute, object) -> {
             if (!(object.getBukkitEntity() instanceof FishHook fishHook)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4179,7 +4179,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // - integrity: ElementTag(Decimal): The integrity of the structure (0-1). Lower integrity values will result in more blocks being removed when loading a structure.
         // used with the seed to determine which blocks are randomly removed to mimic "decay".
         // - metadata: ElementTag: Only applies in DATA mode, sets specific functions that can be applied to the structure,
-        // check the Minecraft wiki (<@link url https://minecraft.gamepedia.com/Structure_Block#Data>) for more information.
+        // check the Minecraft wiki (<@link url https://minecraft.wiki/w/Structure_Block#Data>) for more information.
         // - mirror: ElementTag: How the structure is mirrored; "NONE", "LEFT_RIGHT", or "FRONT_BACK".
         // - box_position: LocationTag: The position of the structure's bounding box, relative to the position of the structure block. Maximum allowed distance is 48 blocks in any direction.
         // - rotation: ElementTag: The rotation of the structure; "NONE", "CLOCKWISE_90", "CLOCKWISE_180", or "COUNTERCLOCKWISE_90".
@@ -5335,7 +5335,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // - integrity: ElementTag(Decimal): The integrity of the structure (0-1). Lower integrity values will result in more blocks being removed when loading a structure.
         // used with the seed to determine which blocks are randomly removed to mimic "decay".
         // - metadata: ElementTag: Can only be set while in DATA mode. sets specific functions that can be applied to the structure,
-        // check the Minecraft wiki (<@link url https://minecraft.gamepedia.com/Structure_Block#Data>) for more information.
+        // check the Minecraft wiki (<@link url https://minecraft.wiki/w/Structure_Block#Data>) for more information.
         // - mirror: ElementTag: How the structure is mirrored; "NONE", "LEFT_RIGHT", or "FRONT_BACK".
         // - box_position: LocationTag: The position of the structure's bounding box, relative to the position of the structure block. Maximum allowed distance is 48 blocks in any direction.
         // - rotation: ElementTag: The rotation of the structure; "NONE", "CLOCKWISE_90", "CLOCKWISE_180", or "COUNTERCLOCKWISE_90".

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -608,7 +608,7 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // @returns ListTag
         // @mechanism MaterialTag.vanilla_tags
         // @description
-        // Returns a list of vanilla tags that apply to this material. See also <@link url https://minecraft.fandom.com/wiki/Tag>.
+        // Returns a list of vanilla tags that apply to this material. See also <@link url https://minecraft.wiki/w/Tag>.
         // -->
         tagProcessor.registerTag(ListTag.class, "vanilla_tags", (attribute, object) -> {
             HashSet<String> tags = VanillaTagHelper.tagsByMaterial.get(object.getMaterial());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
@@ -195,7 +195,7 @@ public class EntityAttributeModifiers implements Property {
     // - determine <[y]>
     // </code>
     //
-    // See also <@link url https://minecraft.fandom.com/wiki/Attribute#Modifiers>
+    // See also <@link url https://minecraft.wiki/w/Attribute#Modifiers>
     //
     // For a quick and dirty in-line input, you can do for example: [generic_max_health=<list[<map[operation=ADD_NUMBER;amount=20;slot=HEAD]>]>]
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/StatisticCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/StatisticCommand.java
@@ -34,7 +34,7 @@ public class StatisticCommand extends AbstractCommand {
     //
     // @Description
     // Changes the specified statistic for the player.
-    // For more info on statistics, see <@link url https://minecraft.fandom.com/wiki/Statistics>
+    // For more info on statistics, see <@link url https://minecraft.wiki/w/Statistics>
     // For statistic names, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Statistic.html>
     //
     // You can add, take, or set a numeric value to the statistic for the linked player.

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/ScoreboardCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/ScoreboardCommand.java
@@ -67,7 +67,7 @@ public class ScoreboardCommand extends AbstractCommand {
     // "Rendertype" can be "INTEGER" or "HEARTS". Defaults to integer.
     //
     // You can set scores manually, or you can use different Minecraft criteria that set and update the scores automatically.
-    // A list of these criteria can be found here: <@link url https://minecraft.fandom.com/wiki/Scoreboard#Objectives>
+    // A list of these criteria can be found here: <@link url https://minecraft.wiki/w/Scoreboard#Objectives>
     // If the object already exists, and you don't specify the criteria, it will use the existing setting.
     //
     // You can use the "remove" argument to remove different parts of scoreboards.

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/GameRuleCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/GameRuleCommand.java
@@ -30,7 +30,7 @@ public class GameRuleCommand extends AbstractCommand {
     // @Group world
     //
     // @Description
-    // Sets a gamerule on the world. A list of valid gamerules can be found here: <@link url https://minecraft.fandom.com/wiki/Game_rule>
+    // Sets a gamerule on the world. A list of valid gamerules can be found here: <@link url https://minecraft.wiki/w/Game_rule>
     // Note: Be careful, gamerules are CASE SENSITIVE.
     //
     // @Tags

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -674,7 +674,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // @description
         // Returns a list of all registered advancement names.
         // Generally used with <@link tag PlayerTag.has_advancement>.
-        // See also <@link url https://minecraft.fandom.com/wiki/Advancement>.
+        // See also <@link url https://minecraft.wiki/w/Advancement>.
         // -->
         tagProcessor.registerTag(ListTag.class, "advancement_types", (attribute, object) -> {
             listDeprecateWarn(attribute);
@@ -1629,7 +1629,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // @attribute <server.vanilla_entity_tags>
         // @returns ListTag
         // @description
-        // Returns a list of vanilla tags applicable to entity types. See also <@link url https://minecraft.fandom.com/wiki/Tag>.
+        // Returns a list of vanilla tags applicable to entity types. See also <@link url https://minecraft.wiki/w/Tag>.
         // -->
         tagProcessor.registerTag(ListTag.class, "vanilla_entity_tags", (attribute, object) -> {
             return new ListTag(VanillaTagHelper.entityTagsByKey.keySet());
@@ -1639,7 +1639,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // @attribute <server.vanilla_tagged_entities[<tag>]>
         // @returns ListTag(EntityTag)
         // @description
-        // Returns a list of entity types referred to by the specified vanilla tag. See also <@link url https://minecraft.fandom.com/wiki/Tag>.
+        // Returns a list of entity types referred to by the specified vanilla tag. See also <@link url https://minecraft.wiki/w/Tag>.
         // -->
         tagProcessor.registerTag(ListTag.class, ElementTag.class, "vanilla_tagged_entities", (attribute, object, tag) -> {
             Set<EntityType> entityTypes = VanillaTagHelper.entityTagsByKey.get(tag.asLowerString());
@@ -1657,7 +1657,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // @attribute <server.vanilla_material_tags>
         // @returns ListTag
         // @description
-        // Returns a list of vanilla tags applicable to blocks, fluids, or items. See also <@link url https://minecraft.fandom.com/wiki/Tag>.
+        // Returns a list of vanilla tags applicable to blocks, fluids, or items. See also <@link url https://minecraft.wiki/w/Tag>.
         // -->
         tagProcessor.registerTag(ListTag.class, "vanilla_material_tags", (attribute, object) -> {
             return new ListTag(VanillaTagHelper.materialTagsByKey.keySet());
@@ -1667,7 +1667,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // @attribute <server.vanilla_tagged_materials[<tag>]>
         // @returns ListTag(MaterialTag)
         // @description
-        // Returns a list of materials referred to by the specified vanilla tag. See also <@link url https://minecraft.fandom.com/wiki/Tag>.
+        // Returns a list of materials referred to by the specified vanilla tag. See also <@link url https://minecraft.wiki/w/Tag>.
         // -->
         tagProcessor.registerTag(ListTag.class, ElementTag.class, "vanilla_tagged_materials", (attribute, object, tag) -> {
             Set<Material> materials = VanillaTagHelper.materialTagsByKey.get(tag.asLowerString());
@@ -1734,7 +1734,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         //
         // Some inputs will be strictly required for some loot tables, and ignored for others.
         //
-        // A list of valid loot tables can be found here: <@link url https://minecraft.fandom.com/wiki/Loot_table#List_of_loot_tables>
+        // A list of valid loot tables can be found here: <@link url https://minecraft.wiki/w/Loot_table#List_of_loot_tables>
         // Note that the tree view represented on the wiki should be split by slashes for the input - for example, "cow" is under "entities" in the tree so "entities/cow" is how you input that.
         // CAUTION: Invalid loot table IDs will generate an empty list rather than an error.
         //


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.