### PR TITLE
Brewing recipe matchers support

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -160,7 +160,7 @@ public class PaperAPIToolsImpl extends PaperAPITools {
         }
         entity.teleport(loc, cause, teleportFlags.toArray(new TeleportFlag[0]));
     }
-    
+
     record BrewingRecipeWithMatchers(PotionMix potionMix, String inputMatcher, String ingredientMatcher) {}
     public static final Map<NamespacedKey, BrewingRecipeWithMatchers> potionMixes = new HashMap<>();
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -230,12 +230,12 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     }
 
     @Override
-    public String getBrewingRecipeInput(NamespacedKey recipeId) {
+    public String getBrewingRecipeInputMatcher(NamespacedKey recipeId) {
         return potionMixes.get(recipeId).inputMatcher();
     }
 
     @Override
-    public String getBrewingRecipeIngredient(NamespacedKey recipeId) {
+    public String getBrewingRecipeIngredientMatcher(NamespacedKey recipeId) {
         return potionMixes.get(recipeId).ingredientMatcher();
     }
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -232,14 +232,12 @@ public class PaperAPIToolsImpl extends PaperAPITools {
 
     @Override
     public String getBrewingRecipeInput(NamespacedKey recipeId) {
-        BrewingRecipeWithMatchers brewing = potionMixes.get(recipeId);
-        return brewing != null ? brewing.inputMatcher() : null;
+        return potionMixes.get(recipeId).inputMatcher();
     }
 
     @Override
     public String getBrewingRecipeIngredient(NamespacedKey recipeId) {
-        BrewingRecipeWithMatchers brewing = potionMixes.get(recipeId);
-        return brewing != null ? brewing.ingredientMatcher() : null;
+        return potionMixes.get(recipeId).ingredientMatcher();
     }
 
     @Override

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -160,8 +160,7 @@ public class PaperAPIToolsImpl extends PaperAPITools {
         }
         entity.teleport(loc, cause, teleportFlags.toArray(new TeleportFlag[0]));
     }
-
-
+    
     record BrewingRecipeWithMatchers(PotionMix potionMix, String inputMatcher, String ingredientMatcher) {}
     public static final Map<NamespacedKey, BrewingRecipeWithMatchers> potionMixes = new HashMap<>();
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -3,8 +3,11 @@ package com.denizenscript.denizen.paper.utilities;
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizen.scripts.commands.entity.TeleportCommand;
+import com.denizenscript.denizen.scripts.containers.core.ItemScriptContainer;
+import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizencore.DenizenCore;
@@ -158,18 +161,26 @@ public class PaperAPIToolsImpl extends PaperAPITools {
         entity.teleport(loc, cause, teleportFlags.toArray(new TeleportFlag[0]));
     }
 
-    public static HashMap<NamespacedKey, PotionMix> potionMixes = new HashMap<>();
+
+    record BrewingRecipeWithMatchers(PotionMix potionMix, String inputMatcher, String ingredientMatcher) {}
+    public static final Map<NamespacedKey, BrewingRecipeWithMatchers> potionMixes = new HashMap<>();
 
     @Override
-    public void registerBrewingRecipe(String keyName, ItemStack result, ItemStack[] inputItem, boolean inputExact, ItemStack[] ingredientItem, boolean ingredientExact) {
+    public void registerBrewingRecipe(String keyName, ItemStack result, String input, String ingredient, ItemScriptContainer itemScriptContainer) {
         if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
             throw new UnsupportedOperationException();
         }
+        RecipeChoice inputChoice = parseBrewingRecipeChoice(itemScriptContainer, input);
+        if (inputChoice == null) {
+            return;
+        }
+        RecipeChoice ingredientChoice = parseBrewingRecipeChoice(itemScriptContainer, ingredient);
+        if (ingredientChoice == null) {
+            return;
+        }
         NamespacedKey key = new NamespacedKey(Denizen.getInstance(), keyName);
-        RecipeChoice inputChoice = itemArrayToChoice(inputItem, inputExact);
-        RecipeChoice ingredientChoice = itemArrayToChoice(ingredientItem, ingredientExact);
         PotionMix mix = new PotionMix(key, result, inputChoice, ingredientChoice);
-        potionMixes.put(key, mix);
+        potionMixes.put(key, new BrewingRecipeWithMatchers(mix, input.startsWith("matcher:") ? input : null, ingredient.startsWith("matcher:") ? ingredient : null));
         Bukkit.getPotionBrewer().addPotionMix(mix);
     }
 
@@ -185,25 +196,50 @@ public class PaperAPIToolsImpl extends PaperAPITools {
         }
     }
 
-    public static RecipeChoice itemArrayToChoice(ItemStack[] item, boolean exact) {
-        if (exact) {
-            return new RecipeChoice.ExactChoice(item);
+    public static RecipeChoice parseBrewingRecipeChoice(ItemScriptContainer container, String choice) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && choice.startsWith("matcher:")) {
+            String matcher = choice.substring("matcher:".length());
+            return PotionMix.createPredicateChoice(item -> new ItemTag(item).tryAdvancedMatcher(matcher));
         }
-        Material[] mats = new Material[item.length];
-        for (int i = 0; i < item.length; i++) {
-            mats[i] = item[i].getType();
+        boolean exact = true;
+        if (choice.startsWith("material:")) {
+            choice = choice.substring("material:".length());
+            exact = false;
+        }
+        ItemStack[] items = ItemScriptHelper.textToItemArray(container, choice, exact);
+        if (items == null) {
+            return null;
+        }
+        if (exact) {
+            return new RecipeChoice.ExactChoice(items);
+        }
+        Material[] mats = new Material[items.length];
+        for (int i = 0; i < items.length; i++) {
+            mats[i] = items[i].getType();
         }
         return new RecipeChoice.MaterialChoice(mats);
     }
 
     @Override
     public boolean isDenizenMix(ItemStack currInput, ItemStack ingredient) {
-        for (PotionMix mix : potionMixes.values()) {
-            if (mix.getInput().getItemStack().isSimilar(currInput) && mix.getIngredient().getItemStack().isSimilar(ingredient)) {
+        for (BrewingRecipeWithMatchers brewing : potionMixes.values()) {
+            if (brewing.potionMix().getInput().test(currInput) && brewing.potionMix().getIngredient().test(ingredient)) {
                 return true;
             }
         }
         return false;
+    }
+
+    @Override
+    public String getBrewingRecipeInput(NamespacedKey recipeId) {
+        BrewingRecipeWithMatchers brewing = potionMixes.get(recipeId);
+        return brewing != null ? brewing.inputMatcher() : null;
+    }
+
+    @Override
+    public String getBrewingRecipeIngredient(NamespacedKey recipeId) {
+        BrewingRecipeWithMatchers brewing = potionMixes.get(recipeId);
+        return brewing != null ? brewing.ingredientMatcher() : null;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptContainer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptContainer.java
@@ -189,6 +189,7 @@ public class ItemScriptContainer extends ScriptContainer {
     //        7:
     //            # Brewing recipes take one base item and one ingredient item.
     //            # | Brewing recipes are only available on Paper versions 1.18 and up.
+    //            # | Brewing recipes also have a special input option on 1.20 and above: "matcher:<item matcher>", to allow advanced matchers on the input/ingredient items.
     //            type: brewing
     //            input: ItemTag
     //            ingredient: ItemTag

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
@@ -1,18 +1,18 @@
 package com.denizenscript.denizen.scripts.containers.core;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.events.bukkit.ScriptReloadEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.tags.BukkitTagContext;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.events.bukkit.ScriptReloadEvent;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.objects.ItemTag;
-import com.denizenscript.denizen.tags.BukkitTagContext;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
@@ -21,10 +21,13 @@ import com.denizenscript.denizencore.scripts.ScriptBuilder;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.utilities.YamlConfiguration;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -274,28 +277,6 @@ public class ItemScriptHelper implements Listener {
         NMSHandler.itemHelper.registerSmithingRecipe(internalId, item, baseItems, baseExact, additionItems, additionExact, template, templateExact);
     }
 
-    public static void registerBrewingRecipe(ItemScriptContainer container, ItemStack item, String inputItemString, String ingredientItemString, String internalId) {
-        boolean inputExact = true;
-        if (inputItemString.startsWith("material:")) {
-            inputExact = false;
-            inputItemString = inputItemString.substring("material:".length());
-        }
-        ItemStack[] inputItems = textToItemArray(container, inputItemString, inputExact);
-        if (inputItems == null) {
-            return;
-        }
-        boolean ingredientExact = true;
-        if (ingredientItemString.startsWith("material:")) {
-            ingredientExact = false;
-            ingredientItemString = ingredientItemString.substring("material:".length());
-        }
-        ItemStack[] ingredientItems = textToItemArray(container, ingredientItemString, ingredientExact);
-        if (ingredientItems == null) {
-            return;
-        }
-        PaperAPITools.instance.registerBrewingRecipe(internalId, item, inputItems, inputExact, ingredientItems, ingredientExact);
-    }
-
     public static void rebuildRecipes() {
         for (ItemScriptContainer container : item_scripts.values()) {
             try {
@@ -347,7 +328,7 @@ public class ItemScriptHelper implements Listener {
                                 }
                                 registerSmithingRecipe(container, item, template, getString.apply("base"), getString.apply("upgrade"), internalId, retain);
                             }
-                            case "brewing" -> registerBrewingRecipe(container, item, getString.apply("input"), getString.apply("ingredient"), internalId);
+                            case "brewing" -> PaperAPITools.instance.registerBrewingRecipe(internalId, item, getString.apply("input"), getString.apply("ingredient"), container);
                         }
                     }
                 }

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -231,6 +231,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // This is formatted equivalently to the item script recipe input, with "material:" for non-exact matches, and a full ItemTag for exact matches.
         // Note that this won't represent all recipes perfectly (primarily those with multiple input choices per slot).
         // Brewing recipes are only supported on Paper, and only custom ones are available.
+        // Also for brewing recipes, currently "matcher:<item matcher>" input options in recipes added by other plugins are not supported.
         // For furnace-style and stonecutting recipes, this will return a list with only 1 item.
         // For shaped recipes, this will include 'air' for slots that are part of the shape but don't require an item.
         // For smithing recipes, this will return a list with the 'base' item and the 'addition'.

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -26,7 +26,10 @@ import com.denizenscript.denizencore.scripts.ScriptRegistry;
 import com.denizenscript.denizencore.scripts.commands.core.AdjustCommand;
 import com.denizenscript.denizencore.scripts.commands.core.SQLCommand;
 import com.denizenscript.denizencore.scripts.containers.ScriptContainer;
-import com.denizenscript.denizencore.tags.*;
+import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
+import com.denizenscript.denizencore.tags.TagManager;
+import com.denizenscript.denizencore.tags.TagRunnable;
 import com.denizenscript.denizencore.tags.core.UtilTagBase;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
@@ -277,8 +280,19 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
                 addChoice.accept(smithingRecipe.getAddition());
             }
             else if (brewingRecipe != null) {
-                addChoice.accept(brewingRecipe.ingredient());
-                addChoice.accept(brewingRecipe.input());
+                if (brewingRecipe.ingredient() != null) {
+                    addChoice.accept(brewingRecipe.ingredient());
+                }
+                else {
+                    recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeIngredient(recipeKey), true));
+                }
+                if (brewingRecipe.input() != null) {
+                    addChoice.accept(brewingRecipe.input());
+                }
+                else {
+                    recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeInput(recipeKey), true));
+                }
+
             }
             return recipeItems;
         });

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -231,7 +231,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // This is formatted equivalently to the item script recipe input, with "material:" for non-exact matches, and a full ItemTag for exact matches.
         // Note that this won't represent all recipes perfectly (primarily those with multiple input choices per slot).
         // Brewing recipes are only supported on Paper, and only custom ones are available.
