### PR TITLE
Add `NUM_PLAYERS` determination

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
@@ -4,12 +4,10 @@ import com.denizenscript.denizen.events.server.ListPingScriptEvent;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizencore.objects.ArgumentHelper;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
@@ -24,6 +22,53 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
+
+    public ServerListPingScriptEventPaperImpl() {
+        this.<ServerListPingScriptEventPaperImpl, ElementTag>registerOptionalDetermination("protocol_version", ElementTag.class, (evt, context, version) -> {
+            if (version.isInt()) {
+                ((PaperServerListPingEvent) event).setProtocolVersion(version.asInt());
+                return true;
+            }
+            return false;
+        });
+        this.<ServerListPingScriptEventPaperImpl, ElementTag>registerOptionalDetermination("version_name", ElementTag.class, (evt, context, name) -> {
+            ((PaperServerListPingEvent) event).setVersion(name.toString());
+            return true;
+        });
+        this.<ServerListPingScriptEventPaperImpl, ListTag>registerOptionalDetermination("exclude_players", ListTag.class, (evt, context, list) -> {
+            HashSet<UUID> exclusions = new HashSet<>();
+            for (PlayerTag player : list.filter(PlayerTag.class, context)) {
+                exclusions.add(player.getUUID());
+            }
+            Iterator<Player> players = ((PaperServerListPingEvent) event).iterator();
+            while (players.hasNext()) {
+                if (exclusions.contains(players.next().getUniqueId())) {
+                    players.remove();
+                }
+            }
+            return true;
+        });
+        this.<ServerListPingScriptEventPaperImpl, ListTag>registerOptionalDetermination("alternate_player_text", ListTag.class, (evt, context, text) -> {
+            if (!CoreConfiguration.allowRestrictedActions) {
+                Debug.echoError("Cannot use 'alternate_player_text' in list ping event: 'Allow restricted actions' is disabled in Denizen config.yml.");
+                return false;
+            }
+            ((PaperServerListPingEvent) event).getPlayerSample().clear();
+            for (String line : text) {
+                FakeProfile lineProf = new FakeProfile();
+                lineProf.setName(line);
+                ((PaperServerListPingEvent) event).getPlayerSample().add(lineProf);
+            }
+            return true;
+        });
+        this.<ServerListPingScriptEventPaperImpl, ElementTag>registerOptionalDetermination("num_players", ElementTag.class, (evt, context, num) -> {
+            if (num.isInt()) {
+                ((PaperServerListPingEvent) event).setNumPlayers(num.asInt());
+                return true;
+            }
+            return false;
+        });
+    }
 
     public static class FakeProfile implements PlayerProfile {
         public String name;
@@ -58,64 +103,20 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
     }
 
     @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        String determination = determinationObj.toString();
-        String lower = CoreUtilities.toLowerCase(determination);
-        if (lower.startsWith("protocol_version:") && ArgumentHelper.matchesInteger(determination.substring("protocol_version:".length()))) {
-            ((PaperServerListPingEvent) event).setProtocolVersion(Integer.parseInt(determination.substring("protocol_version:".length())));
-            return true;
-        }
-        else if (lower.startsWith("version_name:")) {
-            ((PaperServerListPingEvent) event).setVersion(determination.substring("version_name:".length()));
-            return true;
-        }
-        else if (lower.startsWith("exclude_players:")) {
-            HashSet<UUID> exclusions = new HashSet<>();
-            for (PlayerTag player : ListTag.valueOf(determination.substring("exclude_players:".length()), getTagContext(path)).filter(PlayerTag.class, getTagContext(path))) {
-                exclusions.add(player.getUUID());
-            }
-            Iterator<Player> players = ((PaperServerListPingEvent) event).iterator();
-            while (players.hasNext()) {
-                if (exclusions.contains(players.next().getUniqueId())) {
-                    players.remove();
-                }
-            }
-            return true;
-        }
-        else if (lower.startsWith("alternate_player_text:")) {
-            if (!CoreConfiguration.allowRestrictedActions) {
-                Debug.echoError("Cannot use 'alternate_player_text' in list ping event: 'Allow restricted actions' is disabled in Denizen config.yml.");
-                return true;
-            }
-            ((PaperServerListPingEvent) event).getPlayerSample().clear();
-            for (String line : ListTag.valueOf(determination.substring("alternate_player_text:".length()), getTagContext(path))) {
-                FakeProfile lineProf = new FakeProfile();
-                lineProf.setName(line);
-                ((PaperServerListPingEvent) event).getPlayerSample().add(lineProf);
-            }
-            return true;
-        }
-        return super.applyDetermination(path, determinationObj);
-    }
-
-    @Override
     public void setMotd(String text) {
         event.motd(PaperModule.parseFormattedText(text, ChatColor.WHITE));
     }
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "motd":
-                return new ElementTag(PaperModule.stringifyComponent(event.motd()));
-            case "protocol_version":
-                return new ElementTag(((PaperServerListPingEvent) event).getProtocolVersion());
-            case "version_name":
-                return new ElementTag(((PaperServerListPingEvent) event).getVersion());
-            case "client_protocol_version":
-                return new ElementTag(((PaperServerListPingEvent) event).getClient().getProtocolVersion());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "motd" -> new ElementTag(PaperModule.stringifyComponent(event.motd()));
+            case "protocol_version" -> new ElementTag(((PaperServerListPingEvent) event).getProtocolVersion());
+            case "version_name" -> new ElementTag(((PaperServerListPingEvent) event).getVersion());
+            case "client_protocol_version" ->
+                    new ElementTag(((PaperServerListPingEvent) event).getClient().getProtocolVersion());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.objects.ArgumentHelper;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
@@ -46,30 +47,27 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
     // "VERSION_NAME:<ElementTag>" to change the server's version name (only on Paper).
     // "EXCLUDE_PLAYERS:<ListTag(PlayerTag)>" to exclude a set of players from showing in the player count or preview of online players (only on Paper).
     // "ALTERNATE_PLAYER_TEXT:<ListTag>" to set custom text for the player list section of the server status (only on Paper). (Requires "Allow restricted actions" in Denizen/config.yml). Usage of this to present lines that look like player names (but aren't) is forbidden.
