### PR TITLE
Adds the ``BlockPreDispense`` event.

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -32,6 +32,7 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(AnvilBlockDamagedScriptEvent.class);
         ScriptEvent.registerScriptEvent(AreaEnterExitScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(BellRingScriptEvent.class);
+        ScriptEvent.registerScriptEvent(BlockPreDispenseScriptEvent.class);
         ScriptEvent.registerScriptEvent(CreeperIgnitesScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityAddToWorldScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityKnocksbackEntityScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -21,7 +21,8 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     //
     // @Cancellable true
     //
-    // @Triggers before a block dispenses an item. This event fires before the dispenser finishes processing its drop, allowing access to the slot trying to be dispensed and full cancellation of the dispenser's sounds.
+    // @Triggers before a block dispenses an item.
+    // This event fires before the dispenser finishes processing its drop, allowing access to the slot trying to be dispensed and full cancellation of the dispenser's sounds.
     //
     // @Context
     // <context.location> returns the LocationTag of the dispenser.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -13,7 +13,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
 
     // <--[event]
     // @Events
-    // <block> predispenses <item>
+    // <block> pre dispenses <item>
     //
     // @Group Block
     //
@@ -31,7 +31,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     // -->
 
     public BlockPreDispenseScriptEvent() {
-        registerCouldMatcher("<block> predispenses <item>");
+        registerCouldMatcher("<block> pre dispenses <item>");
     }
 
     public BlockPreDispenseEvent event;
@@ -45,7 +45,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
         if (!path.tryArgObject(0, location)) {
             return false;
         }
-        if (!path.tryArgObject(2, item)) {
+        if (!path.tryArgObject(3, item)) {
             return false;
         }
         return super.matches(path);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -13,7 +13,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
 
     // <--[event]
     // @Events
-    // <block> pre dispenses <item>
+    // <block> tries to dispense <item>
     //
     // @Group Block
     //
@@ -31,7 +31,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     // -->
 
     public BlockPreDispenseScriptEvent() {
-        registerCouldMatcher("<block> pre dispenses <item>");
+        registerCouldMatcher("<block> tries to dispense <item>");
     }
 
     public BlockPreDispenseEvent event;
@@ -45,7 +45,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
         if (!path.tryArgObject(0, location)) {
             return false;
         }
-        if (!path.tryArgObject(3, item)) {
+        if (!path.tryArgObject(4, item)) {
             return false;
         }
         return super.matches(path);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -1,0 +1,71 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import io.papermc.paper.event.block.BlockPreDispenseEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // <block> predispenses <item>
+    //
+    // @Group Block
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers before a block dispenses an item.
+    //
+    // @Context
+    // <context.location> returns the LocationTag of the dispenser.
+    // <context.item> returns the ItemTag of the item about to be dispensed.
+    // <context.slot> returns a ElementTag(Number) of the slot that will be dispensed from.
+    //
+    // -->
+
+    public BlockPreDispenseScriptEvent() {
+        registerCouldMatcher("<block> predispenses <item>");
+    }
+
+    public BlockPreDispenseEvent event;
+    public ItemTag item;
+    public LocationTag location;
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!path.tryArgObject(0, location)) {
+            return false;
+        }
+        if (!path.tryArgObject(2, item)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "item" -> item;
+            case "location" -> location;
+            case "slot" -> new ElementTag(event.getSlot() + 1);
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void onBlockPreDispense(BlockPreDispenseEvent event) {
+        this.event = event;
+        location = new LocationTag(event.getBlock().getLocation());
+        item = new ItemTag(event.getItemStack());
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -21,10 +21,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     //
     // @Cancellable true
     //
-    // @Triggers before a block dispenses an item.
-    //
-    // @description
-    // This event fires before the dispenser finishes processing its drop, allowing access to the slot trying to be dispensed and full cancellation of the dispenser's sounds.
+    // @Triggers before a block dispenses an item. This event fires before the dispenser finishes processing its drop, allowing access to the slot trying to be dispensed and full cancellation of the dispenser's sounds.
     //
     // @Context
     // <context.location> returns the LocationTag of the dispenser.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -22,7 +22,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     // @Cancellable true
     //
     // @Triggers before a block dispenses an item.
-    // This event fires before the dispenser finishes processing its drop, allowing access to the slot trying to be dispensed and full cancellation of the dispenser's sounds.
+    // This event fires before the dispenser fully processes a drop, allowing access to the dispensing slot and cancellation of sound effects.
     //
     // @Context
     // <context.location> returns the LocationTag of the dispenser.
@@ -38,6 +38,7 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     public BlockPreDispenseEvent event;
     public ItemTag item;
     public LocationTag location;
+
     @Override
     public boolean matches(ScriptPath path) {
         if (!runInCheck(path, location)) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -23,6 +23,9 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     //
     // @Triggers before a block dispenses an item.
     //
+    // @description
+    // This event fires before the dispenser finishes processing its drop, allowing access to the slot trying to be dispensed and full cancellation of the dispenser's sounds.
+    //
     // @Context
     // <context.location> returns the LocationTag of the dispenser.
     // <context.item> returns the ItemTag of the item about to be dispensed.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BlockPreDispenseScriptEvent.java
@@ -64,8 +64,8 @@ public class BlockPreDispenseScriptEvent extends BukkitScriptEvent implements Li
     @EventHandler
     public void onBlockPreDispense(BlockPreDispenseEvent event) {
         this.event = event;
-        location = new LocationTag(event.getBlock().getLocation());
         item = new ItemTag(event.getItemStack());
+        location = new LocationTag(event.getBlock().getLocation());
         fire(event);
     }
 }


### PR DESCRIPTION
# Additions
- The Paper-only``BlockPreDispense`` event, ``<block> predispenses <item>``.
  - ``<context.slot>`` returns a ``ElementTag(Number)`` of the slot that will be dispensed from.
  - ``<context.item>`` returns the ``ItemTag`` of the item about to be dispensed.
  - ``<context.location>`` returns the ``LocationTag`` of the dispenser.

Requested by [Yukiyahana](https://discord.com/channels/315163488085475337/1169387019798073414) on Discord.