-        // Also for brewing recipes, currently "matcher:<item matcher>" input options in recipes added by other plugins are not supported.
+        // For brewing recipes, currently "matcher:<item matcher>" input options are only supported in recipes added by Denizen.
         // For furnace-style and stonecutting recipes, this will return a list with only 1 item.
         // For shaped recipes, this will include 'air' for slots that are part of the shape but don't require an item.
         // For smithing recipes, this will return a list with the 'base' item and the 'addition'.

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -293,7 +293,6 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
                 else {
                     recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeInputMatcher(recipeKey), true));
                 }
-
             }
             return recipeItems;
         });

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -285,13 +285,13 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
                     addChoice.accept(brewingRecipe.ingredient());
                 }
                 else {
-                    recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeIngredient(recipeKey), true));
+                    recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeIngredientMatcher(recipeKey), true));
                 }
                 if (brewingRecipe.input() != null) {
                     addChoice.accept(brewingRecipe.input());
                 }
                 else {
-                    recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeInput(recipeKey), true));
+                    recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeInputMatcher(recipeKey), true));
                 }
 
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -125,11 +125,11 @@ public class PaperAPITools {
         return false;
     }
 
-    public String getBrewingRecipeInput(NamespacedKey recipeId) {
+    public String getBrewingRecipeInputMatcher(NamespacedKey recipeId) {
         return null;
     }
 
-    public String getBrewingRecipeIngredient(NamespacedKey recipeId) {
+    public String getBrewingRecipeIngredientMatcher(NamespacedKey recipeId) {
         return null;
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -3,13 +3,11 @@ package com.denizenscript.denizen.utilities;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.scripts.commands.entity.TeleportCommand;
+import com.denizenscript.denizen.scripts.containers.core.ItemScriptContainer;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.api.chat.BaseComponent;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Nameable;
-import org.bukkit.RegionAccessor;
+import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -116,7 +114,7 @@ public class PaperAPITools {
         entity.teleport(loc, cause);
     }
 
-    public void registerBrewingRecipe(String keyName, ItemStack result, ItemStack[] inputItem, boolean inputExact, ItemStack[] ingredientItem, boolean ingredientExact) {
+    public void registerBrewingRecipe(String keyName, ItemStack result, String input, String ingredient, ItemScriptContainer itemScriptContainer) {
         throw new UnsupportedOperationException();
     }
 
@@ -125,6 +123,14 @@ public class PaperAPITools {
 
     public boolean isDenizenMix(ItemStack currInput, ItemStack ingredient) {
         return false;
+    }
+
+    public String getBrewingRecipeInput(NamespacedKey recipeId) {
+        return null;
+    }
+
+    public String getBrewingRecipeIngredient(NamespacedKey recipeId) {
+        return null;
     }
 
     public String getDeathMessage(PlayerDeathEvent event) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -61,6 +61,7 @@ import org.bukkit.inventory.ShapedRecipe;
 
 import java.lang.reflect.Field;
 import java.util.*;
+import java.util.function.Predicate;
 
 public class ItemHelperImpl extends ItemHelper {
 
@@ -503,10 +504,13 @@ public class ItemHelperImpl extends ItemHelper {
                 if (PaperPotionMix_CLASS == null) {
                     PaperPotionMix_CLASS = paperMix.getClass();
                 }
-                RecipeChoice ingredient = CraftRecipe.toBukkit(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "ingredient", paperMix));
-                RecipeChoice input = CraftRecipe.toBukkit(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "input", paperMix));
+                Predicate<net.minecraft.world.item.ItemStack> ingredient = ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "ingredient", paperMix);
+                Predicate<net.minecraft.world.item.ItemStack> input = ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "input", paperMix);
+                // Not an instance of net.minecraft.world.item.crafting.Ingredient = a predicate recipe choice
+                RecipeChoice ingredientChoice = ingredient instanceof Ingredient nmsRecipeChoice ? CraftRecipe.toBukkit(nmsRecipeChoice) : null;
+                RecipeChoice inputChoice = input instanceof Ingredient nmsRecipeChoice ? CraftRecipe.toBukkit(nmsRecipeChoice) : null;
                 ItemStack result = CraftItemStack.asBukkitCopy(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "result", paperMix));
-                return new BrewingRecipe(ingredient, input, result);
+                return new BrewingRecipe(inputChoice, ingredientChoice, result);
             });
         }
         return customBrewingRecipes;


