### PR TITLE
`ItemPotion`: clear stew effects, modernize

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerBeaconEffectScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerBeaconEffectScriptEvent.java
@@ -59,7 +59,7 @@ public class PlayerBeaconEffectScriptEvent extends BukkitScriptEvent implements 
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
         try {
-            event.setEffect(ItemPotion.parseEffect(determinationObj.toString(), getTagContext(path)));
+            event.setEffect(ItemPotion.parseLegacyEffectString(determinationObj.toString(), getTagContext(path)));
             return true;
         }
         catch (Exception e) {
@@ -79,7 +79,7 @@ public class PlayerBeaconEffectScriptEvent extends BukkitScriptEvent implements 
             case "location":
                 return new LocationTag(event.getBlock().getLocation());
             case "effect":
-                return new ElementTag(ItemPotion.stringifyEffect(event.getEffect()));
+                return new ElementTag(ItemPotion.effectToLegacyString(event.getEffect()));
             case "effect_type":
                 return new ElementTag(event.getEffect().getType().getName());
             case "is_primary":

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityPotionEffectScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityPotionEffectScriptEvent.java
@@ -126,10 +126,10 @@ public class EntityPotionEffectScriptEvent extends BukkitScriptEvent implements 
             return new ElementTag(event.isOverride());
         }
         else if (name.equals("new_effect") && event.getNewEffect() != null) {
-            return new ElementTag(ItemPotion.stringifyEffect(event.getNewEffect()));
+            return new ElementTag(ItemPotion.effectToLegacyString(event.getNewEffect()));
         }
         else if (name.equals("old_effect") && event.getOldEffect() != null) {
-            return new ElementTag(ItemPotion.stringifyEffect(event.getOldEffect()));
+            return new ElementTag(ItemPotion.effectToLegacyString(event.getOldEffect()));
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionEffects.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionEffects.java
@@ -60,7 +60,7 @@ public class EntityPotionEffects implements Property {
     public ListTag getEffectsListTag() {
         ListTag result = new ListTag();
         for (PotionEffect effect : getEffectsList()) {
-            result.add(ItemPotion.stringifyEffect(effect));
+            result.add(ItemPotion.effectToLegacyString(effect));
         }
         return result;
     }
@@ -180,7 +180,7 @@ public class EntityPotionEffects implements Property {
                 }
                 else {
                     String effectStr = effectObj.toString();
-                    effect = ItemPotion.parseEffect(effectStr, mechanism.context);
+                    effect = ItemPotion.parseLegacyEffectString(effectStr, mechanism.context);
                 }
                 if (effect == null) {
                     mechanism.echoError("Invalid potion effect '" + effectObj + "'");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -58,7 +58,7 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             if (potionMeta.hasColor()) {
                 base.putObject("color", BukkitColorExtensions.fromColor(potionMeta.getColor()));
             }
-            result.addObject(base);
+            result.addObject(0, base);
         }
         return result;
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -186,16 +186,15 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             else {
                 effect = parseLegacyEffectString(effectObj.toString(), mechanism.context);
             }
-            if (effect != null) {
-                if (meta instanceof PotionMeta potionMeta) {
-                    potionMeta.addCustomEffect(effect, false);
-                }
-                else {
-                    ((SuspiciousStewMeta) meta).addCustomEffect(effect, false);
-                }
+            if (effect == null) {
+                mechanism.echoError("Invalid potion effect '" + effectObj + "'");
+                continue;
+            }
+            if (meta instanceof PotionMeta potionMeta) {
+                potionMeta.addCustomEffect(effect, false);
             }
             else {
-                mechanism.echoError("Invalid potion effect '" + effectObj + "'");
+                ((SuspiciousStewMeta) meta).addCustomEffect(effect, false);
             }
         }
         setItemMeta(meta);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -309,7 +309,7 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             }
             BukkitImplDeprecations.oldPotionEffects.warn(attribute.context);
             return new ElementTag(potionMeta.getBasePotionData().getType().name() + "," + (potionMeta.getBasePotionData().isUpgraded() ? 2 : 1)
-                    + "," + potionMeta.getBasePotionData().isExtended() + "," + (object.object.getBukkitMaterial() == Material.SPLASH_POTION)
+                    + "," + potionMeta.getBasePotionData().isExtended() + "," + (object.getMaterial() == Material.SPLASH_POTION)
                     + (potionMeta.hasColor() ? "," + BukkitColorExtensions.fromColor(potionMeta.getColor()).identify() : ""));
         });
 
