### PR TITLE
Sign updates

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -23,6 +23,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.*;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -99,8 +100,23 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     }
 
     @Override
+    public String[] getSignLines(Sign sign, Side side) {
+        String[] output = new String[4];
+        int i = 0;
+        for (Component component : sign.getSide(side).lines()) {
+            output[i++] = PaperModule.stringifyComponent(component);
+        }
+        return output;
+    }
+
+    @Override
     public void setSignLine(Sign sign, int line, String text) {
         sign.line(line, PaperModule.parseFormattedText(text == null ? "" : text, ChatColor.BLACK));
+    }
+
+    @Override
+    public void setSignLine(Sign sign, Side side, int line, String text) {
+        sign.getSide(side).line(line, PaperModule.parseFormattedText(text == null ? "" : text, ChatColor.BLACK));
     }
 
     @Override

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -24,6 +24,7 @@ import net.md_5.bungee.api.ChatColor;
 import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -136,6 +137,17 @@ public class PaperAPIToolsImpl extends PaperAPITools {
             components.add(PaperModule.parseFormattedText(line, ChatColor.BLACK));
         }
         player.sendSignChange(loc, components);
+    }
+
+    @Override
+    public void sendSignUpdate(Player player, Location loc, String[] text, Side side) {
+        Sign sign = (Sign)loc.getBlock().getState();
+        SignSide signSide = sign.getSide(side);
+        signSide.lines().clear();
+        for (String s : text) {
+            signSide.lines().add(PaperModule.parseFormattedText((s == null ? "" : s), ChatColor.BLACK));
+        }
+        player.sendBlockUpdate(loc, sign);
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.objects;
 
+import com.denizenscript.denizen.utilities.MultiVersionHelper1_20;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
@@ -18,10 +19,11 @@ import com.denizenscript.denizen.utilities.flags.DataPersistenceFlagTracker;
 import com.denizenscript.denizen.utilities.flags.LocationFlagSearchHelper;
 import com.denizenscript.denizen.utilities.world.PathFinder;
 import com.denizenscript.denizen.utilities.world.WorldListChangeTracker;
+import com.denizenscript.denizencore.objects.core.*;
+import com.denizenscript.denizencore.utilities.EnumHelper;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizencore.objects.core.*;
 import com.denizenscript.denizencore.objects.notable.Notable;
 import com.denizenscript.denizencore.objects.notable.Note;
 import com.denizenscript.denizencore.objects.notable.NoteManager;
@@ -40,6 +42,7 @@ import org.bukkit.block.*;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
+import org.bukkit.block.sign.Side;
 import org.bukkit.block.structure.Mirror;
 import org.bukkit.block.structure.StructureRotation;
 import org.bukkit.block.structure.UsageMode;
@@ -1234,19 +1237,30 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
 
         // <--[tag]
         // @attribute <LocationTag.sign_contents>
-        // @returns ListTag
+        // @returns ObjectTag
         // @mechanism LocationTag.sign_contents
         // @group world
         // @description
+        // Pre 1.20
         // Returns a list of lines on a sign.
+        // 1.20+
+        // Returns a map of each side and lines on that side.
         // -->
-        tagProcessor.registerTag(ListTag.class, "sign_contents", (attribute, object) -> {
-            if (object.getBlockStateForTag(attribute) instanceof Sign) {
-                return new ListTag(Arrays.asList(PaperAPITools.instance.getSignLines(((Sign) object.getBlockStateForTag(attribute)))));
-            }
-            else {
+        tagProcessor.registerTag(ObjectTag.class, "sign_contents", (attribute, object) -> {
+            BlockState state = object.getBlockStateForTag(attribute);
+            if (!(state instanceof Sign)) {
+                attribute.echoError("Location is not a valid Sign block.");
                 return null;
             }
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                String[][] contents = MultiVersionHelper1_20.getSignLines((Sign) state);
+                MapTag content = new MapTag();
+                content.putObject("front", new ListTag(Arrays.asList(contents[0])));
+                content.putObject("back", new ListTag(Arrays.asList(contents[1])));
+                return content;
+            }
+            return new ListTag(Arrays.asList(PaperAPITools.instance.getSignLines(((Sign) state))));
+
         });
 
         // <--[tag]
@@ -4122,38 +4136,77 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
 
         // <--[tag]
         // @attribute <LocationTag.sign_glowing>
-        // @returns ElementTag(Boolean)
+        // @returns ObjectTag
         // @mechanism LocationTag.sign_glowing
         // @group world
         // @description
+        // Pre 1.20
         // Returns whether the location is a Sign block that is glowing.
+        // 1.20+
+        // Returns a map of each side and whether the side is glowing.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "sign_glowing", (attribute, object) -> {
+        tagProcessor.registerTag(ObjectTag.class, "sign_glowing", (attribute, object) -> {
             BlockState state = object.getBlockStateForTag(attribute);
             if (!(state instanceof Sign)) {
                 attribute.echoError("Location is not a valid Sign block.");
                 return null;
+            }
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                MapTag glowMap = new MapTag();
+                glowMap.putObject("front", new ElementTag(((Sign) state).getSide(Side.FRONT).isGlowingText()));
+                glowMap.putObject("back", new ElementTag(((Sign) state).getSide(Side.BACK).isGlowingText()));
+                return glowMap;
             }
             return new ElementTag(((Sign) state).isGlowingText());
         });
 
         // <--[tag]
         // @attribute <LocationTag.sign_glow_color>
-        // @returns ElementTag
+        // @returns ObjectTag
         // @mechanism LocationTag.sign_glow_color
         // @group world
         // @description
+        // Pre 1.20
         // Returns the name of the glow-color of the sign at the location.
+        // 1.20+
+        // Returns a map of each side and the name of the color.
         // See also <@link tag LocationTag.sign_glowing>
         // -->
-        tagProcessor.registerTag(ElementTag.class, "sign_glow_color", (attribute, object) -> {
+        tagProcessor.registerTag(ObjectTag.class, "sign_glow_color", (attribute, object) -> {
             BlockState state = object.getBlockStateForTag(attribute);
             if (!(state instanceof Sign)) {
                 attribute.echoError("Location is not a valid Sign block.");
                 return null;
             }
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                MapTag glowMap = new MapTag();
+                glowMap.putObject("front", new ElementTag(((Sign) state).getSide(Side.FRONT).getColor()));
+                glowMap.putObject("back", new ElementTag(((Sign) state).getSide(Side.BACK).getColor()));
+                return glowMap;
+            }
             return new ElementTag(((Sign) state).getColor());
         });
+
+        // <--[tag]
+        // @attribute <LocationTag.sign_waxed>
+        // @returns ElementTag(Boolean)
+        // @mechanism LocationTag.sign_waxed
+        // @group world
+        // @description
+        // Returns whether the location is a Sign block that is waxed.
+        // See also <@link tag LocationTag.sign_glowing>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            tagProcessor.registerTag(ObjectTag.class, "sign_waxed", (attribute, object) -> {
+                BlockState state = object.getBlockStateForTag(attribute);
+                if (!(state instanceof Sign)) {
+                    attribute.echoError("Location is not a valid Sign block.");
+                    return null;
+                }
+                return new ElementTag(((Sign) state).isWaxed());
+            });
+        }
+
 
         // <--[tag]
         // @attribute <LocationTag.map_color>