### PR DESCRIPTION
## Additions

- `PaperAPIToolsImpl$BrewingRecipeWithMatchers` - a record class to hold a `PotionMix` and potential `matcher:` inputs of a brewing recipe.
- `PaperAPIToolsImpl#parseBrewingRecipeChoice` - parses a `String` into a `RecipeChoice` for a brewing recipe.
- `PaperAPIToolsImpl#getBrewingRecipeInput/IngredientMatcher` - gets the `matcher:` used in a brewing recipe by it's ID.

## Changes

- Changed the `PaperAPIToolsImpl.potionMixes` map to have the new `BrewingRecipeWithMatchers` as it's value.
- `PaperAPIToolsImpl#registerBrewingRecipe` now takes the raw recipe inputs instead of parsed ones, so that it can properly handle `matcher:`'s, and parses them with `PaperAPIToolsImpl#parseBrewingRecipeChoice`.
- `PaperAPIToolsImpl#isDenizenMix` now uses `RecipeChoice#test` instead of directly checking the `ItemStack`, as predicate recipe choices don't have one.
- `server.recipe_items` now supports outputting `matcher:` for brewing recipes added by Denizen.
- `ItemHelperImpl(1.20)#getCustomBrewingRecipes` - now accounts for brewing recipes having predicate recipe choices, and returns `null` choices in these cases so that code using it knows to fetch them using the new `PaperAPITools` methods.