@@ -347,7 +347,7 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             }
             if (attribute.startsWith("is_splash", 2)) {
                 attribute.fulfill(1);
-                return new ElementTag(object.object.getBukkitMaterial() == Material.SPLASH_POTION);
+                return new ElementTag(object.getMaterial() == Material.SPLASH_POTION);
             }
             if (attribute.startsWith("is_extended", 2)) {
                 attribute.fulfill(1);
@@ -396,7 +396,7 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             }
             PotionData data = potionMeta.getBasePotionData();
             return new ElementTag(data.getType().name() + "," + (data.isUpgraded() ? 2 : 1)
-                    + "," + data.isExtended() + "," + (object.object.getBukkitMaterial() == Material.SPLASH_POTION));
+                    + "," + data.isExtended() + "," + (object.getMaterial() == Material.SPLASH_POTION));
 
         });
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -175,6 +175,9 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             }
             potionMeta.clearCustomEffects();
         }
+        else {
+            ((SuspiciousStewMeta) meta).clearCustomEffects();
+        }
         for (ObjectTag effectObj : data) {
             PotionEffect effect;
             if (effectObj.canBeType(MapTag.class)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -184,13 +184,6 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
         return as(PotionMeta.class).getCustomEffects();
     }
 
-    public boolean hasCustomEffects() {
-        if (getItemMeta() instanceof SuspiciousStewMeta suspiciousStewMeta) {
-            return suspiciousStewMeta.hasCustomEffects();
-        }
-        return as(PotionMeta.class).hasCustomEffects();
-    }
-
     @Override
     public ListTag getPropertyValue() {
         return getMapTagData(false);
@@ -451,7 +444,7 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
         // Returns whether the item (potion, tipped arrow, or suspicious stew) has a potion effect.
         // -->
         PropertyParser.registerTag(ItemPotion.class, ElementTag.class, "has_potion_effect", (attribute, object) -> {
-            return new ElementTag(object.hasCustomEffects());
+            return new ElementTag(object.getItemMeta() instanceof SuspiciousStewMeta suspiciousStewMeta ? suspiciousStewMeta.hasCustomEffects() : object.as(PotionMeta.class).hasCustomEffects());
         });
 
         // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -232,9 +232,8 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
         //
         // For potions or tipped arrows (not suspicious stew), the first item in the list must be a MapTag with keys:
         // "base_type" - from <@link url https://minecraft.wiki/w/Potion#Item_data>
-        // "color" - ColorTag (optional, default none)
         //
-        // For example: [base_type=strong_swiftness;color=red]
+        // For example: [base_type=strong_swiftness]
         // This example produces an item labeled as "Potion of Swiftness - Speed II (1:30)"
         //
         // Each following item in the list are potion effects, which must be a MapTag with keys:
@@ -246,8 +245,8 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
         // For example: [type=SPEED;amplifier=2;duration=10s;ambient=false;particles=true;icon=true]
         // This example would be a level 3 swiftness potion that lasts 10 seconds.
         //
-        // A very short full default potion item would be: potion[potion_effects=[type=regen]
-        // A (relatively) short full potion item would be: potion[potion_effects=<list[[type=regen]|[type=speed;duration=10s]]>]
+        // A very short full default potion item would be: potion[potion_effects=[base_type=regeneration]
+        // A (relatively) short full potion item would be: potion[potion_effects=<list[[base_type=regeneration]|[type=speed;duration=10s]]>]
         // (Note the list constructor to force data format interpretation, as potion formats can be given multiple ways and the system will get confused without a constructor)
         //
         // @tags

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -325,10 +325,9 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
         // Deprecated in favor of <@link tag ItemTag.effects_data>
         // -->
         PropertyParser.registerTag(ItemPotion.class, ListTag.class, "potion_effects", (attribute, object) -> {
-            BukkitImplDeprecations.oldPotionEffects.warn(attribute.context);
             ListTag result = new ListTag();
             for (PotionEffect pot : object.getCustomEffects()) {
-                result.add(effectToLegacyString(pot));
+                result.add(effectToLegacyString(pot, attribute.context));
             }
             return result;
         });
@@ -492,7 +491,8 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
         }
     }
 
