### PR TITLE
Adds the ``EntityTag.category`` tag

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2930,6 +2930,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             // @returns ElementTag
             // @description
             // Returns the category that the given entity belongs to. Categories may subject this entity to additional effects, benefits or debuffs.
+            // Valid categories can be found at <@link url https://jd.papermc.io/paper/1.20/org/bukkit/entity/EntityCategory.html>
             // -->
             registerSpawnedOnlyTag(ElementTag.class, "category", (attribute, object) -> {
                 return new ElementTag(object.getLivingEntity().getCategory());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2924,6 +2924,16 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 }
                 return MultiVersionHelper1_19.interactionToMap(interaction.getLastInteraction(), interaction.getWorld());
             });
+
+            // <--[tag]
+            // @attribute <EntityTag.category>
+            // @returns ElementTag
+            // @description
+            // Returns the category that the given entity belongs to. Categories may subject this entity to additional effects, benefits or debuffs.
+            // -->
+            registerSpawnedOnlyTag(ElementTag.class, "category", (attribute, object) -> {
+                return new ElementTag(object.getLivingEntity().getCategory());
+            });
         }
 
         // <--[mechanism]


### PR DESCRIPTION
# Additions
#### ``EntityTag.category`` - returns the category that the given EntityTag belongs to. Valid entries listed [here](https://jd.papermc.io/paper/1.20/org/bukkit/entity/EntityCategory.html).

- Requested by [LG_Legacy](https://discord.com/channels/315163488085475337/1109569954010890332)