### PR TITLE
`block equips <item>`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -66,7 +66,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(BlockCooksSmeltsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockDestroyedByExplosionEvent.class);
         ScriptEvent.registerScriptEvent(BlockDispensesScriptEvent.class);
-        ScriptEvent.registerScriptEvent(BlockEquipsItemOnEntityScriptEvent.class);
+        ScriptEvent.registerScriptEvent(BlockEquipsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockExplodesScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockFadesScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockFallsScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -66,6 +66,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(BlockCooksSmeltsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockDestroyedByExplosionEvent.class);
         ScriptEvent.registerScriptEvent(BlockDispensesScriptEvent.class);
+        ScriptEvent.registerScriptEvent(BlockEquipsItemOnEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockExplodesScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockFadesScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockFallsScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemOnEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemOnEntityScriptEvent.java
@@ -1,0 +1,90 @@
+package com.denizenscript.denizen.events.block;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDispenseArmorEvent;
+
+public class BlockEquipsItemOnEntityScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // <block> equips <item> (on <entity>)
+    //
+    // @Group Block
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a block dispenses armor and is equipped to an entity.
+    //
+    // @Context
+    // <context.block> returns the MaterialTag of the dispenser.
+    // <context.item> returns the ItemTag of the armor being dispensed.
+    // <context.entity> returns the EntityTag of the entity having the armor equipped.
+    // <context.location> returns the LocationTag of the dispenser.
+    //
+    // @Player when the equipped entity is a player.
+    //
+    // @NPC when the equipped entity is an NPC.
+    // -->
+
+    public BlockEquipsItemOnEntityScriptEvent() {
+        registerCouldMatcher("<block> equips <item> (on <entity>)");
+    }
+
+    MaterialTag block;
+    ItemTag item;
+    EntityTag entity;
+    LocationTag location;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!path.tryArgObject(0, block)) {
+            return false;
+        }
+        if (!path.tryArgObject(2, item)) {
+            return false;
+        }
+        if (path.eventArgLowerAt(3).equals("on") && !path.tryArgObject(4, entity)) {
+            return false;
+        }
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "block" -> block;
+            case "item" -> item;
+            case "entity" -> entity;
+            case "location" -> location;
+            default -> super.getContext(name);
+        };
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(entity);
+    }
+
+    @EventHandler
+    public void onBlockEquipsItemOntoEntity(BlockDispenseArmorEvent event) {
+        block = new MaterialTag(event.getBlock());
+        item = new ItemTag(event.getItem());
+        entity = new EntityTag(event.getTargetEntity());
+        location = new LocationTag(event.getBlock().getLocation());
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemOnEntityScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemOnEntityScriptEvent.java
@@ -35,6 +35,11 @@ public class BlockEquipsItemOnEntityScriptEvent extends BukkitScriptEvent implem
     // @Player when the equipped entity is a player.
     //
     // @NPC when the equipped entity is an NPC.
+    //
+    // @Example
+    // # Will cause leather armor to be dispensed like a normal item and not be equipped on an armor stand.
+    // on dispenser equips leather* on armor_stand:
+    // - determined cancelled
     // -->
 
     public BlockEquipsItemOnEntityScriptEvent() {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
@@ -23,7 +23,7 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
     //
     // @Cancellable true
     //
-    // @Triggers when a block dispenses armor and is equipped to an entity.
+    // @Triggers when armor is equipped to an entity by a dispenser.
     //
     // @Switch on:<entity> to only process the event if the entity having the armor equipped matches the entity input.
     //
@@ -37,9 +37,9 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
     // @NPC when the equipped entity is an NPC.
     //
     // @Determine
-    // "ITEM:<ItemTag>" to set the armor being equipped.
+    // "ITEM:<ItemTag>" to set the item being dispensed.
     //
-    // @Warning Determined armor types must match or armor will be assigned incorrect slots (for example, if the original item was a helmet but the new item is boots, the boots will be assigned to the helmet slot and will not display properly). Determining a non-armor item will be dispensed normally.
+    // @Warning Determined armor types must match or armor will be assigned incorrect slots (for example, if the original item was a helmet but the new item is boots, the boots will be assigned to the helmet slot and will not display properly). If you determine a non-armor item, it will be dispensed normally.
     //
     // @Example
     // # Will cause leather armor to be dispensed like a normal item and not be equipped on an armor stand.

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
@@ -37,7 +37,7 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
     // @NPC when the equipped entity is an NPC.
     //
     // @Determine
-    // ItemTag to set the armor being equipped.
+    // "ITEM:<ItemTag>" to set the armor being equipped.
     //
     // @Warning Determined armor types must match or armor will be assigned incorrect slots (for example, if the original item was a helmet but the new item is boots, the boots will be assigned to the helmet slot and will not display properly). Determining a non-armor item will be dispensed normally.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
@@ -16,7 +16,7 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
 
     // <--[event]
     // @Events
-    // <block> equips <item>
+    // block equips <item>
     //
     // @Group Block
     //
@@ -40,25 +40,22 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
     //
     // @Example
     // # Will cause leather armor to be dispensed like a normal item and not be equipped on an armor stand.
-    // on dispenser equips leather* on:armor_stand:
+    // on block equips leather* on:armor_stand:
     // - determined cancelled
     // -->
 
     public BlockEquipsItemScriptEvent() {
-        registerCouldMatcher("<block> equips <item>");
+        registerCouldMatcher("block equips <item>");
         registerSwitches("on");
     }
 
-    MaterialTag block;
     ItemTag item;
     EntityTag entity;
     LocationTag location;
+    BlockDispenseArmorEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryArgObject(0, block)) {
-            return false;
-        }
         if (!path.tryArgObject(2, item)) {
             return false;
         }
@@ -74,7 +71,7 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
     @Override
     public ObjectTag getContext(String name) {
         return switch (name) {
-            case "block" -> block;
+            case "block" -> new MaterialTag(event.getBlock());
             case "item" -> item;
             case "entity" -> entity;
             case "location" -> location;
@@ -89,10 +86,10 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
 
     @EventHandler
     public void onBlockEquipsItemOntoEntity(BlockDispenseArmorEvent event) {
-        block = new MaterialTag(event.getBlock());
         item = new ItemTag(event.getItem());
         entity = new EntityTag(event.getTargetEntity());
         location = new LocationTag(event.getBlock().getLocation());
+        this.event = event;
         fire(event);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
@@ -45,6 +45,11 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
     // # Will cause leather armor to be dispensed like a normal item and not be equipped on an armor stand.
     // on block equips leather* on:armor_stand:
     // - determined cancelled
+    //
+    // @Example
+    // # Will equip a golden helmet if a leather helmet is originally being equipped.
+    // on block equips leather_helmet:
+    // - determine golden_helmet
     // -->
 
     public BlockEquipsItemScriptEvent() {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
@@ -49,15 +49,14 @@ public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Lis
     // @Example
     // # Will equip a golden helmet if a leather helmet is originally being equipped.
     // on block equips leather_helmet:
-    // - determine golden_helmet
+    // - determine item:golden_helmet
     // -->
 
     public BlockEquipsItemScriptEvent() {
         registerCouldMatcher("block equips <item>");
         registerSwitches("on");
-        this.<BlockEquipsItemScriptEvent, ItemTag>registerOptionalDetermination(null, ItemTag.class, (evt, context, item) -> {
+        this.<BlockEquipsItemScriptEvent, ItemTag>registerDetermination("item", ItemTag.class, (evt, context, item) -> {
             evt.event.setItem(item.getItemStack());
-            return true;
         });
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BlockEquipsItemScriptEvent.java
@@ -12,11 +12,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDispenseArmorEvent;
 
-public class BlockEquipsItemOnEntityScriptEvent extends BukkitScriptEvent implements Listener {
+public class BlockEquipsItemScriptEvent extends BukkitScriptEvent implements Listener {
 
     // <--[event]
     // @Events
-    // <block> equips <item> (on <entity>)
+    // <block> equips <item>
     //
     // @Group Block
     //
@@ -25,6 +25,8 @@ public class BlockEquipsItemOnEntityScriptEvent extends BukkitScriptEvent implem
     // @Cancellable true
     //
     // @Triggers when a block dispenses armor and is equipped to an entity.
+    //
+    // @Switch on:<entity> to only process the event if the entity having the armor equipped matches the entity input.
     //
     // @Context
     // <context.block> returns the MaterialTag of the dispenser.
@@ -38,12 +40,13 @@ public class BlockEquipsItemOnEntityScriptEvent extends BukkitScriptEvent implem
     //
     // @Example
     // # Will cause leather armor to be dispensed like a normal item and not be equipped on an armor stand.
-    // on dispenser equips leather* on armor_stand:
+    // on dispenser equips leather* on:armor_stand:
     // - determined cancelled
     // -->
 
-    public BlockEquipsItemOnEntityScriptEvent() {
-        registerCouldMatcher("<block> equips <item> (on <entity>)");
+    public BlockEquipsItemScriptEvent() {
+        registerCouldMatcher("<block> equips <item>");
+        registerSwitches("on");
     }
 
     MaterialTag block;
@@ -59,7 +62,7 @@ public class BlockEquipsItemOnEntityScriptEvent extends BukkitScriptEvent implem
         if (!path.tryArgObject(2, item)) {
             return false;
         }
-        if (path.eventArgLowerAt(3).equals("on") && !path.tryArgObject(4, entity)) {
+        if (!path.tryObjectSwitch("on", entity)) {
             return false;
         }
         if (!runInCheck(path, location)) {


### PR DESCRIPTION
## `block equips <item>`

Fires when a block dispenses an item

#### Switches
- `on:<entity>` to fire when the entity being equipped matches

#### Contexts
- ~~`<context.block>` returns the MaterialTag of the dispenser.~~
- `<context.item>` returns the ItemTag of the armor being dispensed.
- `<context.entity>` returns the EntityTag of the entity having the armor equipped.
- `<context.location>` returns the LocationTag of the dispenser.

Requested by [LG_Legacy](https://discord.com/channels/315163488085475337/1204193269165195274)