+    // "NUM_PLAYERS:<ElementTag(Number)>" to change the number of online players that is displayed (only on Paper).
     // ElementTag to change the MOTD that will show.
     //
     // -->
 
     public ListPingScriptEvent() {
         registerCouldMatcher("server list ping");
-    }
-
-
-    public ServerListPingEvent event;
-
-    // Despite the 'cached' class name, there's no actual internal cache.
-    public static HashMap<String, CachedServerIcon> iconCache = new HashMap<>();
-
-    public void setMotd(String text) {
-        event.setMotd(text);
-    }
-
-    @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        String determination = determinationObj.toString();
-        String determineLow = CoreUtilities.toLowerCase(determination);
-        if (determineLow.startsWith("icon:")) {
-            String iconFile = determination.substring("icon:".length());
+        this.<ListPingScriptEvent, ListTag>registerOptionalDetermination(null, ListTag.class, (evt, context, list) -> {
+            if (ArgumentHelper.matchesInteger(list.get(0))) {
+                evt.event.setMaxPlayers(Integer.parseInt(list.get(0)));
+                if (list.size() == 2) {
+                    setMotd(list.get(1));
+                }
+            }
+            else {
+                setMotd(list.get(0));
+            }
+            return true;
+        });
+        this.<ListPingScriptEvent, ElementTag>registerOptionalDetermination("icon", ElementTag.class, (evt, context, iconPath) -> {
+            String iconFile = iconPath.toString();
             CachedServerIcon icon = iconCache.get(iconFile);
             if (icon != null) {
                 event.setServerIcon(icon);
@@ -89,40 +87,31 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
             if (icon != null) {
                 iconCache.put(iconFile, icon);
                 event.setServerIcon(icon);
+                return true;
             }
-            return true;
-        }
-        if (determination.length() > 0 && !determineLow.equalsIgnoreCase("none")) {
-            List<String> values = CoreUtilities.split(determination, '|', 2);
-            if (ArgumentHelper.matchesInteger(values.get(0))) {
-                event.setMaxPlayers(Integer.parseInt(values.get(0)));
-                if (values.size() == 2) {
-                    setMotd(values.get(1));
-                }
-            }
-            else {
-                setMotd(determination);
-            }
-            return true;
-        }
-        else {
-            return super.applyDetermination(path, determinationObj);
-        }
+            return false;
+        });
+    }
+
+
+    public ServerListPingEvent event;
+
+    // Despite the 'cached' class name, there's no actual internal cache.
+    public static HashMap<String, CachedServerIcon> iconCache = new HashMap<>();
+
+    public void setMotd(String text) {
+        event.setMotd(text);
     }
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "motd":
-                return new ElementTag(event.getMotd());
-            case "max_players":
-                return new ElementTag(event.getMaxPlayers());
-            case "num_players":
-                return new ElementTag(event.getNumPlayers());
-            case "address":
-                return new ElementTag(event.getAddress().toString());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "motd" -> new ElementTag(event.getMotd());
+            case "max_players" -> new ElementTag(event.getMaxPlayers());
+            case "num_players" -> new ElementTag(event.getNumPlayers());
+            case "address" -> new ElementTag(event.getAddress().toString());
+            default -> super.getContext(name);
+        };
     }
 
     public void syncFire(ServerListPingEvent event) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
@@ -47,7 +47,7 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
     // "VERSION_NAME:<ElementTag>" to change the server's version name (only on Paper).
     // "EXCLUDE_PLAYERS:<ListTag(PlayerTag)>" to exclude a set of players from showing in the player count or preview of online players (only on Paper).
     // "ALTERNATE_PLAYER_TEXT:<ListTag>" to set custom text for the player list section of the server status (only on Paper). (Requires "Allow restricted actions" in Denizen/config.yml). Usage of this to present lines that look like player names (but aren't) is forbidden.
-    // "NUM_PLAYERS:<ElementTag(Number)>" to change the number of online players that is displayed (only on Paper).
+    // "NUM_PLAYERS:<ElementTag(Number)>" to change the number of online players that are displayed (only on Paper).
     // ElementTag to change the MOTD that will show.
     //
     // -->


### PR DESCRIPTION
# Adds the `NUM_PLAYERS:<ElementTag(Number)>` determination to the `server list ping` event

Customize the amount of players online in the server list.

Also modernizes the determinations/contexts for the `ListPingScriptEvent` and `ServerListPingScriptEventPaperImpl` (so long!) class.

Requested by [Ikuria](https://discord.com/channels/315163488085475337/1187119729027064010)

#### Notes:
It's been a while since I've used the new determination format (I actually don't know if I've ever used it at all) so if I messed it up, please let me know. I tested all the determinations and they both worked the same way, so hopefully I didn't make a mistake that I can't see!