### PR TITLE
Update structure support

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4272,12 +4272,12 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @name Structure lookups
             // @description
             // There are several tags to locate structures, such as <@link tag LocationTag.find_structure> and <@link tag LocationTag.find_structure_type>.
-            // These tags work similarly to the '/locate' command, but can have several side effects/edge cases:
+            // These tags work similarly to the '/locate' command, and have several side effects/edge cases:
             // - The radius is in chunks, but isn't always a set square radius around the origin; certain structures may modify the amounts of chunks checked.
             //   For example, woodland mansions can potentially check up to 20,000 blocks away (or more) regardless of the radius used.
             // - Lookups can take a long amount of time (several seconds, over 10 in some cases), especially when looking for unexplored structures,
             //   which will cause the server to freeze while searching.
-            // - They will not load/generate chunks.
+            // - They will not load/generate chunks (but can search not-yet-generated chunks and return a location in them).
             // - They can lead to situations where the server hangs and crashes when trying to find unexplored structures (if there aren't any/any nearby),
             //   as it keeps looking further and further out.
             // - The returned location only contains the X and Z values, and will always have a Y value of 0.
@@ -4290,7 +4290,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @warning See <@link language Structure lookups> for potential issues/edge cases in structure lookups.
             // @group finding
             // @description
-            // Finds the closet structure of the given type within the specified chunk radius, optionally only searching for unexplored ones.
+            // Finds the closet structure of the given type within the specified chunk radius (if any), optionally only searching for unexplored ones.
             // For a list of default structures, see <@link url https://minecraft.wiki/w/Structure#ID>.
             // Alternatively, you can specify a custom structure from a datapack, plugin, etc. as a namespaced key.
             // See also <@link tag LocationTag.find_structure_type> to find structures by type,
@@ -4328,6 +4328,9 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @description
             // Finds the closet structure of the given structure type within the specified chunk radius, optionally only searching for unexplored ones.
             // See <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/generator/structure/StructureType.html> for all available structure types.
+            // The returned map, if any, has 2 keys:
+            // - "location", <@link ObjectType LocationTag> of the structure found.
+            // - "structure", <@link ObjectType ElementTag> of the type of structure found.
             // See also <@link tag LocationTag.find_structure> to find specific structures instead of looking them up by type.
             // -->
             tagProcessor.registerTag(MapTag.class, MapTag.class, "find_structure_type", (attribute, object, input) -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4273,15 +4273,11 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @description
             // There are several tags to locate structures, such as <@link tag LocationTag.find_structure> and <@link tag LocationTag.find_structure_type>.
             // These tags work similarly to the '/locate' command, and have several side effects/edge cases:
-            // - The radius is in chunks, but isn't always a set square radius around the origin; certain structures may modify the amounts of chunks checked.
-            //   For example, woodland mansions can potentially check up to 20,000 blocks away (or more) regardless of the radius used.
-            // - Lookups can take a long amount of time (several seconds, over 10 in some cases), especially when looking for unexplored structures,
-            //   which will cause the server to freeze while searching.
+            // - The radius is in chunks, but isn't always a set square radius around the origin; certain structures may modify the amounts of chunks checked. For example, woodland mansions can potentially check up to 20,000 blocks away (or more) regardless of the radius used.
+            // - Lookups can take a long amount of time (several seconds, over 10 in some cases), especially when looking for unexplored structures, which will cause the server to freeze while searching.
             // - They will not load/generate chunks (but can search not-yet-generated chunks and return a location in them).
-            // - They can lead to situations where the server hangs and crashes when trying to find unexplored structures (if there aren't any/any nearby),
-            //   as it keeps looking further and further out.
-            // - The returned location only contains the X and Z values, and will always have a Y value of 0.
-            //   Tags like <@link tag LocationTag.highest> are available, but note that they require the chunk to be loaded.
+            // - They can lead to situations where the server hangs and crashes when trying to find unexplored structures (if there aren't any/any nearby), as it keeps looking further and further out.
+            // - The returned location only contains the X and Z values, and will always have a Y value of 0. Tags like <@link tag LocationTag.highest> are available, but note that they require the chunk to be loaded.
             // -->
 
             // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4271,8 +4271,8 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // <--[language]
             // @name Structure lookups
             // @description
-            // There are several tags to locate structures, such as <@link tag LocationTag.find_structure> and <@link tag LocationTag.find_structure_type>.
-            // These tags work similarly to the '/locate' command, and have several side effects/edge cases:
+            // Structures can be located using <@link tag LocationTag.find_structure>.
+            // It works similarly to the '/locate' command, and has several side effects/edge cases:
             // - The radius is in chunks, but isn't always a set square radius around the origin; certain structures may modify the amounts of chunks checked. For example, woodland mansions can potentially check up to 20,000 blocks away (or more) regardless of the radius used.
             // - Lookups can take a long amount of time (several seconds, over 10 in some cases), especially when looking for unexplored structures, which will cause the server to freeze while searching.
             // - They will not load/generate chunks (but can search not-yet-generated chunks and return a location in them).
@@ -4289,8 +4289,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // Finds the closest structure of the given type within the specified chunk radius (if any), optionally only searching for unexplored ones.
             // For a list of default structures, see <@link url https://minecraft.wiki/w/Structure#ID>.
             // Alternatively, you can specify a custom structure from a datapack, plugin, etc. as a namespaced key.
-            // See also <@link tag LocationTag.find_structure_type> to find structures by type,
-            // and <@link tag server.structures> for all structures currently available on the server.
+            // See also <@link tag server.structures> for all structures currently available on the server.
             // @example
             // # Use to find the desert temple closest to the player, and tell them what direction it's in.
             // - define found <player.location.find_structure[structure=desert_pyramid;radius=200].if_null[null]>
@@ -4321,56 +4320,6 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 }
                 StructureSearchResult searchResult = object.getWorld().locateNearestStructure(object, structure, radius.asInt(), unexplored.asBoolean());
                 return searchResult != null ? new LocationTag(searchResult.getLocation()) : null;
