### PR TITLE
Cleanup and fix `block spreads` event

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockSpreadsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockSpreadsScriptEvent.java
@@ -37,6 +37,8 @@ public class BlockSpreadsScriptEvent extends BukkitScriptEvent implements Listen
         registerCouldMatcher("<block> spreads"); // NOTE: exists for historical compat reasons.
         registerSwitches("type");
     }
+
+    public LocationTag location;
     public MaterialTag material;
     public BlockSpreadEvent event;
 
@@ -56,7 +58,7 @@ public class BlockSpreadsScriptEvent extends BukkitScriptEvent implements Listen
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runInCheck(path, event.getBlock().getLocation())) {
+        if (!runInCheck(path, location)) {
             return false;
         }
         if (!path.tryArgObject(0, material)) {
@@ -72,7 +74,7 @@ public class BlockSpreadsScriptEvent extends BukkitScriptEvent implements Listen
     @Override
     public ObjectTag getContext(String name) {
         return switch (name) {
-            case "location" -> new LocationTag(event.getBlock().getLocation());
+            case "location" -> location;
             case "material" -> material;
             case "source_location" -> new LocationTag(event.getSource().getLocation());
             default -> super.getContext(name);
@@ -81,6 +83,7 @@ public class BlockSpreadsScriptEvent extends BukkitScriptEvent implements Listen
 
     @EventHandler
     public void onBlockSpreads(BlockSpreadEvent event) {
+        location = new LocationTag(event.getBlock().getLocation());
         material = new MaterialTag(event.getSource());
         this.event = event;
         fire(event);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockSpreadsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockSpreadsScriptEvent.java
@@ -37,8 +37,6 @@ public class BlockSpreadsScriptEvent extends BukkitScriptEvent implements Listen
         registerCouldMatcher("<block> spreads"); // NOTE: exists for historical compat reasons.
         registerSwitches("type");
     }
-
-    public LocationTag location;
     public MaterialTag material;
     public BlockSpreadEvent event;
 
@@ -58,7 +56,7 @@ public class BlockSpreadsScriptEvent extends BukkitScriptEvent implements Listen
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runInCheck(path, location)) {
+        if (!runInCheck(path, event.getBlock().getLocation())) {
             return false;
         }
         if (!path.tryArgObject(0, material)) {
@@ -73,17 +71,16 @@ public class BlockSpreadsScriptEvent extends BukkitScriptEvent implements Listen
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "material": return material;
-            case "source_location": return new LocationTag(event.getBlock().getLocation());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> new LocationTag(event.getBlock().getLocation());
+            case "material" -> material;
+            case "source_location" -> new LocationTag(event.getSource().getLocation());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler
     public void onBlockSpreads(BlockSpreadEvent event) {
-        location = new LocationTag(event.getBlock().getLocation());
         material = new MaterialTag(event.getSource());
         this.event = event;
         fire(event);


### PR DESCRIPTION
## Changes

- ~~Removed the redundant `LocationTag location` field in favor of directly referencing it where relevant.~~
- Updated `getContext` to modern switch syntax.
- Fixed `context.source_location` returning the block that it spread to instead of the source block (had the wrong method call - tested on both `1.20.2` and `1.17.1` and it seemed to work fine).

Reported [here](https://discord.com/channels/315163488085475337/1159557296934891570).