### PR TITLE
Account for game profile changes

### DIFF
--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
@@ -190,7 +190,7 @@ public class Handler extends NMSHandler {
                 profile = minecraftServer.getProfileCache().get(playerProfile.getName()).orElse(null);
             }
             if (profile == null) {
-                profile = new GameProfile(playerProfile.getUniqueId(), playerProfile.getName());
+                profile = ProfileEditorImpl.getGameProfileNoProperties(playerProfile);
             }
             Property textures = profile.getProperties().containsKey("textures") ? Iterables.getFirst(profile.getProperties().get("textures"), null) : null;
             if (textures == null || !textures.hasSignature() || profile.getName() == null || profile.getId() == null) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTagBuilder;
 import com.denizenscript.denizen.nms.v1_20.ReflectionMappingsInfo;
+import com.denizenscript.denizen.nms.v1_20.impl.ProfileEditorImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.VanillaTagHelper;
@@ -13,7 +14,6 @@ import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.common.collect.Iterables;
 import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
@@ -100,11 +100,7 @@ public class BlockHelperImpl implements BlockHelper {
 
     @Override
     public void setPlayerProfile(Skull skull, PlayerProfile playerProfile) {
-        GameProfile gameProfile = new GameProfile(playerProfile.getUniqueId(), playerProfile.getName());
-        if (playerProfile.hasTexture()) {
-            gameProfile.getProperties().put("textures",
-                    new Property("textures", playerProfile.getTexture(), playerProfile.getTextureSignature()));
-        }
+        GameProfile gameProfile = ProfileEditorImpl.getGameProfile(playerProfile);
         try {
             craftSkull_profile.set(skull, gameProfile);
         }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/CustomEntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/CustomEntityHelperImpl.java
@@ -1,19 +1,19 @@
 package com.denizenscript.denizen.nms.v1_20.helpers;
 
-import com.denizenscript.denizen.nms.v1_20.impl.entities.CraftFakePlayerImpl;
-import com.denizenscript.denizen.nms.v1_20.impl.entities.EntityFakeArrowImpl;
-import com.denizenscript.denizen.nms.v1_20.impl.entities.EntityFakePlayerImpl;
-import com.denizenscript.denizen.nms.v1_20.impl.entities.EntityItemProjectileImpl;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.interfaces.CustomEntityHelper;
 import com.denizenscript.denizen.nms.interfaces.FakeArrow;
 import com.denizenscript.denizen.nms.interfaces.FakePlayer;
 import com.denizenscript.denizen.nms.interfaces.ItemProjectile;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
+import com.denizenscript.denizen.nms.v1_20.impl.ProfileEditorImpl;
+import com.denizenscript.denizen.nms.v1_20.impl.entities.CraftFakePlayerImpl;
+import com.denizenscript.denizen.nms.v1_20.impl.entities.EntityFakeArrowImpl;
+import com.denizenscript.denizen.nms.v1_20.impl.entities.EntityFakePlayerImpl;
+import com.denizenscript.denizen.nms.v1_20.impl.entities.EntityItemProjectileImpl;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.mojang.authlib.GameProfile;
 import net.minecraft.server.level.ClientInformation;
 import net.minecraft.server.level.ServerLevel;
 import org.bukkit.Bukkit;
@@ -113,10 +113,7 @@ public class CustomEntityHelperImpl implements CustomEntityHelper {
         UUID uuid = UUID.randomUUID();
         playerProfile.setUniqueId(uuid);
 
-        GameProfile gameProfile = new GameProfile(playerProfile.getUniqueId(), playerProfile.getName());
-        gameProfile.getProperties().put("textures",
-                new Property("textures", playerProfile.getTexture(), playerProfile.getTextureSignature()));
-
+        GameProfile gameProfile = ProfileEditorImpl.getGameProfile(playerProfile);
         final EntityFakePlayerImpl fakePlayer = new EntityFakePlayerImpl(worldServer.getServer(), worldServer, gameProfile, ClientInformation.createDefault(), doAdd);
 
         fakePlayer.forceSetPositionRotation(location.getX(), location.getY(), location.getZ(),

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.IntArrayTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import com.denizenscript.denizen.nms.v1_20.ReflectionMappingsInfo;
+import com.denizenscript.denizen.nms.v1_20.impl.ProfileEditorImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
@@ -230,16 +231,7 @@ public class ItemHelperImpl extends ItemHelper {
 
     @Override
     public ItemStack setSkullSkin(ItemStack itemStack, PlayerProfile playerProfile) {
-        GameProfile gameProfile = new GameProfile(playerProfile.getUniqueId(), playerProfile.getName());
-        if (playerProfile.hasTexture()) {
-            gameProfile.getProperties().get("textures").clear();
-            if (playerProfile.getTextureSignature() != null) {
-                gameProfile.getProperties().put("textures", new Property("textures", playerProfile.getTexture(), playerProfile.getTextureSignature()));
-            }
-            else {
-                gameProfile.getProperties().put("textures", new Property("textures", playerProfile.getTexture()));
-            }
-        }
+        GameProfile gameProfile = ProfileEditorImpl.getGameProfile(playerProfile);
         net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
         net.minecraft.nbt.CompoundTag tag = nmsItemStack.hasTag() ? nmsItemStack.getTag() : new net.minecraft.nbt.CompoundTag();
         tag.put("SkullOwner", NbtUtils.writeGameProfile(new net.minecraft.nbt.CompoundTag(), gameProfile));

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
@@ -405,7 +405,7 @@ public class PlayerHelperImpl extends PlayerHelper {
                 case UPDATE_LISTED -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED;
             });
         }
-        GameProfile profile = new GameProfile(id, name);
+        GameProfile profile = new GameProfile(id, name != null ? name : ProfileEditorImpl.EMPTY_NAME);
         if (texture != null) {
             profile.getProperties().put("textures", new Property("textures", texture, signature));
         }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/ProfileEditorImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/ProfileEditorImpl.java
@@ -32,6 +32,9 @@ import java.util.UUID;
 
 public class ProfileEditorImpl extends ProfileEditor {
 
+    public static final String EMPTY_NAME = "";
+    public static final UUID NIL_UUID = new UUID(0L, 0L);
+
     @Override
     protected void updatePlayer(final Player player, final boolean isSkinChanging) {
         final ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
@@ -116,8 +119,14 @@ public class ProfileEditorImpl extends ProfileEditor {
         return playerInfoUpdatePacket;
     }
 
-    private static GameProfile getGameProfile(PlayerProfile playerProfile) {
-        GameProfile gameProfile = new GameProfile(playerProfile.getUniqueId(), playerProfile.getName());
+    public static GameProfile getGameProfileNoProperties(PlayerProfile playerProfile) {
+        UUID uuid = playerProfile.getUniqueId();
+        String name = playerProfile.getName();
+        return new GameProfile(uuid != null ? uuid : NIL_UUID, name != null ? name : EMPTY_NAME);
+    }
+
+    public static GameProfile getGameProfile(PlayerProfile playerProfile) {
+        GameProfile gameProfile = getGameProfileNoProperties(playerProfile);
         if (playerProfile.hasTexture()) {
             gameProfile.getProperties().put("textures", new Property("textures", playerProfile.getTexture(), playerProfile.getTextureSignature()));
         }


### PR DESCRIPTION
1.20.2 changed game profile handling to use an empty string + nil UUID instead of `null`.

## Changes

- Changed `ProfileEditorImpl#getGameProfile` to `public` and changed it to use the new `ProfileEditorImpl#getGameProfileNoProperties`.
- All relevant places now use the `getGameProfile` methods.

## Additions

- `ProfileEditorImpl#getGameProfileNoProperties` - creates a `GameProfile` from a `PlayerProfile` without transferring over properties (e.g. textures).
- `ProfileEditorImpl.EMPTY_NAME/NIL_UUID` - constants for "null" uuids/names in `GameProfile`s.

## Notes

- Handled this on the NMS level for now, as I don't want to cause issues with handling on older versions - once 1.20.2 is the minimum supported version we could update the entire codebase for that if we're not already Paper-only and using their player profile API by then.