### PR TITLE
`ItemTag.map_to_image`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -8,10 +8,12 @@ import com.denizenscript.denizen.objects.ItemTag;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.map.MapView;
 
 import java.util.List;
 import java.util.Map;
@@ -79,4 +81,7 @@ public abstract class ItemHelper {
         throw new UnsupportedOperationException();
     }
 
+    public byte[] renderMap(MapView mapView, Player player) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -49,15 +49,19 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_20_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R3.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftInventoryPlayer;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftRecipe;
+import org.bukkit.craftbukkit.v1_20_R3.map.CraftMapView;
 import org.bukkit.craftbukkit.v1_20_R3.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_20_R3.util.CraftNamespacedKey;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.map.MapView;
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -514,5 +518,10 @@ public class ItemHelperImpl extends ItemHelper {
             });
         }
         return customBrewingRecipes;
+    }
+
+    @Override
+    public byte[] renderMap(MapView mapView, Player player) {
+        return ((CraftMapView) mapView).render((CraftPlayer) player).buffer;
     }
 }


### PR DESCRIPTION
## Additions

- `ItemHelper#renderMap` - renders a `MapView` for a specific player.
- `ItemTag.map_to_image[<player>]` - returns an `ImageTag` of a filled map item's contents.

## Notes

- Currently `ItemHelper#renderMap` just returns the `byte[]` array of internal image color data, and `ItemTag.map_to_image` has logic to draw that into an image.
The format of the array seems to be consistent across versions, but it's still an implmentation detail, so let me know if having the code to draw it onto an image in the NMS impl is preferrable (didn't do it since it's technically duplicate code, but would also make sense to avoid depending on something that's technically an implementation detail).