### PR TITLE
Several minor cleanups/fixes

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/WardenChangesAngerLevelScriptEvent.java
@@ -48,10 +48,12 @@ public class WardenChangesAngerLevelScriptEvent extends BukkitScriptEvent implem
 
     public WardenChangesAngerLevelScriptEvent() {
         registerCouldMatcher("warden changes anger level");
-        this.<WardenChangesAngerLevelScriptEvent, ElementTag>registerDetermination("anger", ElementTag.class, (evt, context, anger) -> {
+        this.<WardenChangesAngerLevelScriptEvent, ElementTag>registerOptionalDetermination("anger", ElementTag.class, (evt, context, anger) -> {
             if (anger.isInt()) {
                 evt.event.setNewAnger(anger.asInt());
+                return true;
             }
+            return false;
         });
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -90,7 +90,9 @@ public interface BlockHelper {
         spawner.setSpawnedType(entity.getBukkitEntityType());
     }
 
-    Color getMapColor(Block block);
+    default Color getMapColor(Block block) { // TODO: once 1.20 is the minimum supported version, remove from NMS
+        return block.getBlockData().getMapColor();
+    }
 
     default void setVanillaTags(Material material, Set<String> tags) {
         throw new UnsupportedOperationException();

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -46,8 +46,6 @@ public abstract class EntityHelper {
 
     public abstract void forceInteraction(Player player, Location location);
 
-    public abstract Entity getEntity(World world, UUID uuid);
-
     public abstract CompoundTag getNbtData(Entity entity);
 
     public abstract void setNbtData(Entity entity, CompoundTag compoundTag);
@@ -382,7 +380,9 @@ public abstract class EntityHelper {
 
     public abstract void setBoundingBox(Entity entity, BoundingBox box);
 
-    public abstract List<Player> getPlayersThatSee(Entity entity);
+    public List<Player> getPlayersThatSee(Entity entity) { // TODO: once the minimum supported version is 1.20, remove from NMS
+        return List.copyOf(entity.getTrackedBy());
+    }
 
     public void sendAllUpdatePackets(Entity entity) {
         throw new UnsupportedOperationException();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -335,13 +335,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         if (rememberedEntities.containsKey(id)) {
             return rememberedEntities.get(id);
         }
-        for (World world : Bukkit.getWorlds()) {
-            Entity entity = NMSHandler.entityHelper.getEntity(world, id);
-            if (entity != null) {
-                return entity;
-            }
-        }
-        return null;
+        return Bukkit.getEntity(id);
     }
 
     public static boolean matches(String arg) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -2340,16 +2340,6 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         });
 
         // <--[tag]
-        // @attribute <PlayerTag.skin_model>
-        // @returns ElementTag
-        // @description
-        // Returns the player's skin model, either CLASSIC or SLIM.
-        // -->
-        registerOnlineOnlyTag(ElementTag.class, "skin_model", (attribute, object) -> {
-            return new ElementTag(object.getPlayerEntity().getPlayerProfile().getTextures().getSkinModel());
-        });
-
-        // <--[tag]
         // @attribute <PlayerTag.fake_entities>
         // @returns ListTag(EntityTag)
         // @description
@@ -2566,6 +2556,19 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             }
             return result;
         });
+
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+
+            // <--[tag]
+            // @attribute <PlayerTag.skin_model>
+            // @returns ElementTag
+            // @description
+            // Returns the player's skin model, either CLASSIC or SLIM.
+            // -->
+            registerOnlineOnlyTag(ElementTag.class, "skin_model", (attribute, object) -> {
+                return MultiVersionHelper1_18.getSkinModel(object.getPlayerEntity());
+            });
+        }
 
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoatType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoatType.java
@@ -4,8 +4,8 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import org.bukkit.TreeSpecies;
 import org.bukkit.entity.Boat;
