### PR TITLE
Fix `Warden$AngerLevel` access on old versions

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2990,7 +2990,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                 if (!(object.getBukkitEntity() instanceof Warden warden)) {
                     return null;
                 }
-                return new ElementTag(warden.getAngerLevel());
+                return MultiVersionHelper1_19.getWardenAngerLevel(warden);
             });
 
             // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -55,4 +55,8 @@ public class MultiVersionHelper1_19 {
         result.putObject("raw_game_time", new ElementTag(interaction.getTimestamp()));
         return result;
     }
+
+    public static ElementTag getWardenAngerLevel(Warden warden) {
+        return new ElementTag(warden.getAngerLevel());
+    }
 }


### PR DESCRIPTION
Fixes Java not finding `Warden$AngerLevel` on outdated versions with a `MultiVersionHelepr1_19` method to get it.