-            });
-
-            // <--[tag]
-            // @attribute <LocationTag.find_structure_type[type=<type>;radius=<#>(;unexplored=<true/{false}>)]>
-            // @returns MapTag
-            // @warning See <@link language Structure lookups> for potential issues/edge cases in structure lookups.
-            // @group finding
-            // @description
-            // Finds the closest structure of the given structure type within the specified chunk radius, optionally only searching for unexplored ones.
-            // See <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/generator/structure/StructureType.html> for all available structure types.
-            // The returned map, if any, has 2 keys:
-            // - "location", <@link ObjectType LocationTag> of the structure found.
-            // - "structure", <@link ObjectType ElementTag> of the type of structure found.
-            // See also <@link tag LocationTag.find_structure> to find specific structures instead of looking them up by type.
-            // @example
-            // # Use to find the closest structure of the "jigsaw" structure type (ancient cities, for example), and tell the player what direction it's in.
-            // - define found <player.location.find_structure_type[type=jigsaw;radius=200].if_null[null]>
-            // - if <[found]> != null:
-            //   - narrate "The <[found.structure]> structure is <player.location.direction[<[found.location]>]> of you!"
-            // - else:
-            //   - narrate "No structure found."
-            // -->
-            tagProcessor.registerTag(MapTag.class, MapTag.class, "find_structure_type", (attribute, object, input) -> {
-                ElementTag structureTypeName = input.getRequiredObjectAs("type", ElementTag.class, attribute);
-                ElementTag radius = input.getRequiredObjectAs("radius", ElementTag.class, attribute);
-                if (structureTypeName == null || radius == null) {
-                    return null;
-                }
-                org.bukkit.generator.structure.StructureType structureType = Registry.STRUCTURE_TYPE.get(Utilities.parseNamespacedKey(structureTypeName.asString()));
-                if (structureType == null) {
-                    attribute.echoError("Invalid structure type specified: " + structureTypeName + '.');
-                    return null;
-                }
-                if (!radius.isInt()) {
-                    attribute.echoError("Invalid radius specified '" + radius + "': must be a number.");
-                    return null;
-                }
-                ElementTag unexplored = input.getElement("unexplored", "false");
-                if (!unexplored.isBoolean()) {
-                    attribute.echoError("Invalid 'unexplored' value '" + unexplored + "': must be a boolean.");
-                    return null;
-                }
-                StructureSearchResult searchResult = object.getWorld().locateNearestStructure(object, structureType, radius.asInt(), unexplored.asBoolean());
-                if (searchResult == null) {
-                    return null;
-                }
-                MapTag result = new MapTag();
-                result.putObject("location", new LocationTag(searchResult.getLocation()));
-                result.putObject("structure", new ElementTag(Utilities.namespacedKeyToString(searchResult.getStructure().getKey()), true));
-                return result;
             });
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -3065,9 +3065,9 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // <--[tag]
             // @attribute <LocationTag.find.structure[<type>].within[<#.#>]>
             // @returns LocationTag