@@ -4672,22 +4725,65 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @tags
         // <LocationTag.sign_contents>
         // -->
-        if (mechanism.matches("sign_contents") && getBlockState() instanceof Sign) {
-            Sign state = (Sign) getBlockState();
-            for (int i = 0; i < 4; i++) {
-                PaperAPITools.instance.setSignLine(state, i, "");
-            }
-            ListTag list = mechanism.valueAsType(ListTag.class);
-            CoreUtilities.fixNewLinesToListSeparation(list);
-            if (list.size() > 4) {
-                mechanism.echoError("Sign can only hold four lines!");
-            }
-            else {
-                for (int i = 0; i < list.size(); i++) {
-                    PaperAPITools.instance.setSignLine(state, i, list.get(i));
+        if (mechanism.matches("sign_contents")) {
+            BlockState state = getBlockState();
+            if (!(state instanceof Sign sign)) {
+                mechanism.echoError("'sign_contents' mechanism can only be called on Sign blocks.");
+            } else {
+                for (int i = 0; i < 4; i++) {
+                    PaperAPITools.instance.setSignLine(sign, i, "");
                 }
+                ListTag list = mechanism.valueAsType(ListTag.class);
+                CoreUtilities.fixNewLinesToListSeparation(list);
+                if (list.size() > 4) {
+                    mechanism.echoError("Sign can only hold four lines!");
+                } else {
+                    for (int i = 0; i < list.size(); i++) {
+                        PaperAPITools.instance.setSignLine(sign, i, list.get(i));
+                    }
+                }
+                state.update();
             }
-            state.update();
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_sides_contents
+        // @input MapTag
+        // @description
+        // Sets the contents of each side for a sign block.
+        // The input map keys are either 'Front' or 'Back'
+        // @tags
+        // <LocationTag.sign_contents>
+        // -->
+        if (mechanism.matches("sign_sides_contents") && mechanism.requireObject(MapTag.class)) {
+            BlockState state = getBlockState();
+            if (!(state instanceof Sign sign)) {
+                mechanism.echoError("'sign_sides_contents' mechanism can only be called on Sign blocks.");
+            } else {
+                MapTag glowMap = mechanism.valueAsType(MapTag.class);
+                for (Map.Entry<StringHolder, ObjectTag> entry : glowMap.map.entrySet()) {
+                    if (EnumHelper.get(Side.class).valuesMapLower.containsKey(entry.getKey().str)) {
+                        Side side = Side.valueOf(entry.getKey().toString().toUpperCase());
+                        for (int i = 0; i < 4; i++) {
+                            sign.getSide(side).setLine(i, "");
+                        }
+                        ListTag list = entry.getValue().asType(ListTag.class, mechanism.context);
+                        CoreUtilities.fixNewLinesToListSeparation(list);
+                        if (list.size() > 4) {
+                            mechanism.echoError("Sign can only hold four lines!");
+                        } else {
+                            for (int i = 0; i < list.size(); i++) {
+                                sign.getSide(side).setLine(i, list.get(i));
+                            }
+                        }
+                        sign.getSide(side).setGlowingText(entry.getValue().asElement().asBoolean());
+                    } else {
+                        mechanism.echoError("Unknown sign side " + entry.getKey());
+                    }
+                }
+                state.update();
+            }
         }
 
         // <--[mechanism]
@@ -5345,13 +5441,43 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // -->
         if (mechanism.matches("sign_glowing") && mechanism.requireBoolean()) {
             BlockState state = getBlockState();
-            if (!(state instanceof Sign)) {
+            if (!(state instanceof Sign sign)) {
                 mechanism.echoError("'sign_glowing' mechanism can only be called on Sign blocks.");
             }
             else {
-                Sign sign = (Sign) state;
                 sign.setGlowingText(mechanism.getValue().asBoolean());
                 sign.update();
+            }
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_sides_glowing
+        // @input MapTag
+        // @description
+        // Changes whether each side for a sign block is glowing.
+        // The input map keys are either 'Front' or 'Back'
+        // @tags
+        // <LocationTag.sign_glow_color>
+        // <LocationTag.sign_glowing>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("sign_sides_glowing") && mechanism.requireObject(MapTag.class)) {
+                BlockState state = getBlockState();
+                if (!(state instanceof Sign sign)) {
+                    mechanism.echoError("'sign_sides_glowing' mechanism can only be called on Sign blocks.");
+                } else {
+                    MapTag glowMap = mechanism.valueAsType(MapTag.class);
+                    for (Map.Entry<StringHolder, ObjectTag> entry : glowMap.map.entrySet()) {
+                        if (EnumHelper.get(Side.class).valuesMapLower.containsKey(entry.getKey().str)) {
+                            Side side = Side.valueOf(entry.getKey().toString().toUpperCase());
+                            sign.getSide(side).setGlowingText(entry.getValue().asElement().asBoolean());
+                        } else {
+                            mechanism.echoError("Unknown sign side " + entry.getKey());
+                        }
+                    }
+                    sign.update();
+                }
             }
         }
 
@@ -5370,13 +5496,72 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // -->
         if (mechanism.matches("sign_glow_color") && mechanism.requireEnum(DyeColor.class)) {
             BlockState state = getBlockState();
-            if (!(state instanceof Sign)) {
+            if (!(state instanceof Sign sign)) {
                 mechanism.echoError("'sign_glow_color' mechanism can only be called on Sign blocks.");
             }
             else {
-                Sign sign = (Sign) state;
                 sign.setColor(mechanism.getValue().asEnum(DyeColor.class));
                 sign.update();
+            }
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_sides_glow_color
+        // @input MapTag
+        // @description
+        // Changes the glow color of each side of the sign.
+        // For the list of possible colors, see <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html>.
+        // If a sign is not glowing, this is equivalent to applying a chat color to the sign.
+        // The input map keys are either 'Front' or 'Back'
+        // Use <@link mechanism LocationTag.sign_glowing> to toggle whether the sign is glowing.
+        // @tags
+        // <LocationTag.sign_glow_color>
+        // <LocationTag.sign_glowing>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("sign_sides_glow_color") && mechanism.requireObject(MapTag.class)) {
+                BlockState state = getBlockState();
+                if (!(state instanceof Sign sign)) {
+                    mechanism.echoError("'sign_sides_glow_color' mechanism can only be called on Sign blocks.");
+                } else {
+                    MapTag glowMap = mechanism.valueAsType(MapTag.class);
+                    for (Map.Entry<StringHolder, ObjectTag> entry : glowMap.map.entrySet()) {
+                        if (EnumHelper.get(Side.class).valuesMapLower.containsKey(entry.getKey().str)) {
+                            Side side = Side.valueOf(entry.getKey().toString().toUpperCase());
+                            if (EnumHelper.get(DyeColor.class).valuesMapLower.containsKey(entry.getValue().asElement().asLowerString())) {
+                                DyeColor color = DyeColor.valueOf(entry.getValue().asElement().asLowerString().toUpperCase());
+                                sign.getSide(side).setColor(color);
+                            } else {
+                                mechanism.echoError("Unknown dye color " + entry.getValue());
+                            }
+                        } else {
+                            mechanism.echoError("Unknown sign side " + entry.getKey());
+                        }
+                    }
+                    sign.update();
+                }
+            }
+        }
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name sign_waxed
+        // @input ElementTag(Boolean)
+        // @description
+        // Changes whether the sign at the location is waxed.
+        // @tags
+        // <LocationTag.sign_waxed>
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("sign_waxed") && mechanism.requireBoolean()) {
+                BlockState state = getBlockState();
+                if (!(state instanceof Sign sign)) {
+                    mechanism.echoError("'sign_waxed' mechanism can only be called on Sign blocks.");
+                } else {
+                    sign.setWaxed(mechanism.getValue().asBoolean());
+                    sign.update();
+                }
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -1246,7 +1246,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // 1.20+
         // Returns a map of each side and lines on that side.
         // -->
-        tagProcessor.registerTag(ObjectTag.class, "sign_contents", (attribute, object) -> {
+        tagProcessor.registerTag(ListTag.class, "sign_contents", (attribute, object) -> {
             BlockState state = object.getBlockStateForTag(attribute);
             if (!(state instanceof Sign)) {
                 attribute.echoError("Location is not a valid Sign block.");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -45,6 +45,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.block.banner.PatternType;
+import org.bukkit.block.sign.Side;
 import org.bukkit.boss.BossBar;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.*;
@@ -3842,6 +3843,52 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             }
             else {
                 NMSHandler.packetHelper.showSignEditor(getPlayerEntity(), null);
+            }
+        }
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name edit_sign_front
+        // @input LocationTag
+        // @description
+        // Allows the player to edit the front of an existing sign. To create a sign, see <@link command Sign>.
+        // Give no input to make a fake edit interface.
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("edit_sign_front")) {
+                if (mechanism.hasValue() && mechanism.requireObject(LocationTag.class)) {
+                    BlockState state = mechanism.valueAsType(LocationTag.class).getBlockState();
+                    if (!(state instanceof Sign)) {
+                        mechanism.echoError("Invalid location specified: must be a sign.");
+                        return;
+                    }
+                    getPlayerEntity().openSign((Sign) state, Side.FRONT);
+                } else {
+                    NMSHandler.packetHelper.showSignEditor(getPlayerEntity(), null);
+                }
+            }
+        }
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name edit_sign_back
+        // @input LocationTag
+        // @description
+        // Allows the player to edit the back of an existing sign. To create a sign, see <@link command Sign>.
+        // Give no input to make a fake edit interface.
+        // -->
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            if (mechanism.matches("edit_sign_back")) {
+                if (mechanism.hasValue() && mechanism.requireObject(LocationTag.class)) {
+                    BlockState state = mechanism.valueAsType(LocationTag.class).getBlockState();
+                    if (!(state instanceof Sign)) {
+                        mechanism.echoError("Invalid location specified: must be a sign.");
+                        return;
+                    }
+                    getPlayerEntity().openSign((Sign) state, Side.BACK);
+                } else {
+                    NMSHandler.packetHelper.showSignEditor(getPlayerEntity(), null);
+                }
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -20,7 +20,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
-import org.bukkit.block.sign.Side;
+//import org.bukkit.block.sign.Side;
 
 public class SignCommand extends AbstractCommand {
 
@@ -97,8 +97,8 @@ public class SignCommand extends AbstractCommand {
                 scriptEntry.addObject("material", arg.asType(MaterialTag.class));
             }
             else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)
-                    && !scriptEntry.hasObject("side")
-                    && arg.matchesEnum(Side.class)) {
+                    && MultiVersionHelper1_20.isSide(arg.getValue())
+                    && !scriptEntry.hasObject("side")) {
                 scriptEntry.addObject("side", arg.asElement());
             }
             else if (!scriptEntry.hasObject("text")) {
@@ -117,7 +117,7 @@ public class SignCommand extends AbstractCommand {
         scriptEntry.defaultObject("type", new ElementTag(Type.AUTOMATIC));
 
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
-            scriptEntry.defaultObject("side", new ElementTag(Side.FRONT));
+            scriptEntry.defaultObject("side", MultiVersionHelper1_20.sideString("FRONT"));
         }
     }
 
@@ -220,8 +220,7 @@ public class SignCommand extends AbstractCommand {
         String[] textArr = text.toArray(new String[4]);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
             ElementTag sideElement = scriptEntry.getObjectTag("side");
-            Side side = Side.valueOf(sideElement.asLowerString().toUpperCase());
-            Utilities.setSignLines((Sign) signState, side, textArr);
+            Utilities.setSignLines((Sign) signState, sideElement.asLowerString().toUpperCase(), textArr);
         } else {
             Utilities.setSignLines((Sign) signState, textArr);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -1,7 +1,10 @@
 package com.denizenscript.denizen.scripts.commands.world;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.objects.properties.material.MaterialDirectional;
+import com.denizenscript.denizen.utilities.MultiVersionHelper1_20;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -16,19 +19,20 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
 
 public class SignCommand extends AbstractCommand {
 
     public SignCommand() {
         setName("sign");
-        setSyntax("sign (type:{automatic}/sign_post/wall_sign) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)");
+        setSyntax("sign (type:{automatic}/sign_post/wall_sign) (material:<material>) (side:{front}/back) [<line>|...] [<location>] (direction:north/east/south/west)");
         setRequiredArguments(1, 5);
         isProcedural = false;
     }
 
     // <--[command]
     // @Name Sign
-    // @Syntax sign (type:{automatic}/sign_post/wall_sign) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)
+    // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging_sign) (material:<material>) (side:{front}/back) [<line>|...] [<location>] (direction:north/east/south/west)
     // @Required 1
     // @Maximum 5
     // @Short Modifies a sign.
@@ -94,6 +98,11 @@ public class SignCommand extends AbstractCommand {
             else if (!scriptEntry.hasObject("text")) {
                 scriptEntry.addObject("text", arg.asType(ListTag.class));
             }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)
+                        && !scriptEntry.hasObject("side")
+                        && arg.matchesEnum(Side.class)) {
+                scriptEntry.addObject("side", arg.asElement());
+            }
             else {
                 arg.reportUnhandled();
             }
@@ -105,6 +114,10 @@ public class SignCommand extends AbstractCommand {
             throw new InvalidArgumentsException("Must specify sign text!");
         }
         scriptEntry.defaultObject("type", new ElementTag(Type.AUTOMATIC));
+
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            scriptEntry.defaultObject("side", new ElementTag(Side.FRONT));
+        }
     }
 
     public void setWallSign(Block sign, BlockFace bf, MaterialTag material) {
@@ -147,7 +160,11 @@ public class SignCommand extends AbstractCommand {
     }
 
     public static boolean isAnySign(Material material) {
-        return isStandingSign(material) || isWallSign(material);
+        boolean isSign = isStandingSign(material) || isWallSign(material);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            isSign = isSign || MultiVersionHelper1_20.isAnySign(material);
+        }
+        return isSign;
     }
 
     @Override
@@ -190,6 +207,15 @@ public class SignCommand extends AbstractCommand {
             }
         }
         BlockState signState = sign.getState();
-        Utilities.setSignLines((Sign) signState, text.toArray(new String[4]));
+        String[] textArr = text.toArray(new String[4]);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            ElementTag sideElement = scriptEntry.getObjectTag("side");
+            for (int n = 0; n < 4; n++) {
+                ((Sign) signState).getSide(Side.valueOf(sideElement.asLowerString().toUpperCase())).setLine(n, textArr[n]);
+            }
+            signState.update();
+        } else {
+            Utilities.setSignLines((Sign) signState, textArr);
+        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.*;
 
@@ -54,5 +55,9 @@ public class MultiVersionHelper1_19 {
         result.putObject("duration", new DurationTag((world.getGameTime() - interaction.getTimestamp()) / 20d));
         result.putObject("raw_game_time", new ElementTag(interaction.getTimestamp()));
         return result;
+    }
+
+    public static boolean isAnySign(Material material) {
+        return material == Material.MANGROVE_SIGN || material == Material.MANGROVE_WALL_SIGN;
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.utilities;
 
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.utilities.EnumHelper;
 import org.bukkit.Material;
 import org.bukkit.block.Sign;
 import com.denizenscript.denizencore.objects.core.ListTag;
@@ -7,11 +9,11 @@ import com.denizenscript.denizencore.objects.core.MapTag;
 import org.bukkit.block.sign.Side;
 
 public class MultiVersionHelper1_20 {
-    public static String[][] getSignLines(Sign sign) {
-        String[][] contents = new String[2][];
-        contents[0] = sign.getSide(Side.FRONT).getLines();
-        contents[1] = sign.getSide(Side.BACK).getLines();
-        return contents;
+    public static boolean isSide(String side) {
+        return side != null && EnumHelper.get(Side.class).valuesMapLower.containsKey(EnumHelper.cleanKey(side));
+    }
+    public static ElementTag sideString(String side) {
+        return new ElementTag(Side.valueOf(side));
     }
 
     public static boolean isAnyHangingSign(Material material) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
@@ -24,13 +24,17 @@ public class MultiVersionHelper1_20 {
             case JUNGLE_HANGING_SIGN:
             case OAK_HANGING_SIGN:
             case SPRUCE_HANGING_SIGN:
+            case MANGROVE_HANGING_SIGN:
             case CHERRY_HANGING_SIGN:
+            case BAMBOO_HANGING_SIGN:
                 return true;
             default:
                 return false;
         }
     }
     public static boolean isAnySign(Material material) {
-        return material == Material.CHERRY_SIGN || material == Material.CHERRY_WALL_SIGN || isAnyHangingSign(material);
+        return material == Material.CHERRY_SIGN || material == Material.CHERRY_WALL_SIGN
+            || material == Material.BAMBOO_SIGN || material == Material.BAMBOO_WALL_SIGN
+            || isAnyHangingSign(material);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.utilities;
 
+import org.bukkit.Material;
 import org.bukkit.block.Sign;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
@@ -11,5 +12,25 @@ public class MultiVersionHelper1_20 {
         contents[0] = sign.getSide(Side.FRONT).getLines();
         contents[1] = sign.getSide(Side.BACK).getLines();
         return contents;
+    }
+
+    public static boolean isAnyHangingSign(Material material) {
+        switch (material) {
+            case CRIMSON_HANGING_SIGN:
+            case WARPED_HANGING_SIGN:
+            case ACACIA_HANGING_SIGN:
+            case BIRCH_HANGING_SIGN:
+            case DARK_OAK_HANGING_SIGN:
+            case JUNGLE_HANGING_SIGN:
+            case OAK_HANGING_SIGN:
+            case SPRUCE_HANGING_SIGN:
+            case CHERRY_HANGING_SIGN:
+                return true;
+            default:
+                return false;
+        }
+    }
+    public static boolean isAnySign(Material material) {
+        return material == Material.CHERRY_SIGN || material == Material.CHERRY_WALL_SIGN || isAnyHangingSign(material);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_20.java
@@ -1,0 +1,15 @@
+package com.denizenscript.denizen.utilities;
+
+import org.bukkit.block.Sign;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import org.bukkit.block.sign.Side;
+
+public class MultiVersionHelper1_20 {
+    public static String[][] getSignLines(Sign sign) {
+        String[][] contents = new String[2][];
+        contents[0] = sign.getSide(Side.FRONT).getLines();
+        contents[1] = sign.getSide(Side.BACK).getLines();
+        return contents;
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -11,6 +11,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -100,6 +101,18 @@ public class PaperAPITools {
 
     public void sendSignUpdate(Player player, Location loc, String[] text) {
         player.sendSignChange(loc, text);
+    }
+
+    public void sendSignUpdate(Player player, Location loc, String[] text, Side side) {
+        Sign sign = (Sign)loc.getBlock().getState();
+        SignSide signSide = sign.getSide(side);
+        for (int line = 0; line < 4; line++) {
+            signSide.setLine(line, "");
+        }
+        for (int line = 0; line < text.length; line++) {
+            signSide.setLine(line, text[line]);
+        }
+        player.sendBlockUpdate(loc, sign);
     }
 
     public String getCustomName(Nameable object) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -10,6 +10,7 @@ import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.*;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -79,10 +80,16 @@ public class PaperAPITools {
         return sign.getLines();
     }
 
+    public String[] getSignLines(Sign sign, Side side) {
+        return sign.getSide(side).getLines();
+    }
+
     public void setSignLine(Sign sign, int line, String text) {
         sign.setLine(line, text == null ? "" : text);
     }
-
+    public void setSignLine(Sign sign, Side side, int line, String text) {
+        sign.getSide(side).setLine(line, text == null ? "" : text);
+    }
     public void sendResourcePack(Player player, String url, String hash, boolean forced, String prompt) {
         byte[] hashData = new byte[20];
         for (int i = 0; i < 20; i++) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -364,6 +364,13 @@ public class Utilities {
         sign.update();
     }
 
+    public static void setSignLines(Sign sign, String side, String[] lines) {
+        for (int n = 0; n < 4; n++) {
+            PaperAPITools.instance.setSignLine(sign, Side.valueOf(side), n, lines[n]);
+        }
+        sign.update();
+    }
+
     public static void setSignLines(Sign sign, Side side, String[] lines) {
         for (int n = 0; n < 4; n++) {
             PaperAPITools.instance.setSignLine(sign, side, n, lines[n]);

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -23,6 +23,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -359,6 +360,13 @@ public class Utilities {
     public static void setSignLines(Sign sign, String[] lines) {
         for (int n = 0; n < 4; n++) {
             PaperAPITools.instance.setSignLine(sign, n, lines[n]);
+        }
+        sign.update();
+    }
+
+    public static void setSignLines(Sign sign, Side side, String[] lines) {
+        for (int n = 0; n < 4; n++) {
+            PaperAPITools.instance.setSignLine(sign, side, n, lines[n]);
         }
         sign.update();
     }


### PR DESCRIPTION
This is a re submission of the PR with the recommended changes 

Changed sign related tags now have an optional argument to specify front or back (defaults to front)

added new mechs to take in map input for dealing with either front, back, or both at the same time (these are of the name sign_sides_mechname )

added 2 new mechs for the player for editing front and back sign

changed the sign command:
-added argument of whether the text is going to the front or back
-added hanging signs to the sign command (type:hanging_sign)
-material should recognize all signs now (added mangroves for 1.19 and cherry/bamboo for 1.20)
