### PR TITLE
`MapText` custom font support

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/MapCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/MapCommand.java
@@ -177,7 +177,7 @@ public class MapCommand extends AbstractCommand {
         }
         if (text != null) {
             DenizenMapRenderer dmr = DenizenMapManager.getDenizenRenderer(map);
-            dmr.addObject(new MapText(x.asString(), y.asString(), "true", false, text.asString(), null));
+            dmr.addObject(new MapText(x.asString(), y.asString(), "true", false, text.asString(), null, null, null, null));
             dmr.hasChanged = true;
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/MapScriptContainer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/MapScriptContainer.java
@@ -60,6 +60,9 @@ public class MapScriptContainer extends ScriptContainer {
     //             # Optionally add width/height numbers.
     //             width: 128
     //             height: 128
+    //             # Specify a tag to show or hide custom content! Valid for all objects.
+    //             # Note that all inputs other than 'type' for all objects support tags that will be dynamically reparsed per-player each time the map updates.
+    //             visible: <player.name.contains[bob].not>
     //
     //         2:
     //             type: text
@@ -67,10 +70,13 @@ public class MapScriptContainer extends ScriptContainer {
     //             text: Hello <player.name>
     //             # Specify the color of the text as any valid ColorTag.
     //             color: red
-    //             # Specify a tag to show or hide custom content! Valid for all objects.
-    //             # Note that all inputs other than 'type' for all objects support tags that will be dynamically reparsed per-player each time the map updates.
-    //             visible: <player.name.contains[bob].not>
-    //
+    //             # | Optionally, specify the following additional options:
+    //             # Specify a font to use, which allows using special characters/other languages the default font may not support.
+    //             font: arial
+    //             # Specify a size to use (only available with a custom font)
+    //             size: 18
+    //             # Specify a style, as a list that contains either "bold", "italic", or both (only available with a custom font).
+    //             style: bold|italic
     //         3:
     //             type: cursor
     //             # Specify a cursor type
@@ -142,8 +148,8 @@ public class MapScriptContainer extends ScriptContainer {
                                     + "' has no specified text!");
                             return;
                         }
-                        String text = objectSection.getString("text");
-                        added = new MapText(x, y, visible, shouldDebug(), text, objectSection.getString("color", "black"));
+                        added = new MapText(x, y, visible, shouldDebug(), objectSection.getString("text"), objectSection.getString("color", "black"),
+                                objectSection.getString("font"), objectSection.getString("size"), objectSection.getString("style"));
                         break;
                     case "cursor":
                         if (!objectSection.contains("cursor")) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/MapScriptContainer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/MapScriptContainer.java
@@ -62,7 +62,7 @@ public class MapScriptContainer extends ScriptContainer {
     //             height: 128
     //             # Specify a tag to show or hide custom content! Valid for all objects.
     //             # Note that all inputs other than 'type' for all objects support tags that will be dynamically reparsed per-player each time the map updates.
-    //             visible: <player.name.contains[bob].not>
+    //             visible: <player.name.contains_text[bob].not>
     //
     //         2:
     //             type: text

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/MapScriptContainer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/MapScriptContainer.java
@@ -73,7 +73,7 @@ public class MapScriptContainer extends ScriptContainer {
     //             # | Optionally, specify the following additional options:
     //             # Specify a font to use, which allows using special characters/other languages the default font may not support.
     //             font: arial
-    //             # Specify a size to use (only available with a custom font)
+    //             # Specify a text size (only available with a custom font).
     //             size: 18
     //             # Specify a style, as a list that contains either "bold", "italic", or both (only available with a custom font).
     //             style: bold|italic

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/DenizenMapManager.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/DenizenMapManager.java
@@ -72,32 +72,34 @@ public class DenizenMapManager {
             List<String> objects = new ArrayList<>(objectsData.getKeys(false));
             objects.sort(new NaturalOrderComparator());
             for (String objectKey : objects) {
-                String type = objectsData.getString(objectKey + ".type").toUpperCase();
-                String xTag = objectsData.getString(objectKey + ".x");
-                String yTag = objectsData.getString(objectKey + ".y");
-                String visibilityTag = objectsData.getString(objectKey + ".visibility");
-                boolean debug = objectsData.getString(objectKey + ".debug", "false").equalsIgnoreCase("true");
+                ConfigurationSection objectConfig = objectsData.getConfigurationSection(objectKey);
+                String type = objectConfig.getString("type").toUpperCase();
+                String xTag = objectConfig.getString("x");
+                String yTag = objectConfig.getString("y");
+                String visibilityTag = objectConfig.getString("visibility");
+                boolean debug = objectConfig.getString("debug", "false").equalsIgnoreCase("true");
                 MapObject object = null;
                 switch (type) {
                     case "CURSOR":
-                        object = new MapCursor(xTag, yTag, visibilityTag, debug, objectsData.getString(objectKey + ".direction"), objectsData.getString(objectKey + ".cursor"));
+                        object = new MapCursor(xTag, yTag, visibilityTag, debug, objectConfig.getString("direction"), objectConfig.getString("cursor"));
                         break;
                     case "IMAGE":
-                        String file = objectsData.getString(objectKey + ".image");
-                        int width = objectsData.getInt(objectKey + ".width", 0);
-                        int height = objectsData.getInt(objectKey + ".height", 0);
+                        String file = objectConfig.getString("image");
+                        int width = objectConfig.getInt("width", 0);
+                        int height = objectConfig.getInt("height", 0);
                         object = new MapImage(renderer, xTag, yTag, visibilityTag, debug, file, width, height);
                         break;
                     case "TEXT":
-                        object = new MapText(xTag, yTag, visibilityTag, debug, objectsData.getString(objectKey + ".text"), objectsData.getString(objectKey + ".color"));
+                        object = new MapText(xTag, yTag, visibilityTag, debug, objectConfig.getString("text"), objectConfig.getString("color"),
+                                objectConfig.getString("font"), objectConfig.getString("size"), objectConfig.getString("style"));
                         break;
                     case "DOT":
-                        object = new MapDot(xTag, yTag, visibilityTag, debug, objectsData.getString(objectKey + ".radius"), objectsData.getString(objectKey + ".color"));
+                        object = new MapDot(xTag, yTag, visibilityTag, debug, objectConfig.getString("radius"), objectConfig.getString("color"));
                         break;
                 }
                 if (object != null) {
-                    object.worldCoordinates = objectsData.getString(objectKey + ".world_coordinates", "false").equalsIgnoreCase("true");
-                    object.showPastEdge = objectsData.getString(objectKey + ".show_past_edge", "false").equalsIgnoreCase("true");
+                    object.worldCoordinates = objectConfig.getString("world_coordinates", "false").equalsIgnoreCase("true");
+                    object.showPastEdge = objectConfig.getString("show_past_edge", "false").equalsIgnoreCase("true");
                     renderer.addObject(object);
                 }
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/MapText.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/MapText.java
@@ -2,24 +2,33 @@ package com.denizenscript.denizen.utilities.maps;
 
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ColorTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.denizencore.tags.TagManager;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapView;
 import org.bukkit.map.MinecraftFont;
 
+import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 public class MapText extends MapObject {
 
-    protected String textTag, colorTag;
+    protected String textTag, colorTag, fontTag, sizeTag, styleTag;
     protected Map<UUID, String> playerTexts = new HashMap<>();
 
-    public MapText(String xTag, String yTag, String visibilityTag, boolean debug, String textTag, String colorTag) {
+    public MapText(String xTag, String yTag, String visibilityTag, boolean debug, String textTag, String colorTag, String fontTag, String sizeTag, String styleTag) {
         super(xTag, yTag, visibilityTag, debug);
         this.textTag = textTag;
         this.colorTag = colorTag;
+        this.fontTag = fontTag;
+        this.sizeTag = sizeTag;
+        this.styleTag = styleTag;
     }
 
     @Override
@@ -42,6 +51,9 @@ public class MapText extends MapObject {
         data.put("type", "TEXT");
         data.put("text", textTag);
         data.put("color", colorTag);
+        data.put("font", fontTag);
+        data.put("size", sizeTag);
+        data.put("style", styleTag);
         return data;
     }
 
@@ -52,9 +64,35 @@ public class MapText extends MapObject {
                 playerTexts.put(uuid, tag(textTag, player));
             }
             ColorTag color = ColorTag.valueOf(colorTag == null ? "black" : tag(colorTag, player), getTagContext(player));
-            byte b = MapImage.matchColor(color.getAWTColor());
-            String text = ((char) 167) + Byte.toString(b) + ((char) 59) + getText(player);
-            mapCanvas.drawText(getX(player), getY(player), MinecraftFont.Font, text);
+            if (fontTag == null) {
+                byte b = MapImage.matchColor(color.getAWTColor());
+                String text = ((char) 167) + Byte.toString(b) + ((char) 59) + getText(player);
+                mapCanvas.drawText(getX(player), getY(player), MinecraftFont.Font, text);
+                return;
+            }
+            int style = Font.PLAIN;
+            if (styleTag != null) {
+                TagContext context = getTagContext(player);
+                ListTag styles = TagManager.tagObject(styleTag, context).asType(ListTag.class, context);
+                for (String styleStr : styles) {
+                    String styleLower = CoreUtilities.toLowerCase(styleStr);
+                    switch (styleLower) {
+                        case "bold" -> style |= Font.BOLD;
+                        case "italic" -> style |= Font.ITALIC;
+                    }
+                }
+            }
+            int size = sizeTag != null ? TagManager.tagObject(sizeTag, getTagContext(player)).asElement().asInt() : 10;
+            BufferedImage image = new BufferedImage(128, 128, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D graphics = image.createGraphics();
+            graphics.setFont(new Font(tag(fontTag, player), style, size));
+            graphics.setColor(color.getAWTColor());
+            FontMetrics metrics = graphics.getFontMetrics();
+            int y = getY(player) + metrics.getAscent() - metrics.getDescent() - metrics.getLeading();
+            graphics.drawString(getText(player), getX(player), y);
+            graphics.dispose();
+            mapCanvas.drawImage(0, 0, image);
+
         }
         catch (Throwable ex) {
             Debug.echoError(ex);


### PR DESCRIPTION
Requested on [Discord](https://discord.com/channels/315163488085475337/1127359762913312919).

## Changes

- Moved the `visible` boolean config option's meta up a bit, as it didn't really fit in the `text` object example with the new stuff added, and updated it from the deprecated `ElementTag.contains` to `contains_text`.
- Documented the new options in the `text` map object meta exmaple.
- Removed the `String text` when creating a new `MapText` in `MapScriptContainer` in favor of just having the `getString` calls in-line (one was already in-line and I just made the new ones in-line as well as there's not much point in variables there, lmk if they should all be in variables instead though).
- Replaced `objectsData.getX(objectKey + ".KEY")` in `DenizenMapManager` with getting the object's `ConfigurationSection` and getting stuff from that, which is a little cleaner - let me know if there's any reason it was that way.
- Added `fontTag`, `sizeTag`, and `styleTag` fields to `MapText`, for the new options.
- `MapText#render` will now use the current rendering when no font is specified, and render the text onto an image using Java's rendering when one is specified, drawing the image onto the map.

> [!NOTE]
> ### Java font rendering
> Java renders text from the bottom left corner instead of the top left corner, so added some calculations with the font's sizes to try and compensate, which seem to work decently well.
> Albit not always being 100% precise with some fonts (e.g. comic sans is a lil off), most fonts (e.g. arial) seem to work well.

> [!NOTE]
> ### Image caching
> Currently it seems only the text is cached (vs stuff like the color which are always parsed), and caching the image would mean _everything_ would be cached, which I assume is fine? but just making sure before trying to implement that.

> [!NOTE]
> ### Null values in save data
> `MapText#getSaveData` seems to just put the values in even if they're `null`, which is what I did for the new values as well - these could probably be excluded? wouldn't really matter usually, but might be relevant when you have lots of maps.