### PR TITLE
Chiseled Bookshelves Tags & Mech

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -45,6 +45,7 @@ import net.citizensnpcs.npc.ai.NPCHolder;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.ChiseledBookshelf;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -2885,6 +2886,23 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 return null;
             }
             return new ElementTag(humanEntity.isHandRaised());
+        });
+
+        // <--[tag]
+        // @attribute <EntityTag.bookshelf_slot>
+        // @returns ElementTag(Number)
+        // @description
+        // Returns the Chiseled Bookshelf slot that the entity is looking at.
+        // -->
+        registerSpawnedOnlyTag(ElementTag.class, "bookshelf_slot", (attribute, object) -> {
+            RayTraceResult result = object.getLivingEntity().rayTraceBlocks(4.5);
+            if (result == null || !(result.getHitBlock().getType() == Material.CHISELED_BOOKSHELF)) {
+                attribute.echoError("'EntityTag.bookshelf_slot' requires the entity to look at a Chiseled Bookshelf block.");
+                return null;
+            }
+            org.bukkit.block.ChiseledBookshelf bookshelfState = (org.bukkit.block.ChiseledBookshelf) result.getHitBlock().getState();
+            Vector vector = result.getHitPosition().subtract(result.getHitBlock().getLocation().toVector());
+            return new ElementTag(bookshelfState.getSlot(vector) + 1);
         });
 
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2892,15 +2892,16 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @attribute <EntityTag.bookshelf_slot>
         // @returns ElementTag(Number)
         // @description
-        // Returns the Chiseled Bookshelf slot that the entity is looking at.
+        // Returns the Chiseled Bookshelf slot that the entity is looking at, if any.
+        // See also <@link tag LocationTag.slot>
         // -->
         registerSpawnedOnlyTag(ElementTag.class, "bookshelf_slot", (attribute, object) -> {
             RayTraceResult result = object.getLivingEntity().rayTraceBlocks(4.5);
-            if (result == null || !(result.getHitBlock().getType() == Material.CHISELED_BOOKSHELF)) {
+            if (result == null || result.getHitBlock().getType() != Material.CHISELED_BOOKSHELF) {
                 attribute.echoError("'EntityTag.bookshelf_slot' requires the entity to look at a Chiseled Bookshelf block.");
                 return null;
             }
-            org.bukkit.block.ChiseledBookshelf bookshelfState = (org.bukkit.block.ChiseledBookshelf) result.getHitBlock().getState();
+            ChiseledBookshelf bookshelfState = (ChiseledBookshelf) result.getHitBlock().getState();
             Vector vector = result.getHitPosition().subtract(result.getHitBlock().getLocation().toVector());
             return new ElementTag(bookshelfState.getSlot(vector) + 1);
         });

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2888,24 +2888,6 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             return new ElementTag(humanEntity.isHandRaised());
         });
 
-        // <--[tag]
-        // @attribute <EntityTag.bookshelf_slot>
-        // @returns ElementTag(Number)
-        // @description
-        // Returns the Chiseled Bookshelf slot that the entity is looking at, if any.
-        // See also <@link tag LocationTag.slot>
-        // -->
-        registerSpawnedOnlyTag(ElementTag.class, "bookshelf_slot", (attribute, object) -> {
-            RayTraceResult result = object.getLivingEntity().rayTraceBlocks(4.5);
-            if (result == null || result.getHitBlock().getType() != Material.CHISELED_BOOKSHELF) {
-                attribute.echoError("'EntityTag.bookshelf_slot' requires the entity to look at a Chiseled Bookshelf block.");
-                return null;
-            }
-            ChiseledBookshelf bookshelfState = (ChiseledBookshelf) result.getHitBlock().getState();
-            Vector vector = result.getHitPosition().subtract(result.getHitBlock().getLocation().toVector());
-            return new ElementTag(bookshelfState.getSlot(vector) + 1);
-        });
-
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
 
             // <--[tag]
@@ -3033,6 +3015,24 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                     internalData.put(id, entry.getValue());
                 }
                 NMSHandler.entityHelper.modifyInternalEntityData(object.getBukkitEntity(), internalData);