-    public static String effectToLegacyString(PotionEffect effect) {
+    public static String effectToLegacyString(PotionEffect effect, TagContext context) {
+        BukkitImplDeprecations.oldPotionEffects.warn(context);
         return effect.getType().getName() + "," +
                 effect.getAmplifier() + "," +
                 effect.getDuration() + "," +

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -44,7 +44,8 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
     }
 
     public ListTag getMapTagData(boolean includeExtras) {
-        ListTag result = new ListTag(getCustomEffects(), ItemPotion::effectToMap);
+        List<PotionEffect> potionEffects = getCustomEffects();
+        ListTag result = new ListTag(potionEffects.size() + 1);
         if (getItemMeta() instanceof PotionMeta potionMeta) {
             MapTag base = new MapTag();
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
@@ -58,7 +59,10 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
                     base.putObject("color", BukkitColorExtensions.fromColor(potionMeta.getColor()));
                 }
             }
-            result.addObject(0, base);
+            result.addObject(base);
+        }
+        for (PotionEffect potionEffect : potionEffects) {
+            result.addObject(effectToMap(potionEffect));
         }
         return result;
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemPotion.java
@@ -50,13 +50,13 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
                 base.putObject("base_type", new ElementTag(Utilities.namespacedKeyToString(potionMeta.getBasePotionType().getKey()), true));
             }
-            if (includeExtras) { // TODO: Eventually remove these 3.
+            if (includeExtras) { // TODO: Eventually remove these 4
                 base.putObject("type", new ElementTag(potionMeta.getBasePotionData().getType()));
                 base.putObject("upgraded", new ElementTag(potionMeta.getBasePotionData().isUpgraded()));
                 base.putObject("extended", new ElementTag(potionMeta.getBasePotionData().isExtended()));
-            }
-            if (potionMeta.hasColor()) {
-                base.putObject("color", BukkitColorExtensions.fromColor(potionMeta.getColor()));
+                if (potionMeta.hasColor()) {
+                    base.putObject("color", BukkitColorExtensions.fromColor(potionMeta.getColor()));
+                }
             }
             result.addObject(0, base);
         }
@@ -433,7 +433,7 @@ public class ItemPotion extends ItemProperty<ObjectTag> {
             }
         }
         ColorTag color = null;
-        if (input.getObject("color") != null) {
+        if (input.containsKey("color")) {
             ObjectTag colorObj = input.getObject("color");
             if (colorObj.canBeType(ColorTag.class)) {
                 color = colorObj.asType(ColorTag.class, mechanism.context);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemProperty.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemProperty.java
@@ -36,6 +36,12 @@ public abstract class ItemProperty<TData extends ObjectTag> extends ObjectProper
         object.setItemMeta(meta);
     }
 
+    @SuppressWarnings("unchecked")
+    public <T extends ItemMeta> T as(Class<T> metaType) {
+        return (T) getItemMeta();
+    }
+
+    @SuppressWarnings("unchecked")
     public <T extends ItemMeta> void editMeta(Class<T> metaType, Consumer<T> editor) {
         T meta = (T) getItemMeta();
         editor.accept(meta);


### PR DESCRIPTION
## Changes

- Updated `ItemPotion` to modern property format.
- ~~`getMapTagData` now uses the modern `ListTag` convertor constructor instead of manually adding the effects.~~
- `getMapTagData` now initializes the list to the correct size instead of creating a new empty one.
- Switched `MapTag#getObject(X) != null` usages with `MapTag#containsKey(X)`.
- Removed old redundant methods (`isStew`, `getPotionMeta`, etc.) in favor of directly using modern features such as `instanceof` pattern matching.
- Split parsing logic for legacy base potion data into separate methods instead of having it all in `setPropertyValue`, as it was hard to read and made the proper modern code messier.
- Now properly clears suspicious stew effects before adding new ones.
- Updated `potion_effects` to modern mechanism registration.
- Updated `potion_effects`'s mechanism meta examples (some were using outdated format).
- Removed mentions of the `color` map value from the meta and placed it under `includeExtras`, as it was only handled in the legacy base potion data map parsing.
Not sure if this was intentional or not, but it makes sense to remove it there anyway, as it's an entire duplicate feature (`ItemTag.color`).
- Renamed the old comma-separated string potion effect syntax's methods to `parseLegacyEffectString` and `effectToLegacyString`, to properly separate them from the modern parsing methods.
- Moved all legacy logic/tags to the bottom of the file, to have the top/visible parts be just the modern handling.
- Changed the `ElementTag` for the base potion type in `getMapTagData` to be plain-text.

## Additions

- `ItemProperty#as(Class<ItemMeta>)` - same as the `EntityProperty` variant, just a util for casting the `ItemMeta`. 
## Notes

- Currently the property's type is `ObjectTag`, which isn't the ideal but is needed to make the `MapTag`-with-numbered-keys-list input work properly; we could make it `ListTag` and only handle the special input format inside `registerMechanism` before calling `setPropertyValue`, so lmk if that's preferred (as it would obviously mean `setPropertyValue` won't accecpt the special format).