### PR TITLE
Implements the ``pierce_level`` property

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -36,6 +36,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityAreaEffectCloud.class, EntityTag.class);
         PropertyParser.registerProperty(EntityArmorBonus.class, EntityTag.class);
         PropertyParser.registerProperty(EntityArrowDamage.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityArrowPierceLevel.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAttributeBaseValues.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAttributeModifiers.class, EntityTag.class);
         PropertyParser.registerProperty(EntityArmorPose.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
@@ -12,7 +12,7 @@ public class EntityArrowPierceLevel extends EntityProperty<ElementTag> {
     // @name pierce_level
     // @input ElementTag(Number)
     // @description
-    // Controls the number of times this arrow can pierce through an entity. Must be between 0 and 127 times.
+    // The number of times an arrow will pierce through entities while flying. Must be between 0 and 127 times.
     // -->
 
     public static boolean describes(EntityTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
@@ -10,7 +10,7 @@ public class EntityArrowPierceLevel extends EntityProperty<ElementTag> {
     // <--[property]
     // @object EntityTag
     // @name pierce_level
-    // @input ElementTag(Decimal)
+    // @input ElementTag(Number)
     // @description
     // Controls the number of times this arrow can pierce through an entity. Must be between 0 and 127 times.
     // -->
@@ -26,7 +26,7 @@ public class EntityArrowPierceLevel extends EntityProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (mechanism.requireDouble()) {
+        if (mechanism.requireInteger()) {
             as(AbstractArrow.class).setPierceLevel(value.asInt());
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
@@ -12,7 +12,7 @@ public class EntityArrowPierceLevel extends EntityProperty<ElementTag> {
     // @name pierce_level
     // @input ElementTag(Number)
     // @description
-    // The number of entities an arrow will pierce through while flying. Must be between 0 and 127 times.
+    // The number of entities an arrow will pierce through while flying. Must be between 0 and 127.
     // -->
 
     public static boolean describes(EntityTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
@@ -12,7 +12,7 @@ public class EntityArrowPierceLevel extends EntityProperty<ElementTag> {
     // @name pierce_level
     // @input ElementTag(Number)
     // @description
-    // The number of times an arrow will pierce through entities while flying. Must be between 0 and 127 times.
+    // The number of entities an arrow will pierce through while flying. Must be between 0 and 127 times.
     // -->
 
     public static boolean describes(EntityTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityArrowPierceLevel.java
@@ -1,0 +1,42 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.entity.AbstractArrow;
+
+public class EntityArrowPierceLevel extends EntityProperty<ElementTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name pierce_level
+    // @input ElementTag(Decimal)
+    // @description
+    // Controls the number of times this arrow can pierce through an entity. Must be between 0 and 127 times.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof AbstractArrow;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(as(AbstractArrow.class).getPierceLevel());
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (mechanism.requireDouble()) {
+            as(AbstractArrow.class).setPierceLevel(value.asInt());
+        }
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "pierce_level";
+    }
+
+    public static void register() {
+        autoRegister("pierce_level", EntityArrowPierceLevel.class, ElementTag.class, false);
+    }
+}


### PR DESCRIPTION
# Additions
- ``EntityTag.pierce_level`` tag, which returns the current pierce level of the given arrow entity.
- ``EntityTag.pierce_level`` mech, which sets the pierce level of the given arrow entity.