+            });
+
+            // <--[tag]
+            // @attribute <EntityTag.bookshelf_slot>
+            // @returns ElementTag(Number)
+            // @description
+            // Returns the Chiseled Bookshelf slot that the entity is looking at, if any.
+            // See also <@link tag LocationTag.slot>
+            // -->
+            registerSpawnedOnlyTag(ElementTag.class, "bookshelf_slot", (attribute, object) -> {
+                RayTraceResult result = object.getLivingEntity().rayTraceBlocks(4.5);
+                if (result == null || result.getHitBlock().getType() != Material.CHISELED_BOOKSHELF) {
+                    attribute.echoError("'EntityTag.bookshelf_slot' requires the entity to look at a Chiseled Bookshelf block.");
+                    return null;
+                }
+                ChiseledBookshelf bookshelfState = (ChiseledBookshelf) result.getHitBlock().getState();
+                Vector vector = result.getHitPosition().subtract(result.getHitBlock().getLocation().toVector());
+                return new ElementTag(bookshelfState.getSlot(vector) + 1);
             });
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4081,39 +4081,6 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         });
 
         // <--[tag]
-        // @attribute <LocationTag.last_interacted_slot>
-        // @returns ElementTag(Number)
-        // @description
-        // Returns the last interacted slot of a Chiseled Bookshelf inventory.
-        // -->
-        tagProcessor.registerTag(ElementTag.class, "last_interacted_slot", (attribute, object) -> {
-            if (!(object.getBlockStateForTag(attribute) instanceof ChiseledBookshelf chiseledBookshelf)) {
-                return null;
-            }
-            return new ElementTag(chiseledBookshelf.getLastInteractedSlot() + 1);
-        });
-
-        // <--[tag]
-        // @attribute <LocationTag.slot[<vector>]>
-        // @returns ElementTag(Number)
-        // @description
-        // Returns the appropriate slot based on a given point along the bookshelves' surface relative to its position.
-        // It will return 0 if the given vector is not within the bounds of any slot.
-        // @Example
-        // # Obtain and narrate the slot that the player right-clicked.
-        // on player right clicks chiseled_bookshelf:
-        // - define slot <player.eye_location.ray_trace.sub[<context.location>]>
-        // - narrate <context.location.slot[<[slot]>]>
-        // See also <@link tag EntityTag.bookshelf_slot>
-        // -->
-        tagProcessor.registerTag(ElementTag.class, LocationTag.class, "slot", (attribute, object, input) -> {
-            if (!(object.getBlockStateForTag(attribute) instanceof ChiseledBookshelf chiseledBookshelf)) {
-                return null;
-            }
-            return new ElementTag(chiseledBookshelf.getSlot(input.toVector()) + 1);
-        });
-
-        // <--[tag]
         // @attribute <LocationTag.campfire_items>
         // @returns ListTag(ItemTag)
         // @mechanism LocationTag.campfire_items
@@ -4283,6 +4250,19 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 BiomeNMS biome = object.getBiomeForTag(attribute);
                 return biome != null ? new ElementTag(biome.getDownfallTypeAt(object)) : null;
             });
+
+            // <--[tag]
+            // @attribute <LocationTag.last_interacted_slot>
+            // @returns ElementTag(Number)
+            // @description
+            // Returns the last interacted slot of a Chiseled Bookshelf inventory.
+            // -->
+            tagProcessor.registerTag(ElementTag.class, "last_interacted_slot", (attribute, object) -> {
+                if (!(object.getBlockStateForTag(attribute) instanceof ChiseledBookshelf chiseledBookshelf)) {
+                    return null;
+                }
+                return new ElementTag(chiseledBookshelf.getLastInteractedSlot() + 1);
+            });
         }
 
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
@@ -4420,6 +4400,26 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 }
                 sign.setWaxed(value.asBoolean());
                 sign.update();