-            // @deprecated Use 'LocationTag.find_structure'.
+            // @deprecated Use 'LocationTag.find_structure' on 1.19+.
             // @description
-            // Deprecated in favor of <@link tag LocationTag.find_structure>.
+            // Deprecated in favor of <@link tag LocationTag.find_structure> on 1.19+.
             // -->
             else if (attribute.startsWith("structure", 2) && attribute.hasContext(2)) {
                 if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
@@ -3090,9 +3090,9 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // <--[tag]
             // @attribute <LocationTag.find.unexplored_structure[<type>].within[<#.#>]>
             // @returns LocationTag
-            // @deprecated Use 'LocationTag.find_structure' with 'unexplored=true'.
+            // @deprecated Use 'LocationTag.find_structure' with 'unexplored=true' on 1.19+.
             // @description
-            // Deprecated in favor of <@link tag LocationTag.find_structure> with 'unexplored=true'.
+            // Deprecated in favor of <@link tag LocationTag.find_structure> with 'unexplored=true' on 1.19+.
             // -->
             else if (attribute.startsWith("unexplored_structure", 2) && attribute.hasContext(2)) {
                 if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4281,7 +4281,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // -->
 
             // <--[tag]
-            // @attribute <LocationTag.find_structure[structure=<structure>;radius=<number>(;unexplored=<true/{false}>)]>
+            // @attribute <LocationTag.find_structure[structure=<structure>;radius=<#>(;unexplored=<true/{false}>)]>
             // @returns LocationTag
             // @warning See <@link language Structure lookups> for potential issues/edge cases in structure lookups.
             // @group finding
@@ -4317,7 +4317,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             });
 
             // <--[tag]
-            // @attribute <LocationTag.find_structure_type[type=<type>;radius=<number>(;unexplored=<true/{false}>)]>
+            // @attribute <LocationTag.find_structure_type[type=<type>;radius=<#>(;unexplored=<true/{false}>)]>
             // @returns MapTag
             // @warning See <@link language Structure lookups> for potential issues/edge cases in structure lookups.
             // @group finding

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4286,11 +4286,18 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @warning See <@link language Structure lookups> for potential issues/edge cases in structure lookups.
             // @group finding
             // @description
-            // Finds the closet structure of the given type within the specified chunk radius (if any), optionally only searching for unexplored ones.
+            // Finds the closest structure of the given type within the specified chunk radius (if any), optionally only searching for unexplored ones.
             // For a list of default structures, see <@link url https://minecraft.wiki/w/Structure#ID>.
             // Alternatively, you can specify a custom structure from a datapack, plugin, etc. as a namespaced key.
             // See also <@link tag LocationTag.find_structure_type> to find structures by type,
             // and <@link tag server.structures> for all structures currently available on the server.
