### PR TITLE
Fix brewing material choice block handling

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -162,8 +162,8 @@ public class PaperAPIToolsImpl extends PaperAPITools {
         entity.teleport(loc, cause, teleportFlags.toArray(new TeleportFlag[0]));
     }
 
-    record BrewingRecipeWithMatchers(PotionMix potionMix, String inputMatcher, String ingredientMatcher) {}
-    public static final Map<NamespacedKey, BrewingRecipeWithMatchers> potionMixes = new HashMap<>();
+    record BrewingRecipeMatchers(String inputMatcher, String ingredientMatcher) {}
+    public static final Map<NamespacedKey, BrewingRecipeMatchers> potionMixes = new HashMap<>();
 
     @Override
     public void registerBrewingRecipe(String keyName, ItemStack result, String input, String ingredient, ItemScriptContainer itemScriptContainer) {
@@ -179,9 +179,8 @@ public class PaperAPIToolsImpl extends PaperAPITools {
             return;
         }
         NamespacedKey key = new NamespacedKey(Denizen.getInstance(), keyName);
-        PotionMix mix = new PotionMix(key, result, inputChoice, ingredientChoice);
-        potionMixes.put(key, new BrewingRecipeWithMatchers(mix, input.startsWith("matcher:") ? input : null, ingredient.startsWith("matcher:") ? ingredient : null));
-        Bukkit.getPotionBrewer().addPotionMix(mix);
+        potionMixes.put(key, new BrewingRecipeMatchers(input.startsWith("matcher:") ? input : null, ingredient.startsWith("matcher:") ? ingredient : null));
+        Bukkit.getPotionBrewer().addPotionMix(new PotionMix(key, result, inputChoice, ingredientChoice));
     }
 
     @Override
@@ -218,16 +217,6 @@ public class PaperAPIToolsImpl extends PaperAPITools {
             mats[i] = items[i].getType();
         }
         return new RecipeChoice.MaterialChoice(mats);