@@ -38,10 +38,9 @@ public class EntityBoatType extends EntityProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag type, Mechanism mechanism) {
-        if (!mechanism.requireEnum(TreeSpecies.class)) {
-            return;
+        if (mechanism.requireEnum(TreeSpecies.class)) {
+            as(Boat.class).setWoodType(type.asEnum(TreeSpecies.class));
         }
-        as(Boat.class).setWoodType(type.asEnum(TreeSpecies.class));
     }
 
     public static void register() {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_18.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_18.java
@@ -1,0 +1,11 @@
+package com.denizenscript.denizen.utilities;
+
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.entity.Player;
+
+public class MultiVersionHelper1_18 {
+
+    public static ElementTag getSkinModel(Player player) {
+        return new ElementTag(player.getPlayerProfile().getTextures().getSkinModel());
+    }
+}

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -143,12 +143,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public Entity getEntity(World world, UUID uuid) {
-        net.minecraft.world.entity.Entity entity = ((CraftWorld) world).getHandle().getEntity(uuid);
-        return entity == null ? null : entity.getBukkitEntity();
-    }
-
-    @Override
     public CompoundTag getNbtData(Entity entity) {
         net.minecraft.nbt.CompoundTag compound = new net.minecraft.nbt.CompoundTag();
         ((CraftEntity) entity).getHandle().saveAsPassenger(compound);

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -160,12 +160,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public Entity getEntity(World world, UUID uuid) {
-        net.minecraft.world.entity.Entity entity = ((CraftWorld) world).getHandle().getEntity(uuid);
-        return entity == null ? null : entity.getBukkitEntity();
-    }
-
-    @Override
     public CompoundTag getNbtData(Entity entity) {
         net.minecraft.nbt.CompoundTag compound = new net.minecraft.nbt.CompoundTag();
         ((CraftEntity) entity).getHandle().saveAsPassenger(compound);

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -169,12 +169,6 @@ public class EntityHelperImpl extends EntityHelper {
     }
 
     @Override
-    public Entity getEntity(World world, UUID uuid) {
-        net.minecraft.world.entity.Entity entity = ((CraftWorld) world).getHandle().getEntity(uuid);
-        return entity == null ? null : entity.getBukkitEntity();
-    }
-
-    @Override
     public CompoundTag getNbtData(Entity entity) {
         net.minecraft.nbt.CompoundTag compound = new net.minecraft.nbt.CompoundTag();
         ((CraftEntity) entity).getHandle().saveAsPassenger(compound);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
@@ -277,12 +277,6 @@ public class BlockHelperImpl implements BlockHelper {
         }
     }
 
-    @Override
-    public Color getMapColor(Block block) {
-        CraftBlock craftBlock = (CraftBlock) block;
-        return Color.fromRGB(craftBlock.getNMS().getMapColor(craftBlock.getHandle(), craftBlock.getPosition()).col);
-    }
-
     public static final MethodHandle HOLDERSET_NAMED_BIND = ReflectionHelper.getMethodHandle(HolderSet.Named.class, ReflectionMappingsInfo.HolderSetNamed_bind_method, List.class);
     public static final MethodHandle HOLDER_REFERENCE_BINDTAGS = ReflectionHelper.getMethodHandle(Holder.Reference.class, ReflectionMappingsInfo.HolderReference_bindTags_method, Collection.class);
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -124,7 +124,7 @@ public class EntityHelperImpl extends EntityHelper {
         if (attrib != null) {
             damage = attrib.getValue();
         }
-        if (attacker.getEquipment() != null && attacker.getEquipment().getItemInMainHand() != null) {
+        if (attacker.getEquipment() != null) {
             damage += EnchantmentHelper.getDamageBonus(CraftItemStack.asNMSCopy(attacker.getEquipment().getItemInMainHand()), monsterType);
         }
         if (damage <= 0) {
@@ -175,12 +175,6 @@ public class EntityHelperImpl extends EntityHelper {
         ((CraftBlock) location.getBlock()).getNMS().use(((CraftWorld) location.getWorld()).getHandle(),
                 craftPlayer != null ? craftPlayer.getHandle() : null, InteractionHand.MAIN_HAND,
                 new BlockHitResult(new Vec3(0, 0, 0), null, CraftLocation.toBlockPosition(location), false));
-    }
-
-    @Override
-    public Entity getEntity(World world, UUID uuid) {
-        net.minecraft.world.entity.Entity entity = ((CraftWorld) world).getHandle().getEntity(uuid);
-        return entity == null ? null : entity.getBukkitEntity();
     }
 
     @Override
@@ -352,20 +346,6 @@ public class EntityHelperImpl extends EntityHelper {
         else {
             entity.teleport(location);
         }
-    }
-
-    @Override
-    public List<Player> getPlayersThatSee(Entity entity) {
-        ChunkMap tracker = ((ServerLevel) ((CraftEntity) entity).getHandle().level()).getChunkSource().chunkMap;
-        ChunkMap.TrackedEntity entityTracker = tracker.entityMap.get(entity.getEntityId());
-        ArrayList<Player> output = new ArrayList<>();
-        if (entityTracker == null) {
-            return output;
-        }
-        for (ServerPlayerConnection player : entityTracker.seenBy) {
-            output.add(player.getPlayer().getBukkitEntity());
-        }
-        return output;
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
@@ -446,18 +446,7 @@ public class PlayerHelperImpl extends PlayerHelper {
     public void refreshPlayer(Player player) {
         ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
         ServerLevel nmsWorld = (ServerLevel) nmsPlayer.level();
-        CommonPlayerSpawnInfo spawnInfo = new CommonPlayerSpawnInfo(
-                nmsWorld.dimensionTypeId(),
-                nmsWorld.dimension(),
-                BiomeManager.obfuscateSeed(nmsWorld.getSeed()),
-                nmsPlayer.gameMode.getGameModeForPlayer(),
-                nmsPlayer.gameMode.getPreviousGameModeForPlayer(),
-                nmsWorld.isDebug(),
-                nmsWorld.isFlat(),
-                nmsPlayer.getLastDeathLocation(),
-                nmsPlayer.getPortalCooldown()
-        );
-        nmsPlayer.connection.send(new ClientboundRespawnPacket(spawnInfo, ClientboundRespawnPacket.KEEP_ALL_DATA));
+        nmsPlayer.connection.send(new ClientboundRespawnPacket(nmsPlayer.createCommonSpawnInfo(nmsWorld), ClientboundRespawnPacket.KEEP_ALL_DATA));
         nmsPlayer.connection.teleport(player.getLocation());
         if (nmsPlayer.isPassenger()) {
            nmsPlayer.connection.send(new ClientboundSetPassengersPacket(nmsPlayer.getVehicle()));

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntityType;
 import org.bukkit.craftbukkit.v1_20_R3.util.CraftLocation;
 import org.bukkit.entity.EntityType;
 
@@ -167,17 +168,7 @@ public class BiomeNMSImpl extends BiomeNMS {
             return entityTypes;
         }
         for (MobSpawnSettings.SpawnerData meta : typeSettingList.unwrap()) {
-            try {
-                String n = net.minecraft.world.entity.EntityType.getKey(meta.type).getPath();
-                EntityType et = EntityType.fromName(n);
-                if (et == null) {
-                    et = EntityType.valueOf(n.toUpperCase(Locale.ENGLISH));
-                }
-                entityTypes.add(et);
-            }
-            catch (Throwable e) {
-                // Ignore the error. Likely from invalid entity type name output.
-            }
+            entityTypes.add(CraftEntityType.minecraftToBukkit(meta.type));
         }
         return entityTypes;
     }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -395,8 +395,8 @@ public class DenizenNetworkManagerImpl extends Connection {
         AttachPacketHandlers.registerHandlers();
         BlockLightPacketHandlers.registerHandlers();
         DenizenPacketHandlerPacketHandlers.registerHandlers();
-        DisguisePacketHandlers.registerHandlers();
         EntityMetadataPacketHandlers.registerHandlers();
+        DisguisePacketHandlers.registerHandlers();
         FakeBlocksPacketHandlers.registerHandlers();
         FakeEquipmentPacketHandlers.registerHandlers();
         FakePlayerPacketHandlers.registerHandlers();

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
@@ -31,19 +31,13 @@ public class DisguisePacketHandlers {
     public static void registerHandlers() {
         registerPacketHandler(ClientboundSetEntityDataPacket.class, ClientboundSetEntityDataPacket::id, DisguisePacketHandlers::processEntityDataPacket);
         registerPacketHandler(ClientboundUpdateAttributesPacket.class, ClientboundUpdateAttributesPacket::getEntityId, DisguisePacketHandlers::processAttributesPacket);
-        //registerPacketHandler(ClientboundAddPlayerPacket.class, ClientboundAddPlayerPacket::getEntityId, DisguisePacketHandlers::sendDisguiseForPacket);
         registerPacketHandler(ClientboundAddEntityPacket.class, ClientboundAddEntityPacket::getId, DisguisePacketHandlers::sendDisguiseForPacket);
         registerPacketHandler(ClientboundTeleportEntityPacket.class, ClientboundTeleportEntityPacket::getId, DisguisePacketHandlers::processTeleportPacket);
         registerPacketHandler(ClientboundMoveEntityPacket.Rot.class, ClientboundMoveEntityPacket::getEntity, DisguisePacketHandlers::processMoveEntityRotPacket);
         registerPacketHandler(ClientboundMoveEntityPacket.PosRot.class, ClientboundMoveEntityPacket::getEntity, DisguisePacketHandlers::processMoveEntityPosRotPacket);
     }
 
-    public static final Field TELEPORT_PACKET_ENTITY_ID = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_id, int.class);
-    public static final Field TELEPORT_PACKET_X = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_x, double.class);
-    public static final Field TELEPORT_PACKET_Y = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_y, double.class);
-    public static final Field TELEPORT_PACKET_Z = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_z, double.class);
     public static final Field TELEPORT_PACKET_YAW = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_yRot, byte.class);
-    public static final Field TELEPORT_PACKET_PITCH = ReflectionHelper.getFields(ClientboundTeleportEntityPacket.class).get(ReflectionMappingsInfo.ClientboundTeleportEntityPacket_xRot, byte.class);
 
     private static boolean antiDuplicate = false;
 
@@ -120,13 +114,8 @@ public class DisguisePacketHandlers {
 
     public static ClientboundTeleportEntityPacket processTeleportPacket(DenizenNetworkManagerImpl networkManager, ClientboundTeleportEntityPacket teleportEntityPacket, DisguiseCommand.TrackedDisguise disguise) throws IllegalAccessException {
         if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
-            ClientboundTeleportEntityPacket pNew = new ClientboundTeleportEntityPacket(((CraftEntity) disguise.entity.getBukkitEntity()).getHandle());
-            TELEPORT_PACKET_ENTITY_ID.setInt(pNew, teleportEntityPacket.getId());
-            TELEPORT_PACKET_X.setDouble(pNew, teleportEntityPacket.getX());
-            TELEPORT_PACKET_Y.setDouble(pNew, teleportEntityPacket.getY());
-            TELEPORT_PACKET_Z.setDouble(pNew, teleportEntityPacket.getZ());
+            ClientboundTeleportEntityPacket pNew = new ClientboundTeleportEntityPacket(DenizenNetworkManagerImpl.copyPacket(teleportEntityPacket));
             TELEPORT_PACKET_YAW.setByte(pNew, EntityAttachmentHelper.adaptedCompressedAngle(teleportEntityPacket.getyRot(), 180));
-            TELEPORT_PACKET_PITCH.setByte(pNew, teleportEntityPacket.getxRot());
             return pNew;
         }
         return sendDisguiseForPacket(networkManager, teleportEntityPacket, disguise);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/HiddenEntitiesPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/HiddenEntitiesPacketHandlers.java
@@ -11,7 +11,6 @@ import net.minecraft.world.entity.Entity;
 public class HiddenEntitiesPacketHandlers {
 
     public static void registerHandlers() {
-        //DenizenNetworkManagerImpl.registerPacketHandler(ClientboundAddPlayerPacket.class, HiddenEntitiesPacketHandlers::processHiddenEntitiesForPacket);
         DenizenNetworkManagerImpl.registerPacketHandler(ClientboundAddEntityPacket.class, HiddenEntitiesPacketHandlers::processHiddenEntitiesForPacket);
         DenizenNetworkManagerImpl.registerPacketHandler(ClientboundAddExperienceOrbPacket.class, HiddenEntitiesPacketHandlers::processHiddenEntitiesForPacket);
         DenizenNetworkManagerImpl.registerPacketHandler(ClientboundMoveEntityPacket.Rot.class, HiddenEntitiesPacketHandlers::processHiddenEntitiesForPacket);
@@ -33,9 +32,6 @@ public class HiddenEntitiesPacketHandlers {
         try {
             int ider = -1;
             Entity e = null;
-            /*if (packet instanceof ClientboundAddPlayerPacket) {
-                ider = ((ClientboundAddPlayerPacket) packet).getEntityId();
-            }*/
             if (packet instanceof ClientboundAddEntityPacket) {
                 ider = ((ClientboundAddEntityPacket) packet).getId();
             }


### PR DESCRIPTION
## Changes

- Makes `WardenChangesAngerLevelScriptEvent`'s determination registration properly use `registerOptionalDetermination` to return `false` for invalid input.
- Added a default implementation for `BlockHelper#getMapColor` using Spigot's new `BlockData#getMapColor`.
- Removed `EntityHelper#getEntity(World, UUID)` in favor of Spigot's `Bukkit#getEntity(UUID)`.
- Added a default implementation for `EntityHelper#getPlayersThatSee` using Spigot's new `Entity#getTrackedBy`.
- `EntityTag#getEntityForID` now uses `Bukkit#getEntity`.
- Replaced redundant early return usage in `EntityBoatType#setPropertyValue`.
- Removed the redundant `attacker.getEquipment().getItemInMainHand() != null` from `EntityHelperImpl(1.20)#getDamageTo`, as `getItemInMainHand` isn't nullable.
- `PlayerHelperImpl(1.20)#refreshPlayer` now uses `ServerPlayer#createCommonSpawnInfo` instead of manually creating the spawn info.
- `BiomeNMSImpl(1.20)#getSpawnableEntities` now uses the new `CraftEntityType#minecraftToBukkit` instead of the existing hacky conversion.
- Moved the `DisguisePacketHandlers` to after the `EntityMetadataPacketHandlers`, to avoid stuff like the `invisible` command overriding disguised entity's visibility.
- `DisguisePacketHandlers#processTeleportPacket` now uses `DenizenNetworkManagerImpl#copyPacket` instead of manually creating a new packet and copying values over (which also means relevant reflection constants were removed).
- Removed some old commented out `ClientboundAddPlayerPacket` handling code.
- Fixed `PlayerTag.skin_model` breaking on 1.17 because Spigot's player profile API didn't exist back then, and uses a `MultiVersionHelper` because Java doesn't like it when enums that don't exist are referenced.

## Additions

- `MultiVersionHelper1_18` - used by `PlayerTag.skin_model`, because that API didn't exist before 1.18 and it has an enum.