### PR TITLE
Add support for void worlds with vanilla biomes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -4,6 +4,12 @@ import com.denizenscript.denizen.events.ScriptEventRegistry;
 import com.denizenscript.denizen.events.bukkit.SavesReloadEvent;
 import com.denizenscript.denizen.events.server.ServerPrestartScriptEvent;
 import com.denizenscript.denizen.events.server.ServerStartScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.interfaces.FakeArrow;
+import com.denizenscript.denizen.nms.interfaces.FakePlayer;
+import com.denizenscript.denizen.nms.interfaces.ItemProjectile;
+import com.denizenscript.denizen.npc.DenizenNPCHelper;
+import com.denizenscript.denizen.npc.TraitRegistry;
 import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.objects.PlayerTag;
@@ -25,22 +31,15 @@ import com.denizenscript.denizen.utilities.command.manager.messaging.Messaging;
 import com.denizenscript.denizen.utilities.debugging.BStatsMetricsLite;
 import com.denizenscript.denizen.utilities.debugging.DebugSubmit;
 import com.denizenscript.denizen.utilities.debugging.StatsRecord;
-import com.denizenscript.denizen.utilities.world.WorldListChangeTracker;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizen.utilities.entity.DenizenEntityType;
 import com.denizenscript.denizen.utilities.flags.PlayerFlagHandler;
 import com.denizenscript.denizen.utilities.flags.WorldFlagHandler;
 import com.denizenscript.denizen.utilities.implementation.DenizenCoreImplementation;
 import com.denizenscript.denizen.utilities.maps.DenizenMapManager;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.interfaces.FakeArrow;
-import com.denizenscript.denizen.nms.interfaces.FakePlayer;
-import com.denizenscript.denizen.nms.interfaces.ItemProjectile;
-import com.denizenscript.denizen.npc.TraitRegistry;
-import com.denizenscript.denizen.npc.DenizenNPCHelper;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
-import com.denizenscript.denizen.utilities.world.VoidGenerator1_17;
+import com.denizenscript.denizen.utilities.world.VoidGenerator;
+import com.denizenscript.denizen.utilities.world.WorldListChangeTracker;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
 import com.denizenscript.denizencore.objects.core.SecretTag;
@@ -50,10 +49,13 @@ import com.denizenscript.denizencore.scripts.ScriptHelper;
 import com.denizenscript.denizencore.scripts.commands.queue.RunLaterCommand;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
 import com.denizenscript.denizencore.utilities.debugging.StrongWarning;
 import com.denizenscript.denizencore.utilities.text.ConfigUpdater;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -603,9 +605,10 @@ public class Denizen extends JavaPlugin {
 
     @Override
     public ChunkGenerator getDefaultWorldGenerator(String worldName, String id) {
-        if (CoreUtilities.toLowerCase(id).equals("void")) {
-            return new VoidGenerator1_17();
-        }
-        return null;
+        return switch (CoreUtilities.toLowerCase(id)) {
+            case "void" -> new VoidGenerator(true);
+            case "void_biomes" -> new VoidGenerator(false);
+            default -> null;
+        };
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
@@ -3,7 +3,6 @@ package com.denizenscript.denizen.scripts.commands.world;
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.utilities.Settings;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -12,6 +11,7 @@ import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.Holdable;
 import com.denizenscript.denizencore.utilities.AsciiMatcher;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
@@ -44,8 +44,9 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
     // @Description
     // This command creates a new minecraft world with the specified name, or loads an existing world by that name.
     //
-    // Optionally specify a plugin-based world generator by it's generator ID.
-    // If you want an empty void world, you can use "generator:denizen:void".
+    // Optionally specify a plugin-based world generator by its generator ID.
+    // If you want an empty void world with a void biome, you can use "denizen:void".
+    // If you want an empty void world with vanilla biomes, you can use "denizen:void_biomes".
     //
     // Optionally specify additional generator settings as JSON input.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/world/VoidGenerator.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/world/VoidGenerator.java
@@ -5,14 +5,19 @@ import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.generator.WorldInfo;
 
-import java.util.Collections;
 import java.util.List;
 
-public class VoidGenerator1_17 extends ChunkGenerator {
+public class VoidGenerator extends ChunkGenerator {
+
+    final boolean setVoidBiome;
+
+    public VoidGenerator(boolean setVoidBiome) {
+        this.setVoidBiome = setVoidBiome;
+    }
 
     public static class VoidBiomeProvider extends BiomeProvider {
 
-        public static List<Biome> biomes = Collections.singletonList(Biome.THE_VOID);
+        public static final List<Biome> VOID_BIOME_LIST = List.of(Biome.THE_VOID);
 
         @Override
         public Biome getBiome(WorldInfo worldInfo, int i, int i1, int i2) {
@@ -21,14 +26,14 @@ public class VoidGenerator1_17 extends ChunkGenerator {
 
         @Override
         public List<Biome> getBiomes(WorldInfo worldInfo) {
-            return biomes;
+            return VOID_BIOME_LIST;
         }
     }
 
-    public static VoidBiomeProvider biomeProviderInstance = new VoidBiomeProvider();
+    public static final VoidBiomeProvider VOID_BIOME_PROVIDER = new VoidBiomeProvider();
 
     @Override
     public BiomeProvider getDefaultBiomeProvider(WorldInfo worldInfo) {
-        return biomeProviderInstance;
+        return setVoidBiome ? VOID_BIOME_PROVIDER : null;
     }
 }


### PR DESCRIPTION
Requested on [Discord](https://discord.com/channels/315163488085475337/1122476107149623316).
## Additions

- `denizen:void_biomes` generator, creates a void world that still has it's vanilla biomes.

## Changes

- Changed `Denizen#getDefaultWorldGenerator` to use a modern `switch` statment.
- Renamed `VoidGenerator1_17` to just `VoidGenerator`, as it's the only one currently.
- Added a `boolean setVoidBiome` to `VoidGenerator`, controls whether the biomes should be overridden to be `The Void`.
- Cleaned up some fields in `VoidGenerator` (mainly naming, and updating to `List#of`).