### PR TITLE
Lectern page tag/mech fix

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -3684,7 +3684,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // Deprecated in favor of <@link tag LocationTag.page>.
         // -->
         tagProcessor.registerTag(ElementTag.class, "lectern_page", (attribute, object) -> {
-            BukkitImplDeprecations.lecternPageTag.warn(attribute.context);
+            BukkitImplDeprecations.lecternPage.warn(attribute.context);
             BlockState state = object.getBlockStateForTag(attribute);
             if (state instanceof Lectern lectern) {
                 return new ElementTag(lectern.getPage());
@@ -5112,7 +5112,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // <LocationTag.lectern_page>
         // -->
         if (mechanism.matches("lectern_page") && mechanism.requireInteger()) {
-            BukkitImplDeprecations.lecternPageMech.warn(mechanism.context);
+            BukkitImplDeprecations.lecternPage.warn(mechanism.context);
             BlockState state = getBlockState();
             if (state instanceof Lectern lectern) {
                 lectern.setPage(mechanism.getValue().asInt());

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4496,12 +4496,15 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // <LocationTag.page>
         // -->
         tagProcessor.registerMechanism("page", false, ElementTag.class, (object, mechanism, input) -> {
+            if (!mechanism.requireInteger()) {
+                return;
+            }
             if (object.getBlockState() instanceof Lectern lectern) {
                 lectern.setPage(input.asInt() - 1);
-                object.getBlockState().update();
+                lectern.update();
             }
             else {
-                Debug.echoError("The 'LocationTag.page' mechanism can only be called on a lectern block.");
+                mechanism.echoError("The 'LocationTag.page' mechanism can only be called on a lectern block.");
             }
         });
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4491,7 +4491,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @name page
         // @input ElementTag(Number)
         // @description
-        // Changes the page currently displayed on the book in a lectern block.
+        // Sets the page currently displayed on the book in a lectern block.
         // @tags
         // <LocationTag.page>
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -3701,8 +3701,7 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // Returns the current page on display in the book on this Lectern block.
         // -->
         tagProcessor.registerTag(ElementTag.class, "page", (attribute, object) -> {
-            BlockState state = object.getBlockStateForTag(attribute);
-            if (state instanceof Lectern lectern) {
+            if (object.getBlockState() instanceof Lectern lectern) {
                 return new ElementTag(lectern.getPage() + 1);
             }
             return null;
@@ -4497,10 +4496,9 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // <LocationTag.page>
         // -->
         tagProcessor.registerMechanism("page", false, ElementTag.class, (object, mechanism, input) -> {
-            BlockState state = object.getBlockState();
-            if (state instanceof Lectern lectern) {
+            if (object.getBlockState() instanceof Lectern lectern) {
                 lectern.setPage(input.asInt() - 1);
-                state.update();
+                object.getBlockState().update();
             }
             else {
                 Debug.echoError("The 'LocationTag.page' mechanism can only be called on a lectern block.");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -3679,13 +3679,31 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @returns ElementTag(Number)
         // @mechanism LocationTag.lectern_page
         // @group world
+        // @deprecated Use 'LocationTag.page'
+        // @description
+        // Deprecated in favor of <@link tag LocationTag.page>.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "lectern_page", (attribute, object) -> {
+            BukkitImplDeprecations.lecternPageTag.warn(attribute.context);
+            BlockState state = object.getBlockStateForTag(attribute);
+            if (state instanceof Lectern lectern) {
+                return new ElementTag(lectern.getPage());
+            }
+            return null;
+        });
+
+        // <--[tag]
+        // @attribute <LocationTag.page>
+        // @returns ElementTag(Number)
+        // @mechanism LocationTag.page
+        // @group world
         // @description
         // Returns the current page on display in the book on this Lectern block.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "lectern_page", (attribute, object) -> {
+        tagProcessor.registerTag(ElementTag.class, "page", (attribute, object) -> {
             BlockState state = object.getBlockStateForTag(attribute);
-            if (state instanceof Lectern) {
-                return new ElementTag(((Lectern) state).getPage());
+            if (state instanceof Lectern lectern) {
+                return new ElementTag(lectern.getPage() + 1);
             }
             return null;
         });
@@ -4468,6 +4486,26 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 chiseledBookshelf.setLastInteractedSlot(input.asInt() - 1);
             }
         });
+
+        // <--[mechanism]
+        // @object LocationTag
+        // @name page
+        // @input ElementTag(Number)
+        // @description
+        // Changes the page currently displayed on the book in a lectern block.
+        // @tags
+        // <LocationTag.page>
+        // -->
+        tagProcessor.registerMechanism("page", false, ElementTag.class, (object, mechanism, input) -> {
+            BlockState state = object.getBlockState();
+            if (state instanceof Lectern lectern) {
+                lectern.setPage(input.asInt() - 1);
+                state.update();
+            }
+            else {
+                Debug.echoError("The 'LocationTag.page' mechanism can only be called on a lectern block.");
+            }
+        });
     }
 
     public static final ObjectTagProcessor<LocationTag> tagProcessor = new ObjectTagProcessor<>();
@@ -5067,15 +5105,17 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // @object LocationTag
         // @name lectern_page
         // @input ElementTag(Number)
+        // @deprecated Use LocationTag.page
         // @description
-        // Changes the page currently displayed on the book in a lectern block.
+        // Deprecated in favor of <@link tag LocationTag.page>.
         // @tags
         // <LocationTag.lectern_page>
         // -->
         if (mechanism.matches("lectern_page") && mechanism.requireInteger()) {
+            BukkitImplDeprecations.lecternPageMech.warn(mechanism.context);
             BlockState state = getBlockState();
-            if (state instanceof Lectern) {
-                ((Lectern) state).setPage(mechanism.getValue().asInt());
+            if (state instanceof Lectern lectern) {
+                lectern.setPage(mechanism.getValue().asInt());
                 state.update();
             }
             else {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -321,10 +321,7 @@ public class BukkitImplDeprecations {
     public static Warning takeExperience = new FutureWarning("takeExperience", "Using the 'take' command to take experience is deprecated in favor of the 'experience' command.");
 
     // Added 2024/02/19, deprecate officially by 2027.
-    public static Warning lecternPageMech = new FutureWarning("lecternPageMech", "The mechanism 'LocationTag.lectern_page' is deprecated in favor of 'LocationTag.page'.");
-
-    // Added 2024/02/19, deprecate officially by 2027.
-    public static Warning lecternPageTag = new FutureWarning("lecternPageTag", "The tag 'LocationTag.lectern_page' is deprecated in favor of 'LocationTag.page'.");
+    public static Warning lecternPage = new FutureWarning("lecternPage", "'LocationTag.lectern_page' is deprecated in favor of 'LocationTag.page'.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -320,6 +320,12 @@ public class BukkitImplDeprecations {
     // Added 2023/11/16, deprecate officially by 2027
     public static Warning takeExperience = new FutureWarning("takeExperience", "Using the 'take' command to take experience is deprecated in favor of the 'experience' command.");
 
+    // Added 2024/02/19, deprecate officially by 2027.
+    public static Warning lecternPageMech = new FutureWarning("lecternPageMech", "The mechanism 'LocationTag.lectern_page' is deprecated in favor of 'LocationTag.page'.");
+
+    // Added 2024/02/19, deprecate officially by 2027.
+    public static Warning lecternPageTag = new FutureWarning("lecternPageTag", "The tag 'LocationTag.lectern_page' is deprecated in favor of 'LocationTag.page'.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2023/10/29 without warning.


### PR DESCRIPTION
- Coming back to an old PR of mine that I closed because I was too dumb at the time lol: https://github.com/DenizenScript/Denizen/pull/2484

- Deprecates the `lectern_page` tag & mech as they are one number off, ie If a book on a lectern is on page 14, the tag will return 13. & if you want to change the page on the lectern, you have to set the number to be one number higher than the preferred page. 