-    }
-
-    @Override
-    public boolean isDenizenMix(ItemStack currInput, ItemStack ingredient) {
-        for (BrewingRecipeWithMatchers brewing : potionMixes.values()) {
-            if (brewing.potionMix().getInput().test(currInput) && brewing.potionMix().getIngredient().test(ingredient)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -37,6 +37,7 @@ import org.bukkit.scoreboard.Team;
 import org.bukkit.util.Consumer;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class PaperAPIToolsImpl extends PaperAPITools {
@@ -237,6 +238,11 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     @Override
     public String getBrewingRecipeIngredientMatcher(NamespacedKey recipeId) {
         return potionMixes.get(recipeId).ingredientMatcher();
+    }
+
+    @Override
+    public RecipeChoice createPredicateRecipeChoice(Predicate<ItemStack> predicate) {
+        return PotionMix.createPredicateChoice(predicate);
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
@@ -626,7 +626,7 @@ public class ItemScriptHelper implements Listener {
                 event.getResults().set(i, currInput);
                 continue;
             }
-            // If it's a custom recipe, and either the input or ingredient are material choices and should be blocked
+            // If it's a custom recipe and either the input or ingredient are material choices and should be blocked
             if (customRecipe != null && (shouldBlockChoice(customRecipe.ingredient(), ingredientBlockCraft) || shouldBlockChoice(customRecipe.input(), inputBlockCraft))) {
                 event.getResults().set(i, currInput);
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.bukkit.ScriptReloadEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
@@ -595,15 +596,45 @@ public class ItemScriptHelper implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     public void onBrewingStandBrews(BrewEvent event) {
         ItemStack ingredient = event.getContents().getIngredient();
-        ItemStack currInput;
+        boolean ingredientBlockCraft = !isAllowedToCraftWith(ingredient);
+        List<ItemHelper.BrewingRecipe> potentialRecipes = null;
         for (int i = 0; i < 3; i++) {
-            currInput = event.getContents().getItem(i);
-            if(!NMSHandler.itemHelper.isValidMix(currInput, ingredient) || !PaperAPITools.instance.isDenizenMix(currInput, ingredient)) {
-                if (!isAllowedToCraftWith(currInput)) {
-                    event.setCancelled(true);
+            ItemStack currInput = event.getContents().getItem(i);
+            boolean inputBlockCraft = !isAllowedToCraftWith(currInput);
+            if (!inputBlockCraft && !ingredientBlockCraft) {
+                continue;
+            }
+            ItemHelper.BrewingRecipe customRecipe = null;
+            if (Denizen.supportsPaper && NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+                if (potentialRecipes == null) {
+                    potentialRecipes = new ArrayList<>();
+                    for (ItemHelper.BrewingRecipe recipe : NMSHandler.itemHelper.getCustomBrewingRecipes().values()) {
+                        if (recipe.ingredient().test(ingredient)) {
+                            potentialRecipes.add(recipe);
+                        }
+                    }
+                }
+                for (ItemHelper.BrewingRecipe recipe : potentialRecipes) {
+                    if (currInput != null && recipe.input().test(currInput)) {
+                        customRecipe = recipe;
+                        break;
+                    }
                 }
             }
+            // If it's a vanilla mix and either the ingredient or input should be blocked (checked above)
+            if (customRecipe == null && NMSHandler.itemHelper.isValidMix(currInput, ingredient)) {
+                event.getResults().set(i, currInput);
+                continue;
+            }
+            // If it's a custom recipe, and either the input or ingredient are material choices and should be blocked
+            if (customRecipe != null && (shouldBlockChoice(customRecipe.ingredient(), ingredientBlockCraft) || shouldBlockChoice(customRecipe.input(), inputBlockCraft))) {
+                event.getResults().set(i, currInput);
+            }
         }
+    }
+
+    private boolean shouldBlockChoice(RecipeChoice choice, boolean blockCraft) {
+        return blockCraft && choice instanceof RecipeChoice.MaterialChoice;
     }
 
     @EventHandler(priority = EventPriority.LOW)

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -281,13 +281,13 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
                 addChoice.accept(smithingRecipe.getAddition());
             }
             else if (brewingRecipe != null) {
-                if (brewingRecipe.ingredient() != null) {
+                if (brewingRecipe.ingredient() instanceof RecipeChoice.ExactChoice || brewingRecipe.ingredient() instanceof RecipeChoice.MaterialChoice) {
                     addChoice.accept(brewingRecipe.ingredient());
                 }
                 else {
                     recipeItems.addObject(new ElementTag(PaperAPITools.instance.getBrewingRecipeIngredientMatcher(recipeKey), true));
                 }
-                if (brewingRecipe.input() != null) {
+                if (brewingRecipe.input() instanceof RecipeChoice.ExactChoice || brewingRecipe.input() instanceof RecipeChoice.MaterialChoice) {
                     addChoice.accept(brewingRecipe.input());
                 }
                 else {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -123,10 +123,6 @@ public class PaperAPITools {
     public void clearBrewingRecipes() {
     }
 
-    public boolean isDenizenMix(ItemStack currInput, ItemStack ingredient) {
-        return false;
-    }
-
     public String getBrewingRecipeInputMatcher(NamespacedKey recipeId) {
         return null;
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -24,6 +24,7 @@ import org.bukkit.util.Consumer;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.function.Predicate;
 
 public class PaperAPITools {
 
@@ -132,6 +133,10 @@ public class PaperAPITools {
 
     public String getBrewingRecipeIngredientMatcher(NamespacedKey recipeId) {
         return null;
+    }
+
+    public RecipeChoice createPredicateRecipeChoice(Predicate<ItemStack> predicate) {
+        throw new UnsupportedOperationException();
     }
 
     public String getDeathMessage(PlayerDeathEvent event) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.nms.v1_20.helpers;
 
-import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
@@ -510,10 +509,10 @@ public class ItemHelperImpl extends ItemHelper {
                 if (PaperPotionMix_CLASS == null) {
                     PaperPotionMix_CLASS = paperMix.getClass();
                 }
-                RecipeChoice ingredientChoice = convertChoice(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "ingredient", paperMix));
-                RecipeChoice inputChoice = convertChoice(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "input", paperMix));
+                RecipeChoice ingredient = convertChoice(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "ingredient", paperMix));
+                RecipeChoice input = convertChoice(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "input", paperMix));
                 ItemStack result = CraftItemStack.asBukkitCopy(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "result", paperMix));
-                return new BrewingRecipe(inputChoice, ingredientChoice, result);
+                return new BrewingRecipe(input, ingredient, result);
             });
         }
         return customBrewingRecipes;

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.nms.v1_20.helpers;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
@@ -10,6 +11,7 @@ import com.denizenscript.denizen.nms.v1_20.impl.ProfileEditorImpl;
 import com.denizenscript.denizen.nms.v1_20.impl.jnbt.CompoundTagImpl;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
+import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
@@ -508,16 +510,21 @@ public class ItemHelperImpl extends ItemHelper {
                 if (PaperPotionMix_CLASS == null) {
                     PaperPotionMix_CLASS = paperMix.getClass();
                 }
-                Predicate<net.minecraft.world.item.ItemStack> ingredient = ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "ingredient", paperMix);
-                Predicate<net.minecraft.world.item.ItemStack> input = ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "input", paperMix);
-                // Not an instance of net.minecraft.world.item.crafting.Ingredient = a predicate recipe choice
-                RecipeChoice ingredientChoice = ingredient instanceof Ingredient nmsRecipeChoice ? CraftRecipe.toBukkit(nmsRecipeChoice) : null;
-                RecipeChoice inputChoice = input instanceof Ingredient nmsRecipeChoice ? CraftRecipe.toBukkit(nmsRecipeChoice) : null;
+                RecipeChoice ingredientChoice = convertChoice(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "ingredient", paperMix));
+                RecipeChoice inputChoice = convertChoice(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "input", paperMix));
                 ItemStack result = CraftItemStack.asBukkitCopy(ReflectionHelper.getFieldValue(PaperPotionMix_CLASS, "result", paperMix));
                 return new BrewingRecipe(inputChoice, ingredientChoice, result);
             });
         }
         return customBrewingRecipes;
+    }
+
+    private RecipeChoice convertChoice(Predicate<net.minecraft.world.item.ItemStack> nmsPredicate) {
+        // Not an instance of net.minecraft.world.item.crafting.Ingredient = a predicate recipe choice
+        if (nmsPredicate instanceof Ingredient ingredient) {
+            return CraftRecipe.toBukkit(ingredient);
+        }
+        return PaperAPITools.instance.createPredicateRecipeChoice(item -> nmsPredicate.test(CraftItemStack.asNMSCopy(item)));
     }
 
     @Override


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1192100486631923783).

