### PR TITLE
Fix bed spawn location tags/mechs

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
@@ -48,11 +48,7 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.util.Vector;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public abstract class ImprovedOfflinePlayer {
 
@@ -190,26 +186,33 @@ public abstract class ImprovedOfflinePlayer {
         markModified();
     }
 
-    public Location getBedSpawnLocation() {
-        return new Location(
-                Bukkit.getWorld(this.compound.getString("SpawnWorld")),
-                this.compound.getInt("SpawnX"),
-                this.compound.getInt("SpawnY"),
-                this.compound.getInt("SpawnZ")
-        );
+    public void setBedSpawnLocation(Location location) {
+        if (location == null && !compound.containsKey("SpawnDimension")) {
+            return;
+        }
+        CompoundTagBuilder builder = compound.createBuilder();
+        if (location != null) {
+            builder.putInt("SpawnX", location.getBlockX())
+                    .putInt("SpawnY", location.getBlockY())
+                    .putInt("SpawnZ", location.getBlockZ())
+                    .putFloat("SpawnAngle", location.getYaw())
+                    .putString("SpawnDimension", location.getWorld().getKey().toString());
+        }
+        else {
+            builder.remove("SpawnX").remove("SpawnY").remove("SpawnZ").remove("SpawnAngle").remove("SpawnDimension");
+        }
+        this.compound = builder.build();
+        markModified();
+        // Must save to file immediately to work with normal Spigot OfflinePlayer API
+        saveToFile();
     }
 
     public boolean isSpawnForced() {
         return this.compound.getBoolean("SpawnForced");
     }
 
-    public void setBedSpawnLocation(Location location, boolean override) {
-        this.compound = compound.createBuilder()
-                .putInt("SpawnX", (int) location.getX())
-                .putInt("SpawnY", (int) location.getY())
-                .putInt("SpawnZ", (int) location.getZ())
-                .putString("SpawnWorld", location.getWorld().getName())
-                .putBoolean("SpawnForced", override).build();
+    public void setSpawnForced(boolean spawnForced) {
+        this.compound = compound.createBuilder().putBoolean("SpawnForced", spawnForced).build();
         markModified();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -77,6 +77,8 @@ public abstract class PlayerHelper {
 
     public abstract void setSpawnForced(Player player, boolean forced);
 
+    public abstract Location getBedSpawnLocation(Player player);
+
     public abstract long getLastActionTime(Player player);
 
     public enum ProfileEditMode { ADD, UPDATE_DISPLAY, UPDATE_LATENCY, UPDATE_GAME_MODE, UPDATE_LISTED }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -468,7 +468,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             getPlayerEntity().setBedSpawnLocation(location);
         }
         else {
-            getNBTEditor().setBedSpawnLocation(location, getNBTEditor().isSpawnForced());
+            getNBTEditor().setBedSpawnLocation(location);
         }
     }
 
@@ -819,24 +819,27 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @returns LocationTag
         // @mechanism PlayerTag.bed_spawn_location
         // @description
-        // Returns the location of the player's bed spawn location, null if
-        // it doesn't exist.
+        // Returns the location of the player's bed spawn location, null if it doesn't exist.
         // Works with offline players.
         // -->
         registerOfflineTag(LocationTag.class, "bed_spawn", (attribute, object) -> {
+            Location bedSpawn = object.isOnline() ? NMSHandler.playerHelper.getBedSpawnLocation(object.getPlayerEntity()) : object.getOfflinePlayer().getBedSpawnLocation();
+            return bedSpawn != null ? new LocationTag(bedSpawn) : null;
+        });
+
+        // <--[tag]
+        // @attribute <PlayerTag.calculated_bed_spawn>
+        // @returns LocationTag
+        // @description
+        // Returns the player's calculated bed spawn location.
+        // This is a location around their set spawn where they could actually spawn, such as a safe block next to a bed.
+        // See <@link tag PlayerTag.bed_spawn> for the actual spawn location they have set.
+        // -->
+        registerOnlineOnlyTag(LocationTag.class, "calculated_bed_spawn", (attribute, object) -> {
             try {
                 NMSHandler.chunkHelper.changeChunkServerThread(object.getWorld());
-                Location loc;
-                if (object.isOnline()) {
-                    loc = object.getPlayerEntity().getBedSpawnLocation();
-                }
-                else {
-                    loc = object.getNBTEditor().getBedSpawnLocation();
-                }
-                if (loc == null) {
-                    return null;
-                }
-                return new LocationTag(loc);
+                Location calculatedBedSpawn = object.getPlayerEntity().getBedSpawnLocation();
+                return calculatedBedSpawn != null ? new LocationTag(calculatedBedSpawn) : null;
             }
             finally {
                 NMSHandler.chunkHelper.restoreServerThread(object.getWorld());
@@ -2618,6 +2621,48 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 object.getOfflinePlayer().setWhitelisted(input.asBoolean());
             }
         }, "is_whitelisted");
+
+
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name bed_spawn_location
+        // @input LocationTag
+        // @description
+        // Sets the bed location that the player respawns at.
+        // Provide no input to unset.
+        // @tags
+        // <PlayerTag.bed_spawn>
+        // -->
+        registerOfflineMechanism("bed_spawn_location", (object, mechanism) -> {
+            if (!mechanism.hasValue()) {
+                object.setBedSpawnLocation(null);
+            }
+            else if (mechanism.requireObject(LocationTag.class)) {
+                object.setBedSpawnLocation(mechanism.valueAsType(LocationTag.class));
+            }
+        });
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name spawn_forced
+        // @input ElementTag(Boolean)
+        // @description
+        // Sets whether the player's bed spawn location is forced (ie still valid even if a bed is missing).
+        // @tags
+        // <PlayerTag.spawn_forced>
+        // -->
+        registerOfflineMechanism("spawn_forced", ElementTag.class, (object, mechanism, input) -> {
+            if (!mechanism.requireBoolean()) {
+                return;
+            }
+            if (object.isOnline()) {
+                NMSHandler.playerHelper.setSpawnForced(object.getPlayerEntity(), input.asBoolean());
+            }
+            else {
+                object.getNBTEditor().setSpawnForced(input.asBoolean());
+            }
+        });
     }
 
     public static ObjectTagProcessor<PlayerTag> tagProcessor = new ObjectTagProcessor<>();
@@ -2659,6 +2704,16 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         });
     }
 
