### PR TITLE
`MaterialTag.food_points`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -84,4 +84,8 @@ public abstract class ItemHelper {
     public byte[] renderMap(MapView mapView, Player player) {
         throw new UnsupportedOperationException();
     }
+
+    public int getFoodPoints(Material itemType) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.objects;
 
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.nms.interfaces.BlockHelper;
 import com.denizenscript.denizen.objects.properties.material.*;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
@@ -655,6 +656,21 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
             result.putObject("fall_sound", new ElementTag(group.getFallSound().name()));
             return result;
         });
+
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+
+            // <--[tag]
+            // @attribute <MaterialTag.food_points>
+            // @returns ElementTag(Number)
+            // @description
+            // If the material is an item, returns the amount of hunger it restores when eaten.
+            // See <@link url https://minecraft.wiki/w/Food> for more information on food mechanics.
+            // -->
+            tagProcessor.registerTag(ElementTag.class, "food_points", (attribute, object) -> {
+                Material itemType = object.getMaterial();
+                return itemType.isEdible() ? new ElementTag(NMSHandler.itemHelper.getFoodPoints(itemType)) : null;
+            });
+        }
     }
 
     public static ObjectTagProcessor<MaterialTag> tagProcessor = new ObjectTagProcessor<>();

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -530,4 +530,9 @@ public class ItemHelperImpl extends ItemHelper {
     public byte[] renderMap(MapView mapView, Player player) {
         return ((CraftMapView) mapView).render((CraftPlayer) player).buffer;
     }
+
+    @Override
+    public int getFoodPoints(Material itemType) {
+        return CraftMagicNumbers.getItem(itemType).getFoodProperties().getNutrition();
+    }
 }


### PR DESCRIPTION
Requested on [Discord](https://discord.com/channels/315163488085475337/1138431627740065863).

## Additions

- `ItemHelper#getFoodPoints(Material)` - gets the amount of hunger an item restores (implemented on 1.20).
- `MaterialTag.food_points` - returns the amount of hunger an item restores when eaten (1.20+).

> [!NOTE]
> The tag is on `MaterialTag` since it only requires the item type, but maybe we should start implementing such tags on `ItemTag` with the proper item/block type split coming soon? in the off chance someone actually has a `MaterialTag` instead of an `ItemTag` that they want to use it on they can just `MaterialTag.item` for now.