+            });
+
+            // <--[tag]
+            // @attribute <LocationTag.slot[<vector>]>
+            // @returns ElementTag(Number)
+            // @description
+            // Returns the appropriate slot based on a given point along the bookshelves' surface relative to its position.
+            // It will return 0 if the given vector is not within the bounds of any slot.
+            // See also <@link tag EntityTag.bookshelf_slot>
+            // @Example
+            // # Obtain and narrate the slot that the player right-clicked.
+            // on player right clicks chiseled_bookshelf:
+            // - define slot <player.eye_location.ray_trace.sub[<context.location>]>
+            // - narrate <context.location.slot[<[slot]>]>
+            // -->
+            tagProcessor.registerTag(ElementTag.class, LocationTag.class, "slot", (attribute, object, input) -> {
+                if (!(object.getBlockStateForTag(attribute) instanceof ChiseledBookshelf chiseledBookshelf)) {
+                    return null;
+                }
+                return new ElementTag(chiseledBookshelf.getSlot(input.toVector()) + 1);
             });
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4086,6 +4086,10 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // Returns the last interacted slot of a Chiseled Bookshelf inventory.
         // -->
         tagProcessor.registerTag(ElementTag.class, "last_interacted_slot", (attribute, object) -> {
+            BlockState state = object.getBlockStateForTag(attribute);
+            if (!(state instanceof ChiseledBookshelf)) {
+                return null;
+            }
             return new ElementTag(((ChiseledBookshelf) object.getBlockState()).getLastInteractedSlot() + 1);
         });
 
@@ -4100,8 +4104,13 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // on player right clicks chiseled_bookshelf:
         // - define slot <player.eye_location.ray_trace.sub[<context.location>]>
         // - narrate <context.location.slot[<[slot]>]>
+        // See also <@link tag EntityTag.bookshelf_slot>
         // -->
         tagProcessor.registerTag(ElementTag.class, "slot", (attribute, object) -> {
+            BlockState state = object.getBlockStateForTag(attribute);
+            if (!(state instanceof ChiseledBookshelf)) {
+                return null;
+            }
             return new ElementTag(((ChiseledBookshelf) object.getBlockState()).getSlot(attribute.paramAsType(LocationTag.class).toVector()) + 1);
         });
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4083,7 +4083,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @attribute <LocationTag.last_interacted_slot>
         // @returns ElementTag(Number)
         // @description
-        // Returns the last interacted slot of this Chiseled Bookshelf inventory.
+        // Returns the last interacted slot of a Chiseled Bookshelf inventory.
         // -->
         tagProcessor.registerTag(ElementTag.class, "last_interacted_slot", (attribute, object) -> {
             return new ElementTag(((ChiseledBookshelf) object.getBlockState()).getLastInteractedSlot() + 1);
@@ -4445,7 +4445,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @name last_interacted_slot
         // @input ElementTag(Number)
         // @description
-        // Sets the last interacted slot of this Chiseled Bookshelf inventory.
+        // Sets the last interacted slot of a Chiseled Bookshelf inventory.
         // @tags
         // <LocationTag.last_interacted_slot
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -55,7 +55,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 import org.bukkit.util.*;
 
-import javax.swing.text.Element;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4080,6 +4080,32 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         });
 
         // <--[tag]
+        // @attribute <LocationTag.last_interacted_slot>
+        // @returns ElementTag(Number)
+        // @description
+        // Returns the last interacted slot of this Chiseled Bookshelf inventory.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "last_interacted_slot", (attribute, object) -> {
+            return new ElementTag(((ChiseledBookshelf) object.getBlockState()).getLastInteractedSlot() + 1);
+        });
+
+        // <--[tag]
+        // @attribute <LocationTag.slot[<vector>]>
+        // @returns ElementTag(Number)
+        // @description
+        // Returns the appropriate slot based on a vector relative to this block.
+        // It will return -1 if the given vector is not within the bounds of any slot.
+        // @Example
+        // # Obtain and narrate the slot that the player right-clicked.
+        // on player right clicks chiseled_bookshelf:
+        // - define slot <player.eye_location.ray_trace.sub[<context.location>]>
+        // - narrate <context.location.slot[<[slot]>]>
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "slot", (attribute, object) -> {
+            return new ElementTag(((ChiseledBookshelf) object.getBlockState()).getSlot(attribute.paramAsType(LocationTag.class).toVector()) + 1);
+        });
+
+        // <--[tag]
         // @attribute <LocationTag.campfire_items>
         // @returns ListTag(ItemTag)
         // @mechanism LocationTag.campfire_items
