### PR TITLE
Support banning players by name

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/BanCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/BanCommand.java
@@ -38,6 +38,7 @@ public class BanCommand extends AbstractCommand {
     //
     // @Description
     // Add or remove player or ip address bans from the server. Banning a player will also kick them from the server.
+    // You may specify a list of player names instead of <@link ObjectType PlayerTag>s, which should only ever be used for special cases (such as banning players that haven't joined the server yet).
     //
     // You may optionally specify both a list of players and list of addresses.
     //


### PR DESCRIPTION
Requested on [Discord](https://discord.com/channels/315163488085475337/1097461968085975081).
## Changes

- Updated the `ban` command to modern command handling.
- Changed the `source` and `reason` arguments to be properly nullable (as that's supported internally now).
- Minor cleanup to how IP/Name bans are removed, as the code was a bit boilerplate already.

## Additions

- `names:` argument to allow banning players who haven't joined the server yet by name.

## Notes

- Might be nice to add proper player profile/something similar support at some point if this sort of issue comes up again (maybe with whitelisting?), but for now a simple solution like this should do.