### PR TITLE
Fix `InventoryTag` properties handling

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/InventoryTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/InventoryTag.java
@@ -407,10 +407,9 @@ public class InventoryTag implements ObjectTag, Notable, Adjustable, FlaggableOb
                 continue;
             }
             String name = CoreUtilities.toLowerCase(data.get(0));
-            String description = ObjectFetcher.unescapeProperty(data.get(1));
-            ElementTag descriptionElement = new ElementTag(description);
-            Mechanism mechanism = new Mechanism(data.get(0), descriptionElement, context);
             if (!name.equals("holder") && !name.equals("uniquifier") && !name.equals("size") && !name.equals("script_name")) {
+                String description = ObjectFetcher.unescapeProperty(data.get(1));
+                Mechanism mechanism = new Mechanism(name, ObjectFetcher.pickObjectFor(description, context), context);
                 result.safeAdjust(mechanism);
             }
         }


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1199403465265381376).

## Changes (to `InventoryTag#internalApplyPropertySet`)

- Moved everything but `name` to within the if check, as there's no point in creating them if they might not be used.
- Removed `descriptionElement` in favor of using `ObjectFetcher#pickObjectFor` in the `Mechanism` constructor.
- Now passes `name` to the mechanism constructor instead of getting it from `data` again (`Mechanism` lowercases it anyway).