### PR TITLE
Fix custom payload and client brand handling

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -376,4 +376,10 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     public void kickPlayer(Player player, String message) {
         player.kick(PaperModule.parseFormattedText(message, ChatColor.WHITE));
     }
+
+    @Override
+    public String getClientBrand(Player player) {
+        String clientBrand = player.getClientBrandName();
+        return clientBrand != null ? clientBrand : "unknown";
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -50,7 +50,10 @@ public abstract class PlayerHelper {
 
     public abstract void resendRecipeDetails(Player player);
 
-    public abstract String getClientBrand(Player player);
+    // TODO: once 1.20 is the minimum supported version, remove from NMS in favor of Paper API
+    public String getClientBrand(Player player) {
+        throw new UnsupportedOperationException();
+    }
 
     public enum SkinLayer {
         CAPE(0),

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -50,7 +50,7 @@ public abstract class PlayerHelper {
 
     public abstract void resendRecipeDetails(Player player);
 
-    public abstract String getPlayerBrand(Player player);
+    public abstract String getClientBrand(Player player);
 
     public enum SkinLayer {
         CAPE(0),

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -1485,8 +1485,6 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @description
         // Returns the brand of the client, as sent via the "minecraft:brand" packet.
         // On normal clients, will say "vanilla". On broken clients, will say "unknown". Modded clients will identify themselves (though not guaranteed!).
-        // On Spigot servers, it may be ideal to change setting "Packets.Auto init" in the Denizen config to "true" to guarantee this tag functions as expected.
-        // This is not needed on Paper servers.
         // -->
         registerOnlineOnlyTag(ElementTag.class, "client_brand", (attribute, object) -> {
             return new ElementTag(PaperAPITools.instance.getClientBrand(object.getPlayerEntity()), true);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -1485,11 +1485,11 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @description
         // Returns the brand of the client, as sent via the "minecraft:brand" packet.
         // On normal clients, will say "vanilla". On broken clients, will say "unknown". Modded clients will identify themselves (though not guaranteed!).
-        // It may be ideal to change setting "Packets.Auto init" in the Denizen config to "true" to guarantee this tag functions as expected.
+        // On Spigot servers, it may be ideal to change setting "Packets.Auto init" in the Denizen config to "true" to guarantee this tag functions as expected.
+        // This is not needed on Paper servers.
         // -->
         registerOnlineOnlyTag(ElementTag.class, "client_brand", (attribute, object) -> {
-            NetworkInterceptHelper.enable();
-            return new ElementTag(NMSHandler.playerHelper.getPlayerBrand(object.getPlayerEntity()), true);
+            return new ElementTag(PaperAPITools.instance.getClientBrand(object.getPlayerEntity()), true);
         });
 
         // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.scripts.commands.entity.TeleportCommand;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptContainer;
+import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -204,5 +205,10 @@ public class PaperAPITools {
 
     public void kickPlayer(Player player, String message) {
         player.kickPlayer(message);
+    }
+
+    public String getClientBrand(Player player) {
+        NetworkInterceptHelper.enable();
+        return NMSHandler.playerHelper.getClientBrand(player);
     }
 }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
@@ -331,7 +331,7 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public String getPlayerBrand(Player player) {
+    public String getClientBrand(Player player) {
         return ((DenizenNetworkManagerImpl) ((CraftPlayer) player).getHandle().connection.connection).packetListener.brand;
     }
 

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
@@ -348,7 +348,7 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public String getPlayerBrand(Player player) {
+    public String getClientBrand(Player player) {
         return ((DenizenNetworkManagerImpl) ((CraftPlayer) player).getHandle().connection.connection).packetListener.brand;
     }
 

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
@@ -353,7 +353,7 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public String getPlayerBrand(Player player) {
+    public String getClientBrand(Player player) {
         return DenizenNetworkManagerImpl.getNetworkManager(player).packetListener.brand;
     }
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
@@ -355,11 +355,6 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public String getClientBrand(Player player) {
-        return DenizenNetworkManagerImpl.getNetworkManager(player).packetListener.brand;
-    }
-
-    @Override
     public byte getSkinLayers(Player player) {
         return ((CraftPlayer) player).getHandle().getEntityData().get(PLAYER_DATA_ACCESSOR_SKINLAYERS);
     }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
@@ -355,7 +355,7 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public String getPlayerBrand(Player player) {
+    public String getClientBrand(Player player) {
         return DenizenNetworkManagerImpl.getNetworkManager(player).packetListener.brand;
     }
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenPacketListenerImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenPacketListenerImpl.java
@@ -10,9 +10,7 @@ import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.scripts.commands.entity.FakeEquipCommand;
 import com.denizenscript.denizen.utilities.packets.DenizenPacketHandler;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
-import io.netty.buffer.Unpooled;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.ServerboundResourcePackPacket;
@@ -22,8 +20,6 @@ import net.minecraft.server.network.CommonListenerCookie;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_20_R2.block.CraftBlock;
 import org.bukkit.event.block.SignChangeEvent;
-
-import java.nio.charset.StandardCharsets;
 
 public class DenizenPacketListenerImpl extends AbstractListenerPlayInImpl {
 
@@ -93,12 +89,6 @@ public class DenizenPacketListenerImpl extends AbstractListenerPlayInImpl {
     public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
         if (NMSHandler.debugPackets) {
             Debug.log("Custom packet payload: " + packet.payload().id().toString() + " sent from " + player.getScoreboardName());
-        }
-        if (packet.payload().id().getNamespace().equals("minecraft") && packet.payload().id().getPath().equals("brand")) {
-            FriendlyByteBuf newData = new FriendlyByteBuf(Unpooled.buffer());
-            packet.payload().write(newData);
-            int i = newData.readVarInt(); // read off the varInt of length to get rid of it
-            brand = StandardCharsets.UTF_8.decode(newData.nioBuffer()).toString();
         }
         super.handleCustomPayload(packet);
     }


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1173706581322502144).
## Explanation
Our current `brand` payload handling used `CustomPacketPayload#write` to get the payload's contents, which in the case of `UnknownPayload` finished reading its `ByteBuf`, making Paper code that tries reading it later on down the line error.

## Additions

- `PaperAPITools#getClientBrand` - so that the Paper API for this could be used, see `Changes`.

## Changes

- Renamed `PlayerHelper#getPlayerBrand` to `getClientBrand` to better match other places/naming.
- Removed `DenizenPacketListenerImpl#handleCustomPayload`'s brand reading logic, as brands are now only sent during the configuration phase, and we now use proper API for this on Paper servers, so it would only ever be useful on BungeeCord Spigot servers (as Bungee breaks it to get sent during the play phase).
- ~~Changed `PlayerTag.client_brand`'s `Enable "Packets.Auto init"` meta to mention it's not needed on Paper servers.~~
- Removed `PlayerTag.client_brand`'s `Enable "Packets.Auto init"` meta.
- Removed the `1.20` NMS impl for `PlayerHelper#getClientBrand` and marked it for removal on 1.20.

## Notes

- We could re-add proper logic for `DenizenPacketListenerImpl#handleCustomPayload` (copying the buffer basically), but since this would only ever be useful on Spigot servers running under a BungeeCord proxy not sure if this is needed/worth the effort, especially since this only works due to a Bungee bug/breaking change.
- ~~About the `PlayerTag.client_brand` meta change, do we want to entirely remove that? technically it's still valid with the backing code broken.~~ removed.