### PR TITLE
Fixup `give` and `take` commands

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/GiveCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/GiveCommand.java
@@ -1,18 +1,17 @@
 package com.denizenscript.denizen.scripts.commands.item;
 
-import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizen.utilities.command.TabCompleteHelper;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
-import com.denizenscript.denizencore.scripts.commands.generator.*;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.utilities.depends.Depends;
-import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.command.TabCompleteHelper;
+import com.denizenscript.denizen.utilities.inventory.SlotHelper;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -22,7 +21,7 @@ public class GiveCommand extends AbstractCommand {
 
     public GiveCommand() {
         setName("give");
-        setSyntax("give [xp/<item>|...] (quantity:<#>) (unlimit_stack_size) (to:<inventory>) (slot:<slot>) (allowed_slots:<slot-matcher>) (ignore_leftovers)");
+        setSyntax("give [<item>|...] (quantity:<#>) (unlimit_stack_size) (to:<inventory>) (slot:<slot>) (allowed_slots:<slot-matcher>) (ignore_leftovers)");
         setRequiredArguments(1, 7);
         isProcedural = false;
         addRemappedPrefixes("to", "t");
@@ -31,14 +30,14 @@ public class GiveCommand extends AbstractCommand {
 
     // <--[command]
     // @Name Give
-    // @Syntax give [xp/<item>|...] (quantity:<#>) (unlimit_stack_size) (to:<inventory>) (slot:<slot>) (allowed_slots:<slot-matcher>) (ignore_leftovers)
+    // @Syntax give [<item>|...] (quantity:<#>) (unlimit_stack_size) (to:<inventory>) (slot:<slot>) (allowed_slots:<slot-matcher>) (ignore_leftovers)
     // @Required 1
     // @Maximum 7
     // @Short Gives the player an item or xp.
     // @Group item
     //
     // @Description
-    // Gives the linked player inventory items or xp.
+    // Gives the linked player items.
     //
     // Optionally specify a slot to put the items into. If the slot is already filled, the next available slot will be used.
     // If the inventory is full, the items will be dropped on the ground at the inventory's location.
@@ -52,19 +51,12 @@ public class GiveCommand extends AbstractCommand {
     // You may optionally specify "allowed_slots" to forcibly restrict the item to only be given to certain specific slots that match a slot-matcher.
     // You may optionally specify "ignore_leftovers" to cause leftover items to be ignored. If not specified, leftover items will be dropped.
     //
-    // If 'xp' is specified, this will give experience points to the linked player.
-    //
+    // To give xp to a player, use <@link command experience>.
     // To give money to a player, use <@link command money>.
     //
     // @Tags
-    // <PlayerTag.xp_level>
-    // <PlayerTag.xp_to_next_level>
     // <PlayerTag.inventory>
     // <entry[saveName].leftover_items> returns a ListTag of any item(s) that didn't fit into the inventory.
-    //
-    // @Usage
-    // Use to give XP to the player.
-    // - give xp quantity:10
     //
     // @Usage
     // Use to give an item to the player.
@@ -79,8 +71,6 @@ public class GiveCommand extends AbstractCommand {
     // - give diamond player:<[target]>
     // -->
 
-    public enum Type {__ITEM, MONEY, EXP, XP, EXPERIENCE}
-
     @Override
     public void addCustomTabCompletions(TabCompletionsBuilder tab) {
         TabCompleteHelper.tabCompleteItems(tab);
@@ -88,72 +78,49 @@ public class GiveCommand extends AbstractCommand {
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("quantity") @ArgPrefixed @ArgDefaultText("-1") double quantity,
-                                   @ArgName("type") @ArgPrefixed @ArgDefaultText("__item") Type type, // legacy compat
-                                   @ArgName("unlimit_stack_size") boolean unlimit_stack_size,
-                                   @ArgName("ignore_leftovers") boolean ignore_leftovers,
-                                   @ArgName("allowed_slots") @ArgPrefixed @ArgDefaultNull String allowed_slots,
+                                   @ArgName("unlimit_stack_size") boolean unlimitStackSize,
+                                   @ArgName("ignore_leftovers") boolean ignoreLeftovers,
+                                   @ArgName("allowed_slots") @ArgPrefixed @ArgDefaultNull String allowedSlots,
                                    @ArgName("to") @ArgPrefixed @ArgDefaultNull InventoryTag inventory,
                                    @ArgName("slot") @ArgPrefixed @ArgDefaultText("1") String slot,
                                    @ArgName("items") @ArgLinear @ArgSubType(ItemTag.class) List<ItemTag> items) {
-        if (type != Type.__ITEM && !Utilities.entryHasPlayer(scriptEntry)) {
-            throw new InvalidArgumentsRuntimeException("Must link a player to give money or XP!");
-        }
+        ListTag leftoverSave = new ListTag();
         if (inventory == null) {
             if (!Utilities.entryHasPlayer(scriptEntry)) {
                 throw new InvalidArgumentsRuntimeException("Must specify an inventory to give to!");
             }
             inventory = Utilities.getEntryPlayer(scriptEntry).getInventory();
         }
-        if (type == Type.MONEY) {
-            BukkitImplDeprecations.giveTakeMoney.warn(scriptEntry);
-        }
-        ListTag leftoverSave = new ListTag();
-        switch (type) {
-            case MONEY:
-                if (Depends.economy != null) {
-                    Depends.economy.depositPlayer(Utilities.getEntryPlayer(scriptEntry).getOfflinePlayer(), quantity < 0 ? 1 : quantity);
+        boolean limited = !unlimitStackSize;
+        for (ItemTag item : items) {
+            ItemStack is = new ItemStack(item.getItemStack());
+            if (is.getType() == Material.AIR) {
+                Debug.echoError("Cannot give air!");
+                continue;
+            }
+            if (quantity >= 0) {
+                is.setAmount((int) quantity);
+            }
+            int slotId = SlotHelper.nameToIndexFor(slot, inventory.getInventory().getHolder());
+            if (slotId == -1) {
+                Debug.echoError("The input '" + slot + "' is not a valid slot!");
+                return;
+            }
+            List<ItemStack> leftovers = inventory.addWithLeftovers(slotId, allowedSlots, limited, is);
+            for (ItemStack extraItem : leftovers) {
+                leftoverSave.addObject(new ItemTag(extraItem));
+            }
+            if (!leftovers.isEmpty() && !ignoreLeftovers) {
+                Debug.echoDebug(scriptEntry, "The inventory didn't have enough space, the rest of the items have been placed on the floor.");
+                Location inventoryLocation = inventory.getLocation();
+                if (inventoryLocation == null) {
+                    Debug.echoError("Cannot drop extras from failed give command - no inventory location.");
+                    return;
                 }
-                else {
-                    Debug.echoError("No economy loaded! Have you installed Vault and a compatible economy plugin?");
+                for (ItemStack leftoverItem : leftovers) {
+                    inventoryLocation.getWorld().dropItem(inventoryLocation, leftoverItem);
                 }
-                break;
-            case XP:
-            case EXP:
-            case EXPERIENCE:
-                Utilities.getEntryPlayer(scriptEntry).getPlayerEntity().giveExp((int) (quantity < 0 ? 1 : quantity));
-                break;
-            case __ITEM:
-                boolean limited = !unlimit_stack_size;
-                for (ItemTag item : items) {
-                    ItemStack is = new ItemStack(item.getItemStack());
-                    if (is.getType() == Material.AIR) {
-                        Debug.echoError("Cannot give air!");
-                        continue;
-                    }
-                    if (quantity >= 0) {
-                        is.setAmount((int) quantity);
-                    }
-                    int slotId = SlotHelper.nameToIndexFor(slot, inventory.getInventory().getHolder());
-                    if (slotId == -1) {
-                        Debug.echoError(scriptEntry, "The input '" + slot + "' is not a valid slot!");
-                        return;
-                    }
-                    List<ItemStack> leftovers = inventory.addWithLeftovers(slotId, allowed_slots, limited, is);
-                    for (ItemStack extraItem : leftovers) {
-                        leftoverSave.addObject(new ItemTag(extraItem));
-                    }
-                    if (!leftovers.isEmpty() && !ignore_leftovers) {
-                        Debug.echoDebug(scriptEntry, "The inventory didn't have enough space, the rest of the items have been placed on the floor.");
-                        for (ItemStack leftoverItem : leftovers) {
-                            if (inventory.getLocation() == null) {
-                                Debug.echoError("Cannot drop extras from failed give command - no inventory location.");
-                                return;
-                            }
-                            inventory.getLocation().getWorld().dropItem(inventory.getLocation(), leftoverItem);
-                        }
-                    }
-                }
-                break;
+            }
         }
         scriptEntry.saveObject("leftover_items", leftoverSave);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/TakeCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/TakeCommand.java
@@ -1,15 +1,15 @@
 package com.denizenscript.denizen.scripts.commands.item;
 
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.objects.InventoryTag;
+import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
-import com.denizenscript.denizen.objects.InventoryTag;
-import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -17,7 +17,7 @@ import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -33,14 +33,14 @@ public class TakeCommand extends AbstractCommand {
 
     public TakeCommand() {
         setName("take");
-        setSyntax("take [xp/iteminhand/cursoritem/bydisplay:<name>/bycover:<title>|<author>/slot:<slot>/flagged:<flag>/item:<matcher>] (quantity:<#>) (from:<inventory>)");
+        setSyntax("take [iteminhand/cursoritem/bydisplay:<name>/bycover:<title>|<author>/slot:<slot>/flagged:<flag>/item:<matcher>] (quantity:<#>) (from:<inventory>)");
         setRequiredArguments(1, 3);
         isProcedural = false;
     }
 
     // <--[command]
     // @Name Take
-    // @Syntax take [xp/iteminhand/cursoritem/bydisplay:<name>/bycover:<title>|<author>/slot:<slot>/flagged:<flag>/item:<matcher>] (quantity:<#>) (from:<inventory>)
+    // @Syntax take [iteminhand/cursoritem/bydisplay:<name>/bycover:<title>|<author>/slot:<slot>/flagged:<flag>/item:<matcher>] (quantity:<#>) (from:<inventory>)
     // @Required 1
     // @Maximum 3
     // @Short Takes an item from the player.
@@ -67,8 +67,6 @@ public class TakeCommand extends AbstractCommand {
     //
     // Using 'item:' will take items that match an advanced item matcher, using the system behind <@link language Advanced Object Matching>.
     //
-    // Using 'xp' will take experience from the player.
-    //
     // Flagged, Slot, ByDisplay, and Raw_Exact, all take a list as input to take multiple different item types at once.
     //
     // If no quantity is specified, exactly 1 item will be taken.
@@ -77,9 +75,10 @@ public class TakeCommand extends AbstractCommand {
     //
     // Optionally using 'from:' to specify a specific inventory to take from. If not specified, the linked player's inventory will be used.
     //
-    // The options 'iteminhand', 'cursoritem', and 'xp' require a linked player and will ignore the 'from:' inventory.
+    // The options 'iteminhand' and 'cursoritem' require a linked player and will ignore the 'from:' inventory.
     //
-    // To give money to a player, use <@link command money>.
+    // To take xp from a player, use <@link command experience>.
+    // To take money from a player, use <@link command money>.
     //
     // @Tags
     // <PlayerTag.item_in_hand>
@@ -126,7 +125,7 @@ public class TakeCommand extends AbstractCommand {
         for (Argument arg : scriptEntry) {
             if (!scriptEntry.hasObject("type")
                     && arg.matches("money", "coins")) {
-                BukkitImplDeprecations.giveTakeMoney.warn(scriptEntry);
+                BukkitImplDeprecations.takeMoney.warn(scriptEntry);
                 scriptEntry.addObject("type", Type.MONEY);
             }
             else if (!scriptEntry.hasObject("type")
@@ -309,6 +308,7 @@ public class TakeCommand extends AbstractCommand {
                 break;
             }
             case XP: {
+                BukkitImplDeprecations.takeExperience.warn(scriptEntry);
                 Utilities.getEntryPlayer(scriptEntry).getPlayerEntity().giveExp(-quantity.asInt());
                 break;
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -223,7 +223,7 @@ public class BukkitImplDeprecations {
 
     // Added 2021/08/30, made very-slow 2022/12/31.
     // 2022-year-end commonality: #23
-    public static Warning giveTakeMoney = new VerySlowWarning("giveTakeMoney", "The 'take' and 'give' commands option for 'money' are deprecated in favor of using the 'money' command.");
+    public static Warning takeMoney = new VerySlowWarning("takeMoney", "Using the 'take' command to take money is deprecated in favor of the 'money' command.");
 
     // Added 2022/01/30, made very-slow 2022/12/31.
     public static Warning entityItemEnderman = new VerySlowWarning("entityItemEnderman", "The property 'entity.item' for endermen has been replaced by 'entity.material' due to usage of block materials.");
@@ -292,6 +292,9 @@ public class BukkitImplDeprecations {
 
     // Added 2023/10/04, deprecate officially by 2027
     public static Warning translateLegacySyntax = new FutureWarning("translateLegacySyntax", "<&translate[...].with[...]> is deprecated in favor of the modern <&translate[key=...;with=...]> syntax.");
+
+    // Added 2023/11/16, deprecate officially by 2027
+    public static Warning takeExperience = new FutureWarning("takeExperience", "Using the 'take' command to take experience is deprecated in favor of the 'experience' command.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 


### PR DESCRIPTION
## Changes

- Fully removed the `xp` and `money` options from the `give` command, see [discussion](https://discord.com/channels/315163488085475337/1011496047811506227/1175103442671390731) on Discord.
- Changed some `snail_case` variable naming to proper `camelCase` in the `give` command.
- Added a variable for the inventory's location instead of calling the method every time in the `give` command.
- Deprecated taking xp in the `take` command.
- Renamed the `giveTakeMoney` deprecation warning to just `takeMoney`, as it no longer applies to `give` - let me know if that should be reverted due to deprecation warning tracking reasons.

## Notes

- Let me know if the `give` command should have `StrongWarning`s for giving money/xp, it'd make the logic a bit messier since you'd still need the entire handling for these inputs, but can be added if needed.