@@ -4411,6 +4437,25 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             else if (mechanism.requireObject(EntityTag.class)) {
                 NMSHandler.blockHelper.setSpawnerSpawnedType(spawner, mechanism.valueAsType(EntityTag.class));
                 spawner.update();
+            }
+        });
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name last_interacted_slot
+        // @input ElementTag(Number)
+        // @description
+        // Sets the last interacted slot of this Chiseled Bookshelf inventory.
+        // @tags
+        // <LocationTag.last_interacted_slot
+        // -->
+        tagProcessor.registerMechanism("last_interacted_slot", false, (object, mechanism) -> {
+            if (!(object.getBlockState() instanceof ChiseledBookshelf)) {
+                mechanism.echoError("Mechanism 'LocationTag.last_interacted_slot' is only valid for Chiseled Bookshelves.");
+                return;
+            }
+            if (mechanism.requireInteger()) {
+                ((ChiseledBookshelf) object.getBlockState()).setLastInteractedSlot(mechanism.getValue().asInt() + 1);
             }
         });
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -55,6 +55,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 import org.bukkit.util.*;
 
+import javax.swing.text.Element;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -4086,19 +4087,18 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // Returns the last interacted slot of a Chiseled Bookshelf inventory.
         // -->
         tagProcessor.registerTag(ElementTag.class, "last_interacted_slot", (attribute, object) -> {
-            BlockState state = object.getBlockStateForTag(attribute);
-            if (!(state instanceof ChiseledBookshelf)) {
+            if (!(object.getBlockStateForTag(attribute) instanceof ChiseledBookshelf chiseledBookshelf)) {
                 return null;
             }
-            return new ElementTag(((ChiseledBookshelf) object.getBlockState()).getLastInteractedSlot() + 1);
+            return new ElementTag(chiseledBookshelf.getLastInteractedSlot() + 1);
         });
 
         // <--[tag]
         // @attribute <LocationTag.slot[<vector>]>
         // @returns ElementTag(Number)
         // @description
-        // Returns the appropriate slot based on a vector relative to this block.
-        // It will return -1 if the given vector is not within the bounds of any slot.
+        // Returns the appropriate slot based on a given point along the bookshelves' surface relative to its position.
+        // It will return 0 if the given vector is not within the bounds of any slot.
         // @Example
         // # Obtain and narrate the slot that the player right-clicked.
         // on player right clicks chiseled_bookshelf:
@@ -4106,12 +4106,11 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // - narrate <context.location.slot[<[slot]>]>
         // See also <@link tag EntityTag.bookshelf_slot>
         // -->
-        tagProcessor.registerTag(ElementTag.class, "slot", (attribute, object) -> {
-            BlockState state = object.getBlockStateForTag(attribute);
-            if (!(state instanceof ChiseledBookshelf)) {
+        tagProcessor.registerTag(ElementTag.class, LocationTag.class, "slot", (attribute, object, input) -> {
+            if (!(object.getBlockStateForTag(attribute) instanceof ChiseledBookshelf chiseledBookshelf)) {
                 return null;
             }
-            return new ElementTag(((ChiseledBookshelf) object.getBlockState()).getSlot(attribute.paramAsType(LocationTag.class).toVector()) + 1);
+            return new ElementTag(chiseledBookshelf.getSlot(input.toVector()) + 1);
         });
 
         // <--[tag]
@@ -4456,15 +4455,15 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @description
         // Sets the last interacted slot of a Chiseled Bookshelf inventory.
         // @tags
-        // <LocationTag.last_interacted_slot
+        // <LocationTag.last_interacted_slot>
         // -->
-        tagProcessor.registerMechanism("last_interacted_slot", false, (object, mechanism) -> {
-            if (!(object.getBlockState() instanceof ChiseledBookshelf)) {
+        tagProcessor.registerMechanism("last_interacted_slot", false, ElementTag.class, (object, mechanism, input) -> {
+            if (!(object.getBlockState() instanceof ChiseledBookshelf chiseledBookshelf)) {
                 mechanism.echoError("Mechanism 'LocationTag.last_interacted_slot' is only valid for Chiseled Bookshelves.");
                 return;
             }
             if (mechanism.requireInteger()) {
-                ((ChiseledBookshelf) object.getBlockState()).setLastInteractedSlot(mechanism.getValue().asInt() + 1);
+                chiseledBookshelf.setLastInteractedSlot(input.asInt() - 1);
             }
         });
     }


### PR DESCRIPTION
## Additions
- Adds the ```LocationTag.last_interacted_slot``` tag, which returns the last interacted slot of a Chiseled Bookshelf inventory.
- Adds the ```LocationTag.last_interacted_slot``` mechanism, which sets the last interacted slot of a Chiseled Bookshelf inventory.
- Adds the ```LocationTag.slot[<vector>]``` tag, which returns the appropriate slot based on a vector relative to this block.
