### PR TITLE
`tick` command

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -173,6 +173,7 @@ public class BukkitCommandRegistry {
         registerCommand(SignCommand.class);
         registerCommand(StrikeCommand.class);
         registerCommand(SwitchCommand.class);
+        registerCommand(TickCommand.class);
         registerCommand(TimeCommand.class);
         registerCommand(WeatherCommand.class);
         registerCommand(WorldBorderCommand.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.scripts.commands;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.scripts.commands.core.CooldownCommand;
 import com.denizenscript.denizen.scripts.commands.core.ResetCommand;
 import com.denizenscript.denizen.scripts.commands.core.ZapCommand;
@@ -173,7 +175,9 @@ public class BukkitCommandRegistry {
         registerCommand(SignCommand.class);
         registerCommand(StrikeCommand.class);
         registerCommand(SwitchCommand.class);
-        registerCommand(TickCommand.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            registerCommand(TickCommand.class);
+        }
         registerCommand(TimeCommand.class);
         registerCommand(WeatherCommand.class);
         registerCommand(WorldBorderCommand.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -46,8 +46,7 @@ public class TickCommand extends AbstractCommand {
     // The tick rate resets to 20.0 on server restart.
     // For information about tick rate arguments, see <@link url https://minecraft.wiki/w/Commands/tick>
     //
-    // @Warning Be careful, this command will affect plugins that depend on tick rate and may cause them to break.
-    // @Warning For example, setting the tick rate to 1 will cause the <@link event tick> event to fire once per second.
+    // @Warning Be careful, this command will affect plugins that depend on tick rate and may cause them to break. For example, setting the tick rate to 1 will cause the <@link event tick> event to fire once per second.
     //
     // @Usage
     // Use to set the tick rate to 30 ticks per second.

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -38,11 +38,7 @@ public class TickCommand extends AbstractCommand {
     // - tick rate amount:30
     //
     // @Usage
-    // Use to step the tick rate for 1000 ticks.
-    // - tick step amount:1000
-    //
-    // @Usage
-    // Use to stop stepping early.
+    // Use to stop stepping early if the server is currently stepping.
     // - tick step cancel
     // -->
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -108,7 +108,7 @@ public class TickCommand extends AbstractCommand {
                     return;
                 }
                 if (amount < 1) {
-                    throw new InvalidArgumentsRuntimeException("The sprint action must have a number input not less than one!");
+                    throw new InvalidArgumentsRuntimeException("The sprint action must have a number input not less than 1!");
                 }
                 tickManager.requestGameToSprint((int)amount);
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -47,7 +47,7 @@ public class TickCommand extends AbstractCommand {
     // For information about tick rate arguments, see <@link url https://minecraft.wiki/w/Commands/tick>
     //
     // @Warning Be careful, this command will affect plugins that depend on tick rate and may cause them to break.
-    // @Warning For example, setting the tick rate to 1 will cause the <@event tick> event to fire once per second.
+    // @Warning For example, setting the tick rate to 1 will cause the <@link event tick> event to fire once per second.
     //
     // @Usage
     // Use to set the tick rate to 30 ticks per second.

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -60,7 +60,7 @@ public class TickCommand extends AbstractCommand {
         ServerTickManager tickManager = Bukkit.getServerTickManager();
         switch (action) {
             case RATE -> {
-                if (amount == null) {
+                if (amount == null || !amount.isFloat()) {
                     throw new InvalidArgumentsRuntimeException("The rate action must have a decimal input!");
                 }
                 if (amount.isFloat()) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -11,7 +11,7 @@ public class TickCommand extends AbstractCommand {
 
     // <--[command]
     // @Name tick
-    // @Syntax tick [rate/step/sprint/freeze/reset] (amount:<amount>/cancel)
+    // @Syntax tick [rate/step/sprint/freeze/reset] (amount:<#.#>/cancel)
     // @Required 1
     // @Maximum 2
     // @Short Controls the server's tick rate.
@@ -71,7 +71,7 @@ public class TickCommand extends AbstractCommand {
 
     public TickCommand() {
         setName("tick");
-        setSyntax("tick [rate/step/sprint/freeze/reset] (amount:<amount>/cancel)");
+        setSyntax("tick [rate/step/sprint/freeze/reset] (amount:<#.#>/cancel)");
         setRequiredArguments(1, 2);
         isProcedural = false;
         autoCompile();
@@ -88,10 +88,11 @@ public class TickCommand extends AbstractCommand {
                 if (amount == null || !amount.isFloat()) {
                     throw new InvalidArgumentsRuntimeException("The rate action must have a decimal number input!");
                 }
-                if (amount.asFloat() < 1 || amount.asFloat() > 10000) {
+                float rate = amount.asFloat();
+                if (rate < 1 || rate > 10000) {
                     throw new InvalidArgumentsRuntimeException("Invalid input! Tick rate must be a decimal number between 1.0 and 10000.0 (inclusive)!");
                 }
-                tickManager.setTickRate(amount.asFloat());
+                tickManager.setTickRate(rate);
             }
             case STEP -> {
                 if (cancel) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -79,7 +79,7 @@ public class TickCommand extends AbstractCommand {
 
     public enum TickActions { RATE, STEP, SPRINT, FREEZE, RESET }
 
-    public static void autoExecute(@ArgName("action") @ArgLinear TickActions action,
+    public static void autoExecute(@ArgName("action") TickActions action,
                                    @ArgName("amount") @ArgPrefixed @ArgDefaultNull ElementTag amount,
                                    @ArgName("cancel") boolean cancel) {
         ServerTickManager tickManager = Bukkit.getServerTickManager();
@@ -99,7 +99,7 @@ public class TickCommand extends AbstractCommand {
                     return;
                 }
                 if (amount == null || !amount.isInt()) {
-                    throw new InvalidArgumentsRuntimeException("The step action must have an integer input!");
+                    throw new InvalidArgumentsRuntimeException("The step action must have a number input!");
                 }
                 tickManager.stepGameIfFrozen(amount.asInt());
             }
@@ -109,7 +109,7 @@ public class TickCommand extends AbstractCommand {
                     return;
                 }
                 if (amount == null || !amount.isInt()) {
-                    throw new InvalidArgumentsRuntimeException("The sprint action must have an integer input!");
+                    throw new InvalidArgumentsRuntimeException("The sprint action must have a number input!");
                 }
                 tickManager.requestGameToSprint(amount.asInt());
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -5,7 +5,6 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.Bukkit;
 import org.bukkit.ServerTickManager;
 
@@ -13,94 +12,100 @@ public class TickCommand extends AbstractCommand {
 
     // <--[command]
     // @Name tick
-    // @Syntax tick [rate:<rate>/step:<amount>/sprint:<amount>/freeze (cancel)/reset]
+    // @Syntax tick [rate/step/sprint/freeze/reset] (amount:<amount>) (cancel)
     // @Required 1
-    // @Maximum 3
+    // @Maximum 2
     // @Short Controls the server's tick rate.
     // @Group world
     //
     // @Description
-    // Controls the server's tick rate.
+    // Controls the server's tick rate. Versions 1.20+ only.
     //
-    // To change the tick rate, use the 'rate' argument to change the tick rate. The tick rate must be a number between 1.0 and 10000.0.
+    // To change the tick rate, use the 'rate' argument and input the amount using 'amount'. The tick rate must be a number between 1.0 and 10000.0.
     // To reset the tick rate to the normal value (20.0), use the 'reset' argument.
     //
     // To freeze the tick rate, use the 'freeze' argument. To unfreeze, add the 'cancel' argument.
-    // To step the tick rate while the server is frozen for a specific amount of time, use the 'step' argument and provide a duration.
+    // To step the tick rate while the server is frozen for a specific amount of time, use the 'step' argument and input the amount of ticks using 'amount'.
     // If the server is not frozen when trying to use the 'step' argument, nothing will happen.
     //
-    // To make the tick rate as fast as possible for a specific amount of time, use the 'sprint' argument and provide a duration.
-    // To stop stepping or sprinting early, use 'cancel' as the input.
+    // To make the tick rate as fast as possible for a specific amount of time, use the 'sprint' argument and input the amount of ticks using 'amount'
+    // To stop stepping or sprinting early, use the 'cancel' argument.
     //
     // For information about tick rate arguments, see <@link url https://minecraft.wiki/w/Commands/tick>
     //
     // @Usage
     // Use to set the tick rate to 30 ticks per second.
-    // - tick rate:30
+    // - tick rate amount:30
     //
     // @Usage
     // Use to step the tick rate for 1000 ticks.
-    // - tick step:1000
+    // - tick step amount:1000
     //
     // @Usage
     // Use to stop stepping early.
-    // - tick step:cancel
+    // - tick step cancel
     // -->
 
     public TickCommand() {
         setName("tick");
-        setSyntax("tick [rate:<rate>/step:<amount>/sprint:<amount>/freeze (cancel)/reset]");
+        setSyntax("tick [rate/step/sprint/freeze/reset] (amount:<amount>) (cancel)");
         setRequiredArguments(1, 2);
         isProcedural = false;
         autoCompile();
+        addRemappedPrefixes("amount", "a");
     }
 
+    public enum TickActions { RATE, STEP, SPRINT, FREEZE, RESET }
+
     public static void autoExecute(ScriptEntry scriptEntry,
-                                   @ArgPrefixed @ArgName("rate") @ArgDefaultText("-1") float rate,
-                                   @ArgPrefixed @ArgName("step") @ArgDefaultNull ElementTag step,
-                                   @ArgPrefixed @ArgName("sprint") @ArgDefaultNull ElementTag sprint,
-                                   @ArgName("freeze") boolean freeze,
-                                   @ArgName("reset") boolean reset,
+                                   @ArgName("action") @ArgLinear TickActions action,
+                                   @ArgName("amount") @ArgPrefixed @ArgDefaultNull ElementTag amount,
                                    @ArgName("cancel") boolean cancel) {
         ServerTickManager tickManager = Bukkit.getServerTickManager();
-        if (rate != -1) {
-            if (rate < 1 || rate > 10000) {
-                Debug.echoError(scriptEntry, "Tick rate must between 1.0 and 10000.0 (inclusive)!");
-                return;
+        switch (action) {
+            case RATE -> {
+                if (amount == null) {
+                    throw new InvalidArgumentsRuntimeException("The rate action must have a decimal input!");
+                }
+                if (amount.isFloat()) {
+                    if (amount.asFloat() < 1 || amount.asFloat() > 10000) {
+                        throw new InvalidArgumentsRuntimeException("Invalid input! Tick rate must be a decimal between 1.0 and 10000.0 (inclusive)!");
+                    }
+                    tickManager.setTickRate(amount.asFloat());
+                }
             }
-            tickManager.setTickRate(rate);
-            return;
-        }
-        if (step != null) {
-            if (!step.isInt() && !step.toString().equalsIgnoreCase("cancel")) {
-                throw new InvalidArgumentsRuntimeException("Invalid step input! Must be either an integer or 'cancel'!");
+            case STEP -> {
+                if (cancel) {
+                    tickManager.stopStepping();
+                    return;
+                }
+                if (amount == null) {
+                    throw new InvalidArgumentsRuntimeException("The step action must have an integer input!");
+                }
+                if (amount.isInt()) {
+                    tickManager.stepGameIfFrozen(amount.asInt());
+                }
+                else {
+                    throw new InvalidArgumentsRuntimeException("Invalid input! Step amount must be an integer!");
+                }
             }
-            if (step.isInt()) {
-                tickManager.stepGameIfFrozen(step.asInt());
+            case SPRINT -> {
+                if (cancel) {
+                    tickManager.stopSprinting();
+                    return;
+                }
+                if (amount == null) {
+                    throw new InvalidArgumentsRuntimeException("The sprint action must have an integer input!");
+                }
+                if (amount.isInt()) {
+                    tickManager.requestGameToSprint(amount.asInt());
+                }
+                else {
+                    throw new InvalidArgumentsRuntimeException("Invalid input! Sprint amount must be an integer!");
+                }
             }
-            else {
-                tickManager.stopStepping();
-            }
-            return;
-        }
-        if (sprint != null) {
-            if (!sprint.isInt() && !sprint.toString().equalsIgnoreCase("cancel")) {
-                throw new InvalidArgumentsRuntimeException("Invalid step input! Must be either an integer or 'cancel'!");
-            }
-            if (sprint.isInt()) {
-                tickManager.requestGameToSprint(sprint.asInt());
-            }
-            else {
-                tickManager.stopSprinting();
-            }
-            return;
-        }
-        if (freeze) {
-            tickManager.setFrozen(!cancel);
-            return;
-        }
-        if (reset) {
-            tickManager.setTickRate(20);
+            case FREEZE -> tickManager.setFrozen(!cancel);
+            case RESET -> tickManager.setTickRate(20);
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -101,8 +101,6 @@ public class TickCommand extends AbstractCommand {
         }
         if (reset) {
             tickManager.setTickRate(20);
-            return;
         }
-        throw new InvalidArgumentsRuntimeException("Must specify a tick action!");
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -36,10 +36,12 @@ public class TickCommand extends AbstractCommand {
     // To step the tick rate while the server is frozen for a specific amount of time, use the 'step' argument and input the amount of ticks using 'amount'.
     // Tick rate stepping is allowing the tick rate to resume for a specific amount of ticks while the server is frozen.
     // After the amount of specified ticks have passed, the tick rate will refreeze.
+    // Step input should not be a number less than one.
     // If the server is not frozen when trying to use the 'step' argument, nothing will happen.
     //
     // To make the tick rate as fast as possible for a specific amount of time, use the 'sprint' argument and input the amount of ticks using 'amount'.
     // The tick rate will increase as much as possible without overloading the server for the amount of specified ticks.
+    // Sprint input should be not be a number less than one.
     // For example, if you want to sprint 200 ticks, the tick rate will run 200 ticks as fast as possible and then return to the previous tick rate.
     // To stop stepping or sprinting early, use the 'cancel' argument.
     //
@@ -80,39 +82,35 @@ public class TickCommand extends AbstractCommand {
     public enum TickActions { RATE, STEP, SPRINT, FREEZE, RESET }
 
     public static void autoExecute(@ArgName("action") TickActions action,
-                                   @ArgName("amount") @ArgPrefixed @ArgDefaultNull ElementTag amount,
+                                   @ArgName("amount") @ArgPrefixed @ArgDefaultText("0") float amount,
                                    @ArgName("cancel") boolean cancel) {
         ServerTickManager tickManager = Bukkit.getServerTickManager();
         switch (action) {
             case RATE -> {
-                if (amount == null || !amount.isFloat()) {
-                    throw new InvalidArgumentsRuntimeException("The rate action must have a decimal number input!");
-                }
-                float rate = amount.asFloat();
-                if (rate < 1 || rate > 10000) {
+                if (amount < 1 || amount > 10000) {
                     throw new InvalidArgumentsRuntimeException("Invalid input! Tick rate must be a decimal number between 1.0 and 10000.0 (inclusive)!");
                 }
-                tickManager.setTickRate(rate);
+                tickManager.setTickRate(amount);
             }
             case STEP -> {
                 if (cancel) {
                     tickManager.stopStepping();
                     return;
                 }
-                if (amount == null || !amount.isInt()) {
-                    throw new InvalidArgumentsRuntimeException("The step action must have a number input!");
+                if (amount < 1) {
+                    throw new InvalidArgumentsRuntimeException("The step action must have a number input not less than 1!");
                 }
-                tickManager.stepGameIfFrozen(amount.asInt());
+                tickManager.stepGameIfFrozen((int)amount);
             }
             case SPRINT -> {
                 if (cancel) {
                     tickManager.stopSprinting();
                     return;
                 }
-                if (amount == null || !amount.isInt()) {
-                    throw new InvalidArgumentsRuntimeException("The sprint action must have a number input!");
+                if (amount < 1) {
+                    throw new InvalidArgumentsRuntimeException("The sprint action must have a number input not less than one!");
                 }
-                tickManager.requestGameToSprint(amount.asInt());
+                tickManager.requestGameToSprint((int)amount);
             }
             case FREEZE -> tickManager.setFrozen(!cancel);
             case RESET -> tickManager.setTickRate(20);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -47,7 +47,6 @@ public class TickCommand extends AbstractCommand {
     // - tick step:cancel
     // -->
 
-    // maybe change the reset to also automatically reset the step or sprint or freeze? or figure out how to do 'step cancel' and have it work with no input
     public TickCommand() {
         setName("tick");
         setSyntax("tick [rate:<rate>/step:<amount>/sprint:<amount>/freeze (cancel)/reset]");

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -21,7 +21,7 @@ public class TickCommand extends AbstractCommand {
     // @Description
     // Controls the server's tick rate. Versions 1.20+ only.
     //
-    // To change the tick rate, use the 'rate' argument and input the amount using 'amount'. The tick rate must be a number between 1.0 and 10000.0.
+    // To change the tick rate, use the 'rate' argument and input the amount using 'amount'. The tick rate must be a number between 1.0 and 10000.0 (inclusive).
     // To reset the tick rate to the normal value (20.0), use the 'reset' argument.
     //
     // To freeze the tick rate, use the 'freeze' argument. To unfreeze, add the 'cancel' argument.

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -1,0 +1,109 @@
+package com.denizenscript.denizen.scripts.commands.world;
+
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import org.bukkit.Bukkit;
+import org.bukkit.ServerTickManager;
+
+public class TickCommand extends AbstractCommand {
+
+    // <--[command]
+    // @Name tick
+    // @Syntax tick [rate:<rate>/step:<amount>/sprint:<amount>/freeze (cancel)/reset]
+    // @Required 1
+    // @Maximum 3
+    // @Short Controls the server's tick rate.
+    // @Group world
+    //
+    // @Description
+    // Controls the server's tick rate.
+    //
+    // To change the tick rate, use the 'rate' argument to change the tick rate. The tick rate must be a number between 1.0 and 10000.0.
+    // To reset the tick rate to the normal value (20.0), use the 'reset' argument.
+    //
+    // To freeze the tick rate, use the 'freeze' argument. To unfreeze, add the 'cancel' argument.
+    // To step the tick rate while the server is frozen for a specific amount of time, use the 'step' argument and provide a duration.
+    // If the server is not frozen when trying to use the 'step' argument, nothing will happen.
+    //
+    // To make the tick rate as fast as possible for a specific amount of time, use the 'sprint' argument and provide a duration.
+    // To stop stepping or sprinting early, use 'cancel' as the input.
+    //
+    // For information about tick rate arguments, see <@link url https://minecraft.wiki/w/Commands/tick>
+    //
+    // @Usage
+    // Use to set the tick rate to 30 ticks per second.
+    // - tick rate:30
+    //
+    // @Usage
+    // Use to step the tick rate for 1000 ticks.
+    // - tick step:1000
+    //
+    // @Usage
+    // Use to stop stepping early.
+    // - tick step:cancel
+    // -->
+
+    // maybe change the reset to also automatically reset the step or sprint or freeze? or figure out how to do 'step cancel' and have it work with no input
+    public TickCommand() {
+        setName("tick");
+        setSyntax("tick [rate:<rate>/step:<amount>/sprint:<amount>/freeze (cancel)/reset]");
+        setRequiredArguments(1, 2);
+        isProcedural = false;
+        autoCompile();
+    }
+
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgPrefixed @ArgName("rate") @ArgDefaultText("-1") float rate,
+                                   @ArgPrefixed @ArgName("step") @ArgDefaultNull ElementTag step,
+                                   @ArgPrefixed @ArgName("sprint") @ArgDefaultNull ElementTag sprint,
+                                   @ArgName("freeze") boolean freeze,
+                                   @ArgName("reset") boolean reset,
+                                   @ArgName("cancel") boolean cancel) {
+        ServerTickManager tickManager = Bukkit.getServerTickManager();
+        if (rate != -1) {
+            if (rate < 1 || rate > 10000) {
+                Debug.echoError(scriptEntry, "Tick rate must between 1.0 and 10000.0 (inclusive)!");
+                return;
+            }
+            tickManager.setTickRate(rate);
+            return;
+        }
+        if (step != null) {
+            if (!step.isInt() && !step.toString().equalsIgnoreCase("cancel")) {
+                throw new InvalidArgumentsRuntimeException("Invalid step input! Must be either an integer or 'cancel'!");
+            }
+            if (step.isInt()) {
+                tickManager.stepGameIfFrozen(step.asInt());
+            }
+            else {
+                tickManager.stopStepping();
+            }
+            return;
+        }
+        if (sprint != null) {
+            if (!sprint.isInt() && !sprint.toString().equalsIgnoreCase("cancel")) {
+                throw new InvalidArgumentsRuntimeException("Invalid step input! Must be either an integer or 'cancel'!");
+            }
+            if (sprint.isInt()) {
+                tickManager.requestGameToSprint(sprint.asInt());
+            }
+            else {
+                tickManager.stopSprinting();
+            }
+            return;
+        }
+        if (freeze) {
+            tickManager.setFrozen(!cancel);
+            return;
+        }
+        if (reset) {
+            tickManager.setTickRate(20);
+            return;
+        }
+        throw new InvalidArgumentsRuntimeException("Must specify a tick action!");
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/TickCommand.java
@@ -63,42 +63,30 @@ public class TickCommand extends AbstractCommand {
                 if (amount == null || !amount.isFloat()) {
                     throw new InvalidArgumentsRuntimeException("The rate action must have a decimal input!");
                 }
-                if (amount.isFloat()) {
-                    if (amount.asFloat() < 1 || amount.asFloat() > 10000) {
-                        throw new InvalidArgumentsRuntimeException("Invalid input! Tick rate must be a decimal between 1.0 and 10000.0 (inclusive)!");
-                    }
-                    tickManager.setTickRate(amount.asFloat());
+                if (amount.asFloat() < 1 || amount.asFloat() > 10000) {
+                    throw new InvalidArgumentsRuntimeException("Invalid input! Tick rate must be a decimal between 1.0 and 10000.0 (inclusive)!");
                 }
+                tickManager.setTickRate(amount.asFloat());
             }
             case STEP -> {
                 if (cancel) {
                     tickManager.stopStepping();
                     return;
                 }
-                if (amount == null) {
+                if (amount == null || !amount.isInt()) {
                     throw new InvalidArgumentsRuntimeException("The step action must have an integer input!");
                 }
-                if (amount.isInt()) {
-                    tickManager.stepGameIfFrozen(amount.asInt());
-                }
-                else {
-                    throw new InvalidArgumentsRuntimeException("Invalid input! Step amount must be an integer!");
-                }
+                tickManager.stepGameIfFrozen(amount.asInt());
             }
             case SPRINT -> {
                 if (cancel) {
                     tickManager.stopSprinting();
                     return;
                 }
-                if (amount == null) {
+                if (amount == null || !amount.isInt()) {
                     throw new InvalidArgumentsRuntimeException("The sprint action must have an integer input!");
                 }
-                if (amount.isInt()) {
-                    tickManager.requestGameToSprint(amount.asInt());
-                }
-                else {
-                    throw new InvalidArgumentsRuntimeException("Invalid input! Sprint amount must be an integer!");
-                }
+                tickManager.requestGameToSprint(amount.asInt());
             }
             case FREEZE -> tickManager.setFrozen(!cancel);
             case RESET -> tickManager.setTickRate(20);


### PR DESCRIPTION
## `tick` command

A Denizen-ified version of the new 1.20.4 vanilla `/tick` command.

### Notes
- This Denizen command is ONLY for 1.20.4. To my knowledge, it's the only version specific Denizen command so far (other than the `light` command but that one is wonky). If this is a bad idea, just let me know and we can think of something. If version specific commands ever become more widespread, it may be a good idea to add a meta doc property called `@Version` or something. Just a thought!
- Maybe the notice about the specific version can be in the `@Warning` section of the meta?
- `scriptEntry` is never used. Not sure if I should try and add something so it is used somewhere or just leave it like that. ¯\\\_(ツ)\_/¯

Tested on 1.20.4 and 1.19.4

Requested by [Cilps](https://discord.com/channels/315163488085475337/1199015338692575254)