### PR TITLE
Add support for Horse inventories

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.nms.interfaces;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import org.bukkit.Bukkit;
@@ -457,4 +458,6 @@ public abstract class EntityHelper {
     public void modifyInternalEntityData(Entity entity, MapTag internalData) {
         throw new UnsupportedOperationException();
     }
+
+    public abstract void openHorseInventory(PlayerTag player, EntityTag horse);
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -3,7 +3,6 @@ package com.denizenscript.denizen.nms.interfaces;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import org.bukkit.Bukkit;
@@ -468,5 +467,5 @@ public abstract class EntityHelper {
         throw new UnsupportedOperationException();
     }
 
-    public abstract void openHorseInventory(PlayerTag player, EntityTag horse);
+    public abstract void openHorseInventory(Player player, AbstractHorse horse);
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -255,7 +255,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                                    @ArgName("data_action") @ArgRaw @ArgLinear @ArgDefaultNull String dataAction) {
         if (slot == null) {
             if (actions.contains(Action.ADJUST)) {
-                Debug.echoError("Inventory adjust must have an explicit slot!");
+                throw new InvalidArgumentsRuntimeException("Inventory adjust must have an explicit slot!");
             }
             else {
                 slot = "1";
@@ -271,7 +271,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                 expire = expiration.asType(TimeTag.class, scriptEntry.context);
             }
             else {
-                Debug.echoError("Flag expiration is not a DurationTag or TimeTag!");
+                throw new InvalidArgumentsRuntimeException("Flag expiration is not a DurationTag or TimeTag!");
             }
         }
         AbstractMap.SimpleEntry<Integer, InventoryTag> originEntry = originString != null ? Conversion.getInventory(new Argument(originString), scriptEntry) : null;
@@ -279,7 +279,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         if (destinationEntry == null) {
             InventoryTag inv = Utilities.getEntryPlayer(scriptEntry).getInventory();
             if (inv == null) {
-                Debug.echoError("Must specify a Destination Inventory!");
+                throw new InvalidArgumentsRuntimeException("Must specify a Destination Inventory!");
             }
             destinationEntry = new AbstractMap.SimpleEntry<>(0, inv);
         }
@@ -288,12 +288,11 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         int slotId = SlotHelper.nameToIndexFor(slot, destination.getInventory().getHolder());
         if (slotId < 0) {
             if (slotId == -1) {
-                Debug.echoError(scriptEntry, "The input '" + slot + "' is not a valid slot (unrecognized)!");
+                throw new InvalidArgumentsRuntimeException("The input '" + slot + "' is not a valid slot (unrecognized)!");
             }
             else {
-                Debug.echoError(scriptEntry, "The input '" + slot + "' is not a valid slot (negative values are invalid)!");
+                throw new InvalidArgumentsRuntimeException("The input '" + slot + "' is not a valid slot (negative values are invalid)!");
             }
-            return;
         }
         InventoryTag.trackTemporaryInventory(destination);
         if (origin != null) {
@@ -324,16 +323,14 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                 // Turn destination's contents into a copy of origin's
                 case COPY:
                     if (origin == null) {
-                        Debug.echoError(scriptEntry, "Missing origin argument!");
-                        return;
+                        throw new InvalidArgumentsRuntimeException("Missing origin argument!");
                     }
                     replace(origin, destination);
                     break;
                 // Copy origin's contents to destination, then empty origin
                 case MOVE:
                     if (origin == null) {
-                        Debug.echoError(scriptEntry, "Missing origin argument!");
-                        return;
+                        throw new InvalidArgumentsRuntimeException("Missing origin argument!");
                     }
                     replace(origin, destination);
                     origin.clear();
@@ -341,8 +338,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                 // Swap the contents of the two inventories
                 case SWAP:
                     if (origin == null) {
-                        Debug.echoError(scriptEntry, "Missing origin argument!");
-                        return;
+                        throw new InvalidArgumentsRuntimeException("Missing origin argument!");
                     }
                     InventoryTag temp = new InventoryTag(destination.getInventory().getContents());
                     replace(origin, destination);
@@ -351,16 +347,14 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                 // Set items by slot
                 case SET:
                     if (origin == null) {
-                        Debug.echoError(scriptEntry, "Missing origin argument!");
-                        return;
+                        throw new InvalidArgumentsRuntimeException("Missing origin argument!");
                     }
                     destination.setSlots(slotId, origin.getContents(), originEntry.getKey());
                     break;
                 // Keep only items from the origin's contents in the destination
                 case KEEP: {
                     if (origin == null) {
-                        Debug.echoError(scriptEntry, "Missing origin argument!");
-                        return;
+                        throw new InvalidArgumentsRuntimeException("Missing origin argument!");
                     }
                     ItemStack[] items = origin.getContents();
                     for (ItemStack invStack : destination.getInventory()) {
@@ -387,8 +381,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                 // Exclude all items from the origin's contents in the destination
                 case EXCLUDE: {
                     if (origin == null) {
-                        Debug.echoError(scriptEntry, "Missing origin argument!");
-                        return;
+                        throw new InvalidArgumentsRuntimeException("Missing origin argument!");
                     }
                     int oldCount = destination.count(null, false);
                     int newCount = -1;
@@ -402,8 +395,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                 // Add origin's contents over and over to destination until it is full
                 case FILL: {
                     if (origin == null) {
-                        Debug.echoError(scriptEntry, "Missing origin argument!");
-                        return;
+                        throw new InvalidArgumentsRuntimeException("Missing origin argument!");
                     }
                     int oldCount = destination.count(null, false);
                     int newCount = -1;
@@ -423,7 +415,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                         ((PlayerTag) destination.idHolder).getPlayerEntity().updateInventory();
                     }
                     else {
-                        Debug.echoError("Only player inventories can be force-updated!");
+                        throw new InvalidArgumentsRuntimeException("Only player inventories can be force-updated!");
                     }
                     break;
                 case ADJUST:

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -188,10 +188,10 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         }
     }
 
-    static public Player currentAltPlayer;
-    static public Location currentAltLocation;
-    static public String currentAltTitle, currentAltType;
-    static public ObjectTag currentAltHolder;
+    public static Player currentAltPlayer;
+    public static Location currentAltLocation;
+    public static String currentAltTitle, currentAltType;
+    public static ObjectTag currentAltHolder;
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onOpen(InventoryOpenEvent event) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -262,12 +262,12 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         }
         TimeTag expire = null;
         if (actions.contains(Action.FLAG) && expiration != null) {
-            if (expiration instanceof DurationTag duration) {
+            if (expiration.canBeType(DurationTag.class)) {
                 TimeTag now = TimeTag.now();
-                expire = new TimeTag(now.millis() + duration.getMillis(), now.instant.getZone());
+                expire = new TimeTag(now.millis() + expiration.asType(DurationTag.class, scriptEntry.context).getMillis(), now.instant.getZone());
             }
-            else if (expiration instanceof TimeTag time) {
-                expire = time;
+            else if (expiration.canBeType(TimeTag.class)) {
+                expire = expiration.asType(TimeTag.class, scriptEntry.context);
             }
             else {
                 Debug.echoError("Flag expiration is not a DurationTag or TimeTag!");

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -23,6 +23,7 @@ import com.denizenscript.denizencore.utilities.data.DataAction;
 import com.denizenscript.denizencore.utilities.data.DataActionHelper;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -195,7 +196,13 @@ public class InventoryCommand extends AbstractCommand implements Listener {
             else if (!scriptEntry.hasObject("destination")
                     && arg.matchesPrefix("destination", "dest", "d", "target", "to", "t")
                     && arg.matchesArgumentTypes(InventoryTag.class, EntityTag.class, LocationTag.class)) {
-                scriptEntry.addObject("destination", Conversion.getInventory(arg, scriptEntry));
+                if (arg.matchesArgumentType(EntityTag.class)) {
+                    // MAKES SURE THIS STILL WORKS WITH OTHER ENTITIES
+                    scriptEntry.addObject("destinationEntity", arg.object);
+                }
+                else {
+                    scriptEntry.addObject("destination", Conversion.getInventory(arg, scriptEntry));
+                }
             }
             else if (!scriptEntry.hasObject("slot")
                     && arg.matchesPrefix("slot", "s")) {
@@ -325,6 +332,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         InventoryTag origin = originentry != null ? originentry.getValue() : null;
         AbstractMap.SimpleEntry<Integer, InventoryTag> destinationentry = (AbstractMap.SimpleEntry<Integer, InventoryTag>) scriptEntry.getObject("destination");
         InventoryTag destination = destinationentry.getValue();
+        EntityTag destinationEntity = scriptEntry.getObjectTag("destinationEntity");
         ElementTag slot = scriptEntry.getElement("slot");
         ElementTag mechanism = scriptEntry.getElement("mechanism");
         ObjectTag mechanismValue = scriptEntry.getObjectTag("mechanism_value");
@@ -355,6 +363,10 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                     // Use special method to make opening workbenches and anvils work properly
                     if ((destination.getInventoryType() == InventoryType.WORKBENCH || (destination.getInventoryType() == InventoryType.ANVIL && Denizen.supportsPaper)) && destination.getInventory().getLocation() == null) {
                         doSpecialOpen(destination.getInventoryType(), player.getPlayerEntity(), destination);
+                    }
+                    else if (destinationEntity.getBukkitEntity() instanceof AbstractHorse) {
+                        Debug.log("horse");
+                        NMSHandler.entityHelper.openHorseInventory(player, destinationEntity);
                     }
                     // Otherwise, open inventory as usual
                     else {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -252,28 +252,25 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                                    @ArgName("slot") @ArgPrefixed @ArgDefaultNull String slot,
                                    @ArgName("expiration") @ArgPrefixed @ArgDefaultNull ObjectTag expiration,
                                    @ArgName("data_action") @ArgRaw @ArgLinear @ArgDefaultNull String dataAction) {
-        if (actions.contains(Action.ADJUST) && slot == null) {
-            Debug.echoError("Inventory adjust must have an explicit slot!");
-        }
-        else {
-            slot = "1";
+        if (slot == null) {
+            if (actions.contains(Action.ADJUST)) {
+                Debug.echoError("Inventory adjust must have an explicit slot!");
+            }
+            else {
+                slot = "1";
+            }
         }
         TimeTag expire = null;
-        if (actions.contains(Action.FLAG)) {
-            if (expiration != null) {
-                if (expiration instanceof DurationTag duration) {
-                    TimeTag now = TimeTag.now();
-                    expire = new TimeTag(now.millis() + duration.getMillis(), now.instant.getZone());
-                }
-                else if (expiration instanceof TimeTag time) {
-                    expire = time;
-                }
-                else {
-                    Debug.echoError("Flag expiration is not a DurationTag or TimeTag!");
-                }
+        if (actions.contains(Action.FLAG) && expiration != null) {
+            if (expiration instanceof DurationTag duration) {
+                TimeTag now = TimeTag.now();
+                expire = new TimeTag(now.millis() + duration.getMillis(), now.instant.getZone());
             }
-            if (dataAction == null) {
-                Debug.echoError("Inventory flag must have a flag action!");
+            else if (expiration instanceof TimeTag time) {
+                expire = time;
+            }
+            else {
+                Debug.echoError("Flag expiration is not a DurationTag or TimeTag!");
             }
         }
         AbstractMap.SimpleEntry<Integer, InventoryTag> originEntry = originString != null ? Conversion.getInventory(new Argument(originString), scriptEntry) : null;
@@ -358,7 +355,6 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                     }
                     destination.setSlots(slotId, origin.getContents(), originEntry.getKey());
                     break;
-
                 // Keep only items from the origin's contents in the destination
                 case KEEP: {
                     if (origin == null) {
@@ -439,6 +435,9 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                     NMSHandler.itemHelper.setInventoryItem(destination.getInventory(), toAdjust.getItemStack(), slotId);
                     break;
                 case FLAG:
+                    if (dataAction == null) {
+                        Debug.echoError("Inventory flag must have a flag action!");
+                    }
                     ItemTag toFlag = new ItemTag(destination.getInventory().getItem(slotId));
                     Argument flagArgument = new Argument(dataAction);
                     DataAction flagAction = DataActionHelper.parse(new FlagCommand.FlagActionProvider(), flagArgument, scriptEntry.context);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -8,10 +8,10 @@ import com.denizenscript.denizen.scripts.containers.core.InventoryScriptHelper;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Conversion;
 import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.inventory.InventoryTrackerSystem;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.objects.*;
 import com.denizenscript.denizencore.objects.core.*;
 import com.denizenscript.denizencore.objects.notable.NoteManager;
@@ -46,6 +46,11 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         isProcedural = false;
         allowedDynamicPrefixes = true;
         Bukkit.getPluginManager().registerEvents(this, Denizen.instance);
+        autoCompile();
+        addRemappedPrefixes("origin", "o", "source", "items", "i", "from", "f");
+        addRemappedPrefixes("destination", "dest", "d", "target", "to", "t");
+        addRemappedPrefixes("slot", "s");
+        addRemappedPrefixes("expiration", "expires", "expire", "duration");
     }
 
     // <--[language]
@@ -161,7 +166,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
     // - inventory flag slot:hand my_target:<player.cursor_on> expire:1d
     // -->
 
-    private enum Action {OPEN, CLOSE, COPY, MOVE, SWAP, SET, KEEP, EXCLUDE, FILL, CLEAR, UPDATE, ADJUST, FLAG}
+    public enum Action {OPEN, CLOSE, COPY, MOVE, SWAP, SET, KEEP, EXCLUDE, FILL, CLEAR, UPDATE, ADJUST, FLAG}
 
     @Override
     public void addCustomTabCompletions(TabCompletionsBuilder tab) {
@@ -183,95 +188,10 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         }
     }
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        boolean isAdjust = false, isFlag = false;
-        for (Argument arg : scriptEntry) {
-            if (!scriptEntry.hasObject("origin")
-                    && arg.matchesPrefix("origin", "o", "source", "items", "item", "i", "from", "f")
-                    && (arg.matchesArgumentTypes(InventoryTag.class, EntityTag.class, LocationTag.class, MapTag.class)
-                    || arg.matchesArgumentList(ItemTag.class))) {
-                scriptEntry.addObject("origin", Conversion.getInventory(arg, scriptEntry));
-            }
-            else if (!scriptEntry.hasObject("destination")
-                    && arg.matchesPrefix("destination", "dest", "d", "target", "to", "t")
-                    && arg.matchesArgumentTypes(InventoryTag.class, EntityTag.class, LocationTag.class)) {
-                if (arg.matchesArgumentType(EntityTag.class)) {
-                    // MAKES SURE THIS STILL WORKS WITH OTHER ENTITIES
-                    scriptEntry.addObject("destinationEntity", arg.object);
-                }
-                else {
-                    scriptEntry.addObject("destination", Conversion.getInventory(arg, scriptEntry));
-                }
-            }
-            else if (!scriptEntry.hasObject("slot")
-                    && arg.matchesPrefix("slot", "s")) {
-                scriptEntry.addObject("slot", arg.asElement());
-            }
-            else if (!scriptEntry.hasObject("actions")
-                    && arg.matchesEnumList(Action.class)) {
-                scriptEntry.addObject("actions", arg.asType(ListTag.class).filter(Action.values()));
-                isAdjust = arg.toString().equalsIgnoreCase("adjust");
-                isFlag = arg.toString().equalsIgnoreCase("flag");
-            }
-            else if (!scriptEntry.hasObject("mechanism")
-                    && isAdjust) {
-                if (arg.hasPrefix()) {
-                    scriptEntry.addObject("mechanism", new ElementTag(arg.getPrefix().getValue()));
-                    scriptEntry.addObject("mechanism_value", arg.object);
-                }
-                else {
-                    scriptEntry.addObject("mechanism", arg.asElement());
-                }
-            }
-            else if (!scriptEntry.hasObject("expiration")
-                    && arg.matchesPrefix("duration", "expire", "expires", "expiration")
-                    && isFlag) {
-                if (arg.matchesArgumentType(DurationTag.class)) {
-                    TimeTag now = TimeTag.now();
-                    scriptEntry.addObject("expiration", new TimeTag(now.millis() + arg.asType(DurationTag.class).getMillis(), now.instant.getZone()));
-                }
-                else if (arg.matchesArgumentType(TimeTag.class)) {
-                    scriptEntry.addObject("expiration", arg.asType(TimeTag.class));
-                }
-                else {
-                    arg.reportUnhandled();
-                }
-            }
-            else if (!scriptEntry.hasObject("flag_action")
-                    && isFlag) {
-                scriptEntry.addObject("flag_action", DataActionHelper.parse(new FlagCommand.FlagActionProvider(), arg, scriptEntry.context));
-            }
-            else {
-                arg.reportUnhandled();
-            }
-        }
-        // Check to make sure required arguments have been filled
-        if (!scriptEntry.hasObject("actions")) {
-            throw new InvalidArgumentsException("Must specify an Inventory action!");
-        }
-        if (isAdjust && !scriptEntry.hasObject("mechanism")) {
-            throw new InvalidArgumentsException("Inventory adjust must have a mechanism!");
-        }
-        if (isAdjust && !scriptEntry.hasObject("slot")) {
-            throw new InvalidArgumentsException("Inventory adjust must have an explicit slot!");
-        }
-        if (isFlag && !scriptEntry.hasObject("flag_action")) {
-            throw new InvalidArgumentsException("Inventory flag must have a flag action!");
-        }
-        scriptEntry.defaultObject("slot", new ElementTag(1));
-        scriptEntry.defaultObject("destination",
-                Utilities.entryHasPlayer(scriptEntry) ?
-                        new AbstractMap.SimpleEntry<>(0, Utilities.getEntryPlayer(scriptEntry).getInventory()) : null);
-        if (!scriptEntry.hasObject("destination")) {
-            throw new InvalidArgumentsException("Must specify a Destination Inventory!");
-        }
-    }
-
-    public Player currentAltPlayer;
-    public Location currentAltLocation;
-    public String currentAltTitle, currentAltType;
-    public ObjectTag currentAltHolder;
+    static public Player currentAltPlayer;
+    static public Location currentAltLocation;
+    static public String currentAltTitle, currentAltType;
+    static public ObjectTag currentAltHolder;
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onOpen(InventoryOpenEvent event) {
@@ -291,7 +211,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         InventoryTrackerSystem.trackTemporaryInventory(event.getInventory(), newTag);
     }
 
-    public void doSpecialOpen(InventoryType type, Player player, InventoryTag destination) {
+    public static void doSpecialOpen(InventoryType type, Player player, InventoryTag destination) {
         try {
             if (destination.customTitle != null || destination.idType.equals("script")) {
                 currentAltType = destination.getIdType();
@@ -325,29 +245,55 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         }
     }
 
-    @Override
-    public void execute(final ScriptEntry scriptEntry) {
-        List<String> actions = (List<String>) scriptEntry.getObject("actions");
-        AbstractMap.SimpleEntry<Integer, InventoryTag> originentry = (AbstractMap.SimpleEntry<Integer, InventoryTag>) scriptEntry.getObject("origin");
-        InventoryTag origin = originentry != null ? originentry.getValue() : null;
-        AbstractMap.SimpleEntry<Integer, InventoryTag> destinationentry = (AbstractMap.SimpleEntry<Integer, InventoryTag>) scriptEntry.getObject("destination");
-        InventoryTag destination = destinationentry.getValue();
-        EntityTag destinationEntity = scriptEntry.getObjectTag("destinationEntity");
-        ElementTag slot = scriptEntry.getElement("slot");
-        ElementTag mechanism = scriptEntry.getElement("mechanism");
-        ObjectTag mechanismValue = scriptEntry.getObjectTag("mechanism_value");
-        DataAction flagAction = (DataAction) scriptEntry.getObject("flag_action");
-        TimeTag expiration = scriptEntry.getObjectTag("expiration");
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), db("actions", actions), destination, origin, mechanism, mechanismValue, flagAction, expiration, slot);
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("actions") @ArgLinear @ArgSubType(Action.class) List<Action> actions,
+                                   @ArgName("origin") @ArgRaw @ArgPrefixed @ArgDefaultNull String originString,
+                                   @ArgName("destination") @ArgRaw @ArgPrefixed @ArgDefaultNull String destinationString,
+                                   @ArgName("slot") @ArgPrefixed @ArgDefaultNull String slot,
+                                   @ArgName("expiration") @ArgPrefixed @ArgDefaultNull ObjectTag expiration,
+                                   @ArgName("data_action") @ArgRaw @ArgLinear @ArgDefaultNull String dataAction) {
+        if (actions.contains(Action.ADJUST) && slot == null) {
+            Debug.echoError("Inventory adjust must have an explicit slot!");
         }
-        int slotId = SlotHelper.nameToIndexFor(slot.asString(), destination.getInventory().getHolder());
+        else {
+            slot = "1";
+        }
+        TimeTag expire = null;
+        if (actions.contains(Action.FLAG)) {
+            if (expiration != null) {
+                if (expiration instanceof DurationTag duration) {
+                    TimeTag now = TimeTag.now();
+                    expire = new TimeTag(now.millis() + duration.getMillis(), now.instant.getZone());
+                }
+                else if (expiration instanceof TimeTag time) {
+                    expire = time;
+                }
+                else {
+                    Debug.echoError("Flag expiration is not a DurationTag or TimeTag!");
+                }
+            }
+            if (dataAction == null) {
+                Debug.echoError("Inventory flag must have a flag action!");
+            }
+        }
+        AbstractMap.SimpleEntry<Integer, InventoryTag> originEntry = originString != null ? Conversion.getInventory(new Argument(originString), scriptEntry) : null;
+        AbstractMap.SimpleEntry<Integer, InventoryTag> destinationEntry = destinationString != null ? Conversion.getInventory(new Argument(destinationString), scriptEntry) : null;
+        if (destinationEntry == null) {
+            InventoryTag inv = Utilities.getEntryPlayer(scriptEntry).getInventory();
+            if (inv == null) {
+                Debug.echoError("Must specify a Destination Inventory!");
+            }
+            destinationEntry = new AbstractMap.SimpleEntry<>(0, inv);
+        }
+        InventoryTag origin = originEntry != null ? originEntry.getValue() : null;
+        InventoryTag destination = destinationEntry.getValue();
+        int slotId = SlotHelper.nameToIndexFor(slot, destination.getInventory().getHolder());
         if (slotId < 0) {
             if (slotId == -1) {
-                Debug.echoError(scriptEntry, "The input '" + slot.asString() + "' is not a valid slot (unrecognized)!");
+                Debug.echoError(scriptEntry, "The input '" + slot + "' is not a valid slot (unrecognized)!");
             }
             else {
-                Debug.echoError(scriptEntry, "The input '" + slot.asString() + "' is not a valid slot (negative values are invalid)!");
+                Debug.echoError(scriptEntry, "The input '" + slot + "' is not a valid slot (negative values are invalid)!");
             }
             return;
         }
@@ -356,17 +302,17 @@ public class InventoryCommand extends AbstractCommand implements Listener {
             InventoryTag.trackTemporaryInventory(origin);
         }
         PlayerTag player = Utilities.getEntryPlayer(scriptEntry);
-        for (String action : actions) {
-            switch (Action.valueOf(action.toUpperCase())) {
+        for (Action action : actions) {
+            switch (action) {
                 // Make the attached player open the destination inventory
                 case OPEN:
                     // Use special method to make opening workbenches and anvils work properly
                     if ((destination.getInventoryType() == InventoryType.WORKBENCH || (destination.getInventoryType() == InventoryType.ANVIL && Denizen.supportsPaper)) && destination.getInventory().getLocation() == null) {
                         doSpecialOpen(destination.getInventoryType(), player.getPlayerEntity(), destination);
                     }
-                    else if (destinationEntity.getBukkitEntity() instanceof AbstractHorse) {
-                        Debug.log("horse");
-                        NMSHandler.entityHelper.openHorseInventory(player, destinationEntity);
+                    // Also check if the holder is a horse to do special NMS inventory open
+                    else if (destination.getIdHolder() instanceof EntityTag entity && entity.getLivingEntity() instanceof AbstractHorse) {
+                        NMSHandler.entityHelper.openHorseInventory(player, entity);
                     }
                     // Otherwise, open inventory as usual
                     else {
@@ -410,7 +356,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                         Debug.echoError(scriptEntry, "Missing origin argument!");
                         return;
                     }
-                    destination.setSlots(slotId, origin.getContents(), originentry.getKey());
+                    destination.setSlots(slotId, origin.getContents(), originEntry.getKey());
                     break;
 
                 // Keep only items from the origin's contents in the destination
@@ -484,14 +430,20 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                     }
                     break;
                 case ADJUST:
+                    if (dataAction == null) {
+                        Debug.echoError("Inventory adjust must have a mechanism!");
+                    }
                     ItemTag toAdjust = new ItemTag(destination.getInventory().getItem(slotId));
-                    toAdjust.safeAdjust(new Mechanism(mechanism.asString(), mechanismValue, scriptEntry.getContext()));
+                    Argument mechanismArgument = new Argument(dataAction);
+                    toAdjust.safeAdjust(new Mechanism(mechanismArgument.getPrefix().getValue(), mechanismArgument.object, scriptEntry.getContext()));
                     NMSHandler.itemHelper.setInventoryItem(destination.getInventory(), toAdjust.getItemStack(), slotId);
                     break;
                 case FLAG:
                     ItemTag toFlag = new ItemTag(destination.getInventory().getItem(slotId));
+                    Argument flagArgument = new Argument(dataAction);
+                    DataAction flagAction = DataActionHelper.parse(new FlagCommand.FlagActionProvider(), flagArgument, scriptEntry.context);
                     FlagCommand.FlagActionProvider provider = (FlagCommand.FlagActionProvider) flagAction.provider;
-                    provider.expiration = expiration;
+                    provider.expiration = expire;
                     provider.tracker = toFlag.getFlagTracker();
                     flagAction.execute(scriptEntry.context);
                     toFlag.reapplyTracker(provider.tracker);
@@ -501,7 +453,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         }
     }
 
-    public void replace(InventoryTag origin, InventoryTag destination) {
+    public static void replace(InventoryTag origin, InventoryTag destination) {
         // If the destination is smaller than our current inventory, add as many items as possible
         if (destination.getSize() < origin.getSize()) {
             destination.clear();
@@ -512,7 +464,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
         }
     }
 
-    public void remove(Inventory inventory, ItemStack[] items) {
+    public static void remove(Inventory inventory, ItemStack[] items) {
         for (ItemStack item : items) {
             if (item != null) {
                 inventory.removeItem(item.clone());

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.scripts.containers.core.InventoryScriptHelper;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Conversion;
 import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.inventory.InventoryTrackerSystem;
@@ -308,8 +309,8 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                         doSpecialOpen(destination.getInventoryType(), player.getPlayerEntity(), destination);
                     }
                     // Also check if the holder is a horse to do special NMS inventory open
-                    else if (destination.getIdHolder() instanceof EntityTag entity && entity.getLivingEntity() instanceof AbstractHorse) {
-                        NMSHandler.entityHelper.openHorseInventory(player, entity);
+                    else if (destination.getIdHolder() instanceof EntityTag entity && entity.getLivingEntity() instanceof AbstractHorse horse) {
+                        NMSHandler.entityHelper.openHorseInventory(player.getPlayerEntity(), horse);
                     }
                     // Otherwise, open inventory as usual
                     else {
@@ -427,7 +428,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                     break;
                 case ADJUST:
                     if (dataAction == null) {
-                        Debug.echoError("Inventory adjust must have a mechanism!");
+                        throw new InvalidArgumentsRuntimeException("Inventory adjust must have a mechanism!");
                     }
                     ItemTag toAdjust = new ItemTag(destination.getInventory().getItem(slotId));
                     Argument mechanismArgument = new Argument(dataAction);
@@ -436,7 +437,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
                     break;
                 case FLAG:
                     if (dataAction == null) {
-                        Debug.echoError("Inventory flag must have a flag action!");
+                        throw new InvalidArgumentsRuntimeException("Inventory flag must have a flag action!");
                     }
                     ItemTag toFlag = new ItemTag(destination.getInventory().getItem(slotId));
                     Argument flagArgument = new Argument(dataAction);

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.v1_17.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_17.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
@@ -26,6 +27,7 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
@@ -699,5 +701,11 @@ public class EntityHelperImpl extends EntityHelper {
     @Override
     public void setAggressive(org.bukkit.entity.Mob mob, boolean aggressive) {
         ((CraftMob) mob).getHandle().setAggressive(aggressive);
+    }
+
+    @Override
+    public void openHorseInventory(PlayerTag player, EntityTag horse) {
+        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
+        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
     }
 }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -7,7 +7,6 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.v1_17.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_17.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
@@ -27,7 +26,6 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
-import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
@@ -704,8 +702,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void openHorseInventory(PlayerTag player, EntityTag horse) {
-        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
-        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
+    public void openHorseInventory(Player player, AbstractHorse horse) {
+        net.minecraft.world.entity.animal.horse.AbstractHorse nmsHorse = ((CraftAbstractHorse) horse).getHandle();
+        ((CraftPlayer) player).getHandle().openHorseInventory(nmsHorse, nmsHorse.inventory);
     }
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -7,7 +7,6 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.v1_18.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_18.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
@@ -34,7 +33,6 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
-import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
@@ -781,8 +779,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void openHorseInventory(PlayerTag player, EntityTag horse) {
-        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
-        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
+    public void openHorseInventory(Player player, AbstractHorse horse) {
+        net.minecraft.world.entity.animal.horse.AbstractHorse nmsHorse = ((CraftAbstractHorse) horse).getHandle();
+        ((CraftPlayer) player).getHandle().openHorseInventory(nmsHorse, nmsHorse.inventory);
     }
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.v1_18.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_18.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
@@ -33,6 +34,7 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
@@ -776,5 +778,11 @@ public class EntityHelperImpl extends EntityHelper {
     @Override
     public void setAggressive(org.bukkit.entity.Mob mob, boolean aggressive) {
         ((CraftMob) mob).getHandle().setAggressive(aggressive);
+    }
+
+    @Override
+    public void openHorseInventory(PlayerTag player, EntityTag horse) {
+        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
+        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.nms.v1_19.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_19.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.nms.v1_19.impl.network.handlers.DenizenNetworkManagerImpl;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
@@ -39,6 +40,7 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
@@ -829,5 +831,11 @@ public class EntityHelperImpl extends EntityHelper {
     @Override
     public void setStepHeight(Entity entity, float stepHeight) {
         ((CraftEntity) entity).getHandle().setMaxUpStep(stepHeight);
+    }
+
+    @Override
+    public void openHorseInventory(PlayerTag player, EntityTag horse) {
+        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
+        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -8,7 +8,6 @@ import com.denizenscript.denizen.nms.v1_19.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_19.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.nms.v1_19.impl.network.handlers.DenizenNetworkManagerImpl;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
@@ -40,7 +39,6 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
-import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
@@ -834,8 +832,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void openHorseInventory(PlayerTag player, EntityTag horse) {
-        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
-        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
+    public void openHorseInventory(Player player, AbstractHorse horse) {
+        net.minecraft.world.entity.animal.horse.AbstractHorse nmsHorse = ((CraftAbstractHorse) horse).getHandle();
+        ((CraftPlayer) player).getHandle().openHorseInventory(nmsHorse, nmsHorse.inventory);
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.nms.v1_20.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_20.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkManagerImpl;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -42,6 +43,7 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.item.PrimedTnt;
@@ -844,5 +846,11 @@ public class EntityHelperImpl extends EntityHelper {
     public void modifyInternalEntityData(Entity entity, MapTag internalData) {
         SynchedEntityData nmsEntityData = ((CraftEntity) entity).getHandle().getEntityData();
         convertToInternalData(entity, internalData, (dataItem, converted) -> nmsEntityData.set(dataItem.getAccessor(), converted));
+    }
+
+    @Override
+    public void openHorseInventory(PlayerTag player, EntityTag horse) {
+        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
+        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -8,7 +8,6 @@ import com.denizenscript.denizen.nms.v1_20.ReflectionMappingsInfo;
 import com.denizenscript.denizen.nms.v1_20.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.network.handlers.DenizenNetworkManagerImpl;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -43,7 +42,6 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
-import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.item.PrimedTnt;
@@ -860,8 +858,8 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public void openHorseInventory(PlayerTag player, EntityTag horse) {
-        Horse craftHorse = ((CraftHorse) horse.entity).getHandle();
-        ((CraftPlayer) player.getPlayerEntity()).getHandle().openHorseInventory(craftHorse, craftHorse.inventory);
+    public void openHorseInventory(Player player, AbstractHorse horse) {
+        net.minecraft.world.entity.animal.horse.AbstractHorse nmsHorse = ((CraftAbstractHorse) horse).getHandle();
+        ((CraftPlayer) player).getHandle().openHorseInventory(nmsHorse, nmsHorse.inventory);
     }
 }


### PR DESCRIPTION
# Open Horse Inventories 🐎

### Changes:
- Use NMS magic to open horse inventories for players
- Update the `inventory` command to use `autoExecute`
  - The mechanism and flag actions have been merged into one to make sure the new linear arguments work properly. If they were separate, it can't tell the difference between them (if there is a way to separate them, let me know)
  - The `origin`, `destination`, and data action arguments use `@ArgRaw` so they can be turned into `Argument`s and have the same functionality (i.e. `Conversion.getInventory() and getting the mechanism/flag name) as the normal `execute()` version

A lot of this stuff seems a little "hacky"? There totally is better ways to do this but I just can't think of it. I couldn't find any other commands that read the prefix that use `autoExecute` so I was kind of flying solo on this one but it works and I've tested it. Ouch, sounds like the it works fallacy but this is why we have PR reviews, right :D

If you want me to revert the `autoExecute` changes and keep the horse related stuff let me know too :P

Requtested by TheLastBlockbender on [Discord](https://discord.com/channels/315163488085475337/1143349174994210847)