## Additions

- `PaperAPITools#createPredicateRecipeChoice` - ...creates a predicate recipe choice.
- `ItemScriptHelper#shouldBlockChoice` - util method used in the new brewing handling.
- `ItemHelperImpl(1.20)#convertChoice` - util method to convert a `Predicate<ItemStack(NMS)>` used internally in brewing recipes to a Bukkit recipe choice.

## Changes

- Fixed/Updated `ItemScriptHelper`'s handling of brewing & blocking Denizen items in material choices:
  - It now properly supports custom brewing recipes & checks them for material choices.
  - It now more closely matchers vanilla behavior, where it avoids brewing items that don't match the recipe (e.g. Denizen items in a material choice), while still letting other items, if any, brew as usual - this is done by changing the event's result items instead of cancelling it.
- `ItemHelper#getCustomBrewingRecipes` now properly returns a predicate recipe choice instead of `null` (updated related usages).
- Removed `PaperAPITools#isDenizenMix` as it is no longer used.
- `PaperAPIToolsImpl` no longer stores the `PotionMix` in the `potionMixes` map, as it was only ever used by `PaperAPITools#isDenizenMix`.

> [!NOTE]
> The NMS method used by `ItemHelper#isValidMix` checks both vanilla and custom recipes, which is why the new handling checks for a custom recipe first and then if it can't find one & that's true it knows it's a vanilla recipe.
> This works, but can result in custom recipes technically being checked twice - an alternative is to set the internal custom brewing recipes map to an empty map, call that method, and then set the original map back in, which might be more efficient, but would also mean more messy reflection.