### PR TITLE
Optimize single entity data updates

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/FakeInternalDataCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/FakeInternalDataCommand.java
@@ -100,6 +100,10 @@ public class FakeInternalDataCommand extends AbstractCommand {
             throw new InvalidArgumentsRuntimeException("Must specify players to fake the internal data for.");
         }
         Entity entity = inputEntity.getBukkitEntity();
+        if (data.size() == 1) {
+            NMSHandler.packetHelper.sendEntityDataPacket(sendTo, entity, NMSHandler.entityHelper.convertInternalEntityDataValues(entity, data.get(0)));
+            return;
+        }
         List<List<Object>> frames = new ArrayList<>(data.size());
         for (MapTag frame : data) {
             frames.add(NMSHandler.entityHelper.convertInternalEntityDataValues(entity, frame));


### PR DESCRIPTION
## Changes

- Adds a check to the `FakeInternalData` command to skip the async loop logic and just send the packet if only a single update is specified.