+            // @example
+            // # Use to find the desert temple closest to the player, and tell them what direction it's in.
+            // - define found <player.location.find_structure[structure=desert_pyramid;radius=200].if_null[null]>
+            // - if <[found]> != null:
+            //   - narrate "The closet desert temple is <player.location.direction[<[found]>]> of you!"
+            // - else:
+            //   - narrate "No desert temple found."
             // -->
             tagProcessor.registerTag(LocationTag.class, MapTag.class, "find_structure", (attribute, object, input) -> {
                 ElementTag structureName = input.getRequiredObjectAs("structure", ElementTag.class, attribute);
@@ -4322,12 +4329,19 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @warning See <@link language Structure lookups> for potential issues/edge cases in structure lookups.
             // @group finding
             // @description
-            // Finds the closet structure of the given structure type within the specified chunk radius, optionally only searching for unexplored ones.
+            // Finds the closest structure of the given structure type within the specified chunk radius, optionally only searching for unexplored ones.
             // See <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/generator/structure/StructureType.html> for all available structure types.
             // The returned map, if any, has 2 keys:
             // - "location", <@link ObjectType LocationTag> of the structure found.
             // - "structure", <@link ObjectType ElementTag> of the type of structure found.
             // See also <@link tag LocationTag.find_structure> to find specific structures instead of looking them up by type.
+            // @example
+            // # Use to find the closest structure of the "jigsaw" structure type (ancient cities, for example), and tell the player what direction it's in.
+            // - define found <player.location.find_structure_type[type=jigsaw;radius=200].if_null[null]>
+            // - if <[found]> != null:
+            //   - narrate "The <[found.structure]> structure is <player.location.direction[<[found.location]>]> of you!"
+            // - else:
+            //   - narrate "No structure found."
             // -->
             tagProcessor.registerTag(MapTag.class, MapTag.class, "find_structure_type", (attribute, object, input) -> {
                 ElementTag structureTypeName = input.getRequiredObjectAs("type", ElementTag.class, attribute);

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -944,18 +944,31 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // <--[tag]
         // @attribute <server.structure_types>
         // @returns ListTag
+        // @deprecated use 'server.structures'
         // @description
-        // Returns a list of all structure types known to the server.
-        // Generally used with <@link tag LocationTag.find.structure.within>.
-        // This is NOT their Bukkit names, as seen at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/StructureType.html>.
-        // Instead these are the internal names tracked by Spigot and presumably matching Minecraft internals.
-        // These are all lowercase, as the internal names are lowercase and supposedly are case-sensitive.
-        // It is unclear why the "StructureType" class in Bukkit is not simply an enum as most similar listings are.
+        // Deprecated in favor of <@link tag server.structures>.
         // -->
         tagProcessor.registerTag(ListTag.class, "structure_types", (attribute, object) -> {
             listDeprecateWarn(attribute);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+                BukkitImplDeprecations.oldStructureTypes.warn(attribute.context);
+            }
             return new ListTag(StructureType.getStructureTypes().keySet());
         }, "list_structure_types");
+
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+
+            // <--[tag]
+            // @attribute <server.structures>
+            // @returns ListTag
+            // @description
+            // Returns a list of all structures known to the server, including custom ones added by datapacks.
+            // See <@link url https://minecraft.wiki/w/Structure> for more information.
+            // -->
+            tagProcessor.registerTag(ListTag.class, "structures", (attribute, object) -> {
+                return new ListTag(Registry.STRUCTURE.stream().toList(), structure -> new ElementTag(Utilities.namespacedKeyToString(structure.getKey()), true));
+            });
+        }
 
         // <--[tag]
         // @attribute <server.statistic_type[<statistic>]>

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -963,7 +963,8 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
             // @returns ListTag
             // @description
             // Returns a list of all structures known to the server, including custom ones added by datapacks.
-            // See <@link url https://minecraft.wiki/w/Structure> for more information.
+            // See <@link url https://minecraft.wiki/w/Structure> for more information and a list of default structures.
+            // For information on locating specific structures, see <@link language Structure lookups>.
             // -->
             tagProcessor.registerTag(ListTag.class, "structures", (attribute, object) -> {
                 return new ListTag(Registry.STRUCTURE.stream().toList(), structure -> new ElementTag(Utilities.namespacedKeyToString(structure.getKey()), true));

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -963,8 +963,8 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
             // @returns ListTag
             // @description
             // Returns a list of all structures known to the server, including custom ones added by datapacks.
-            // See <@link url https://minecraft.wiki/w/Structure> for more information and a list of default structures.
-            // For information on locating specific structures, see <@link language Structure lookups>.
+            // For more information and a list of default structures, see <@link url https://minecraft.wiki/w/Structure>.
+            // For locating specific structures, see <@link language Structure lookups>.
             // -->
             tagProcessor.registerTag(ListTag.class, "structures", (attribute, object) -> {
                 return new ListTag(Registry.STRUCTURE.stream().toList(), structure -> new ElementTag(Utilities.namespacedKeyToString(structure.getKey()), true));

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -944,9 +944,9 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // <--[tag]
         // @attribute <server.structure_types>
         // @returns ListTag
-        // @deprecated use 'server.structures'
+        // @deprecated use 'server.structures' on 1.19+.
         // @description
-        // Deprecated in favor of <@link tag server.structures>.
+        // Deprecated in favor of <@link tag server.structures> on 1.19+.
         // -->
         tagProcessor.registerTag(ListTag.class, "structure_types", (attribute, object) -> {
             listDeprecateWarn(attribute);

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -217,6 +217,10 @@ public class BukkitImplDeprecations {
     public static Warning assignmentRemove = new SlowWarning("assignmentRemove", "'assignment remove' without a script is deprecated: use 'clear' to clear all scripts, or 'remove' to remove one at a time.");
     public static Warning npcScriptSingle = new SlowWarning("npcScriptSingle", "'npc.script' is deprecated in favor of 'npc.scripts' (plural).");
 
+    // Added 2024/02/03
+    public static Warning oldStructureTypes = new SlowWarning("oldStructureTypes", "'server.structure_types' is based on outdated API and doesn't support modern datapack features. Use 'server.structures' instead.");
+    public static Warning findStructureTags = new SlowWarning("findStructureTags", "'LocationTag.find.structure' and related tags are deprecated in favor of 'LocationTag.find_structure' and 'find_structure_type'.");
+
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -219,7 +219,7 @@ public class BukkitImplDeprecations {
 
     // Added 2024/02/04
     public static Warning oldStructureTypes = new SlowWarning("oldStructureTypes", "'server.structure_types' is based on outdated API and doesn't support modern datapack features. Use 'server.structures' instead.");
-    public static Warning findStructureTags = new SlowWarning("findStructureTags", "'LocationTag.find.structure' and related tags are deprecated in favor of 'LocationTag.find_structure' and 'find_structure_type'.");
+    public static Warning findStructureTags = new SlowWarning("findStructureTags", "'LocationTag.find.structure' and related tags are deprecated in favor of 'LocationTag.find_structure'.");
 
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -217,7 +217,7 @@ public class BukkitImplDeprecations {
     public static Warning assignmentRemove = new SlowWarning("assignmentRemove", "'assignment remove' without a script is deprecated: use 'clear' to clear all scripts, or 'remove' to remove one at a time.");
     public static Warning npcScriptSingle = new SlowWarning("npcScriptSingle", "'npc.script' is deprecated in favor of 'npc.scripts' (plural).");
 
-    // Added 2024/02/03
+    // Added 2024/02/04
     public static Warning oldStructureTypes = new SlowWarning("oldStructureTypes", "'server.structure_types' is based on outdated API and doesn't support modern datapack features. Use 'server.structures' instead.");
     public static Warning findStructureTags = new SlowWarning("findStructureTags", "'LocationTag.find.structure' and related tags are deprecated in favor of 'LocationTag.find_structure' and 'find_structure_type'.");
 


### PR DESCRIPTION
Requested on [Discord](https://discord.com/channels/315163488085475337/1125979533212917820).

## Changes

- Deprecated `LocationTag.find.structure[<type>].within[<#.#>]` and `LocationTag.find.unexplored_structure[<type>].within[<#.#>]` in favor of `LocationTag.find_structure` on 1.19+.
- Deprecated `server.structure_types` in favor of `server.structures` on 1.19+.
- `oldStructureTypes` deprecation warning, for `server.structure_types`.
- `findStructureTags` deprecation warning, for the `LocationTag.find.structure` tags.

## Additions

- `Structure lookups` language doc, detailing some edge-cases/issues with structure lookups.
- `LocationTag.find_structure[structure=<structure>;radius=<number>(;unexplored=<true/{false}>)]` - does a structure lookup.
- `LocationTag.find_structure_type[type=<type>;radius=<number>(;unexplored=<true/{false}>)]` - does a structure lookup by structure type (e.g. `jigsaw` structures).

> [!NOTE]
>  The old deprecated Spigot API for structures was called `StructureTypes`, and used `server.structure_types` as the tag to list them, which is now also deprecated.
> The issue is that there are _actual_ structure types now, which should have their own listing tag; can probably name it ...`structure_categories` or something, but that's a bit dumb.
> It's almost all the same values as the deprecated `structure_types` tag, but obviously that's still a breaking change.
> We could not have a listing tag for these now? they're probably not as important as the actual structures which do have a listing tag - let me know what do you think.

> [!NOTE]
> Added the 2 deprecations as `SlowWarning` instead of `FutureWarning`, as the API behind them is already (and has been) deprecated in Spigot, and provides inaccurate/missing information.
> Can make it `FutureWarning` and bump once 1.19 is the minimum supported version? but they already only show up on 1.19+, so made sense to always show a proper warning for something that's actively inaccurate & deprecated.