### PR TITLE
Adds the `<context.hostname>` tag to the `server list ping` event.

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
@@ -34,6 +34,7 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
     // <context.max_players> returns the number of max players that will show.
     // <context.num_players> returns the number of online players that will show.
     // <context.address> returns the IP address requesting the list.
+    // <context.hostname> returns an ElementTag of the server address that is being pinged.
     // <context.protocol_version> returns the protocol ID of the server's version (only on Paper).
     // <context.version_name> returns the name of the server's version (only on Paper).
     // <context.client_protocol_version> returns the client's protocol version ID (only on Paper).
@@ -118,6 +119,7 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
             case "max_players" -> new ElementTag(event.getMaxPlayers());
             case "num_players" -> new ElementTag(event.getNumPlayers());
             case "address" -> new ElementTag(event.getAddress().toString());
+            case "hostname" -> new ElementTag(event.getHostname());
             default -> super.getContext(name);
         };
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
@@ -36,7 +36,7 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
     // <context.max_players> returns the number of max players that will show.
     // <context.num_players> returns the number of online players that will show.
     // <context.address> returns the IP address requesting the list.
-    // <context.hostname> returns an ElementTag of the server address that is being pinged. Available only on servers that are 1.19+.
+    // <context.hostname> returns an ElementTag of the server address that is being pinged. Available only on MC 1.19+.
     // <context.protocol_version> returns the protocol ID of the server's version (only on Paper).
     // <context.version_name> returns the name of the server's version (only on Paper).
     // <context.client_protocol_version> returns the client's protocol version ID (only on Paper).

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
@@ -2,6 +2,8 @@ package com.denizenscript.denizen.events.server;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.objects.ArgumentHelper;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -34,7 +36,7 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
     // <context.max_players> returns the number of max players that will show.
     // <context.num_players> returns the number of online players that will show.
     // <context.address> returns the IP address requesting the list.
-    // <context.hostname> returns an ElementTag of the server address that is being pinged.
+    // <context.hostname> returns an ElementTag of the server address that is being pinged. Available only on servers that are 1.19+.
     // <context.protocol_version> returns the protocol ID of the server's version (only on Paper).
     // <context.version_name> returns the name of the server's version (only on Paper).
     // <context.client_protocol_version> returns the client's protocol version ID (only on Paper).
@@ -119,7 +121,7 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
             case "max_players" -> new ElementTag(event.getMaxPlayers());
             case "num_players" -> new ElementTag(event.getNumPlayers());
             case "address" -> new ElementTag(event.getAddress().toString());
-            case "hostname" -> new ElementTag(event.getHostname());
+            case "hostname" -> NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) ? new ElementTag(event.getHostname(), true) : null;
             default -> super.getContext(name);
         };
     }


### PR DESCRIPTION
- Not requested by anyone, but needed for myself.
- Returns an ElementTag of the server address that is being pinged.