+    public static <P extends ObjectTag> void registerOnlineOnlyMechanism(String name, Class<P> paramType, Mechanism.ObjectInputMechRunnerInterface<PlayerTag, P> runnable) {
+        tagProcessor.registerMechanism(name, false, paramType, (object, mechanism, input) -> {
+            if (!object.isOnline()) {
+                mechanism.echoError("Player is not online, but mechanism '" + name + "' requires the player be online, for player: " + object.debuggable());
+                return;
+            }
+            runnable.run(object, mechanism, input);
+        });
+    }
+
     public static <P extends ObjectTag> void registerOfflineMechanism(String name, Class<P> paramType, Mechanism.ObjectInputMechRunnerInterface<PlayerTag, P> runnable, String... deprecatedVariants) {
         tagProcessor.registerMechanism(name, false, paramType, (object, mechanism, input) -> {
             if (!object.isValid()) {
@@ -2669,14 +2724,14 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         }, deprecatedVariants);
     }
 
-    public static <P extends ObjectTag> void registerOnlineOnlyMechanism(String name, Class<P> paramType, Mechanism.ObjectInputMechRunnerInterface<PlayerTag, P> runnable) {
-        tagProcessor.registerMechanism(name, false, paramType, (object, mechanism, input) -> {
-            if (!object.isOnline()) {
-                mechanism.echoError("Player is not online, but mechanism '" + name + "' requires the player be online, for player: " + object.debuggable());
+    public static void registerOfflineMechanism(String name, Mechanism.GenericMechRunnerInterface<PlayerTag> runnable, String... deprecatedVariants) {
+        tagProcessor.registerMechanism(name, false, (object, mechanism) -> {
+            if (!object.isValid()) {
+                mechanism.echoError("Player is not considered valid in mechanism '" + name + "' for player: " + object.debuggable());
                 return;
             }
-            runnable.run(object, mechanism, input);
-        });
+            runnable.run(object, mechanism);
+        }, deprecatedVariants);
     }
 
     @Override
@@ -3028,38 +3083,6 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // -->
         if (mechanism.matches("food_level") && mechanism.requireInteger()) {
             setFoodLevel(mechanism.getValue().asInt());
-        }
-
-        // <--[mechanism]
-        // @object PlayerTag
-        // @name bed_spawn_location
-        // @input LocationTag
-        // @description
-        // Sets the bed location that the player respawns at.
-        // @tags
-        // <PlayerTag.bed_spawn>
-        // -->
-        if (mechanism.matches("bed_spawn_location") && mechanism.requireObject(LocationTag.class)) {
-            setBedSpawnLocation(mechanism.valueAsType(LocationTag.class));
-        }
-
-        // <--[mechanism]
-        // @object PlayerTag
-        // @name spawn_forced
-        // @input ElementTag(Boolean)
-        // @description
-        // Sets whether the player's bed spawn location is forced (ie still valid even if a bed is missing).
-        // @tags
-        // <PlayerTag.spawn_forced>
-        // -->
-        if (mechanism.matches("spawn_forced") && mechanism.requireBoolean()) {
-            if (isOnline()) {
-                NMSHandler.playerHelper.setSpawnForced(getPlayerEntity(), mechanism.getValue().asBoolean());
-            }
-            else {
-                ImprovedOfflinePlayer editor = getNBTEditor();
-                editor.setBedSpawnLocation(editor.getBedSpawnLocation(), mechanism.getValue().asBoolean());
-            }
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -819,7 +819,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @returns LocationTag
         // @mechanism PlayerTag.bed_spawn_location
         // @description
-        // Returns the location of the player's bed spawn location, null if it doesn't exist.
+        // Returns the location of the player's bed spawn location, or null if it doesn't exist.
         // Works with offline players.
         // -->
         registerOfflineTag(LocationTag.class, "bed_spawn", (attribute, object) -> {

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
@@ -23,6 +23,7 @@ import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.mojang.authlib.GameProfile;
 import net.md_5.bungee.api.ChatColor;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.resources.ResourceLocation;
@@ -38,6 +39,7 @@ import net.minecraft.stats.ServerRecipeBook;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import org.bukkit.*;
 import org.bukkit.boss.BossBar;
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
@@ -363,6 +365,20 @@ public class PlayerHelperImpl extends PlayerHelper {
         catch (Throwable ex) {
             Debug.echoError(ex);
         }
+    }
+
+    @Override
+    public Location getBedSpawnLocation(Player player) {
+        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
+        BlockPos spawnPosition = nmsPlayer.getRespawnPosition();
+        if (spawnPosition == null) {
+            return null;
+        }
+        Level nmsWorld = MinecraftServer.getServer().getLevel(nmsPlayer.getRespawnDimension());
+        if (nmsWorld == null) {
+            return null;
+        }
+        return new Location(nmsWorld.getWorld(), spawnPosition.getX(), spawnPosition.getY(), spawnPosition.getZ(), nmsPlayer.getRespawnAngle(), 0);
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
@@ -26,6 +26,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.md_5.bungee.api.ChatColor;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -46,6 +47,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
 import org.bukkit.*;
 import org.bukkit.boss.BossBar;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
@@ -380,6 +382,20 @@ public class PlayerHelperImpl extends PlayerHelper {
         catch (Throwable ex) {
             Debug.echoError(ex);
         }
+    }
+
+    @Override
+    public Location getBedSpawnLocation(Player player) {
+        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
+        BlockPos spawnPosition = nmsPlayer.getRespawnPosition();
+        if (spawnPosition == null) {
+            return null;
+        }
+        Level nmsWorld = MinecraftServer.getServer().getLevel(nmsPlayer.getRespawnDimension());
+        if (nmsWorld == null) {
+            return null;
+        }
+        return new Location(nmsWorld.getWorld(), spawnPosition.getX(), spawnPosition.getY(), spawnPosition.getZ(), nmsPlayer.getRespawnAngle(), 0);
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
@@ -27,6 +27,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.md_5.bungee.api.ChatColor;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.protocol.game.*;
@@ -51,6 +52,7 @@ import net.minecraft.world.item.ItemCooldowns;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.BiomeManager;
 import net.minecraft.world.phys.AABB;
 import org.bukkit.*;
@@ -385,6 +387,20 @@ public class PlayerHelperImpl extends PlayerHelper {
         catch (Throwable ex) {
             Debug.echoError(ex);
         }
+    }
+
+    @Override
+    public Location getBedSpawnLocation(Player player) {
+        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
+        BlockPos spawnPosition = nmsPlayer.getRespawnPosition();
+        if (spawnPosition == null) {
+            return null;
+        }
+        Level nmsWorld = MinecraftServer.getServer().getLevel(nmsPlayer.getRespawnDimension());
+        if (nmsWorld == null) {
+            return null;
+        }
+        return new Location(nmsWorld.getWorld(), spawnPosition.getX(), spawnPosition.getY(), spawnPosition.getZ(), nmsPlayer.getRespawnAngle(), 0);
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
@@ -27,6 +27,7 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.md_5.bungee.api.ChatColor;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.protocol.common.ClientboundUpdateTagsPacket;
@@ -52,6 +53,7 @@ import net.minecraft.world.item.ItemCooldowns;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.BiomeManager;
 import net.minecraft.world.phys.AABB;
 import org.bukkit.*;
@@ -386,6 +388,20 @@ public class PlayerHelperImpl extends PlayerHelper {
         catch (Throwable ex) {
             Debug.echoError(ex);
         }
+    }
+
+    @Override
+    public Location getBedSpawnLocation(Player player) {
+        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
+        BlockPos spawnPosition = nmsPlayer.getRespawnPosition();
+        if (spawnPosition == null) {
+            return null;
+        }
+        Level nmsWorld = MinecraftServer.getServer().getLevel(nmsPlayer.getRespawnDimension());
+        if (nmsWorld == null) {
+            return null;
+        }
+        return new Location(nmsWorld.getWorld(), spawnPosition.getX(), spawnPosition.getY(), spawnPosition.getZ(), nmsPlayer.getRespawnAngle(), 0);
     }
 
     @Override


### PR DESCRIPTION
## Changes

- Removed `ImprovedOfflinePlayer#getBedSpawnLocation` in favor of using the `OfflinePlayer` API variant.
- `ImprovedOfflinePlayer#setBedSpawnLocation` Now allows setting it to `null`, updated for the new name/value format for worlds, and saves the yaw.
- `PlayerTag.bed_spawn` now uses the new `PlayerHelper#getBedSpawnLocation`.
- `PlayerTag.bed_spawn_location` mechanism can now take no input to unset the bed spawn location.
- `PlayerTag.bed_spawn_location` and `PlayerTag.spawn_forced` - updated to modern mechanism registration.

## Additions

- `ImprovedOfflinePlayer#setSpawnForced` - split up from `setBedSpawnLocation`, as it taking it as an extra parameter didn't make much sense.
- `PlayerHelper#getBedSpawnLocation` - gets a player's "raw" bed spawn location (the API method returns the location a player could spawn at, e.g. a block near a bed).
- `PlayerTag.calculated_bed_spawn` - returns a calculated bed spawn location, I.e. the location where a player could spawn (block next to a bed).
- `PlayerTag#registerOfflineMechanism` - an optional input variant.

## Notes

- `ImprovedOfflinePlayer#setBedSpawnLocation` has to immediately call `saveToFile` to make sure the values returned from the `OfflinePlayer` API are up-to-date.
- The `OfflinePlayer` method being used now has a bug where the yaw isn't loaded on 1.17.1 - we could make our own version to account for that, but since it's an extremely niche case on the oldest version I think it should be fine (especially since this is a Paper/Spigot bug).
- The tag and mechanism for bed spawn location have different names for some reason, let me know if one should be renamed to match the other.