### PR TITLE
`EntityTag.drops_item` property

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -71,7 +71,7 @@ public class PropertyRegistry {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             PropertyParser.registerProperty(EntityDisplay.class, EntityTag.class);
         }
-        PropertyParser.registerProperty(EntityDropItem.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityDropsItem.class, EntityTag.class);
         PropertyParser.registerProperty(EntityEquipment.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExplosionFire.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExplosionRadius.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -71,6 +71,7 @@ public class PropertyRegistry {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             PropertyParser.registerProperty(EntityDisplay.class, EntityTag.class);
         }
+        PropertyParser.registerProperty(EntityDropItem.class, EntityTag.class);
         PropertyParser.registerProperty(EntityEquipment.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExplosionFire.class, EntityTag.class);
         PropertyParser.registerProperty(EntityExplosionRadius.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDropItem.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDropItem.java
@@ -1,0 +1,43 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.entity.EnderSignal;
+
+public class EntityDropItem extends EntityProperty<ElementTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name drop_item
+    // @input ElementTag(Boolean)
+    // @description
+    // Whether an eye of ender drops an item when breaking or shatters.
+    // See <@link property EntityTag.item> for controlling an eye's item.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof EnderSignal;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(as(EnderSignal.class).getDropItem());
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (mechanism.requireBoolean()) {
+            as(EnderSignal.class).setDropItem(value.asBoolean());
+        }
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "drop_item";
+    }
+
+    public static void register() {
+        autoRegister("drop_item", EntityDropItem.class, ElementTag.class, false);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDropsItem.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityDropsItem.java
@@ -5,11 +5,11 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import org.bukkit.entity.EnderSignal;
 
-public class EntityDropItem extends EntityProperty<ElementTag> {
+public class EntityDropsItem extends EntityProperty<ElementTag> {
 
     // <--[property]
     // @object EntityTag
-    // @name drop_item
+    // @name drops_item
     // @input ElementTag(Boolean)
     // @description
     // Whether an eye of ender drops an item when breaking or shatters.
@@ -34,10 +34,10 @@ public class EntityDropItem extends EntityProperty<ElementTag> {
 
     @Override
     public String getPropertyId() {
-        return "drop_item";
+        return "drops_item";
     }
 
     public static void register() {
-        autoRegister("drop_item", EntityDropItem.class, ElementTag.class, false);
+        autoRegister("drops_item", EntityDropsItem.class, ElementTag.class, false);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityItem.java
@@ -4,12 +4,12 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.TagContext;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
@@ -17,6 +17,20 @@ import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 
 public class EntityItem implements Property {
+
+    // <--[property]
+    // @object EntityTag
+    // @name item
+    // @input ItemTag
+    // @description
+    // An entity's item, which can be:
+    // - the item represented and displayed by a dropped item.
+    // - the item represented by a thrown trident.
+    // - a throwable projectile's display item.
+    // - an eye-of-ender's item, which is both displayed and dropped.
+    // - a fireball's display item.
+    // - an item display's display item.
+    // -->
 
     public static boolean describes(ObjectTag object) {
         if (!(object instanceof EntityTag)) {
@@ -136,20 +150,6 @@ public class EntityItem implements Property {
     }
 
     public static void register() {
-
-        // <--[tag]
-        // @attribute <EntityTag.item>
-        // @returns ItemTag
-        // @mechanism EntityTag.item
-        // @group properties
-        // @description
-        // If the entity is a dropped item, returns the item represented by the entity.
-        // If the entity is a trident, returns the trident item represented by the entity.
-        // If the entity is a throwable projectile, returns the display item for that projectile.
-        // If the entity is an eye-of-ender, returns the item to be displayed and dropped by it.
-        // If the entity is a fireball, returns the fireball's display item.
-        // If the entity is an Item Display, returns the entity's display item.
-        // -->
         PropertyParser.registerTag(EntityItem.class, ItemTag.class, "item", (attribute, object) -> {
             return object.getItem(true, attribute.context);
         });
@@ -157,21 +157,6 @@ public class EntityItem implements Property {
 
     @Override
     public void adjust(Mechanism mechanism) {
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name item
-        // @input ItemTag
-        // @description
-        // If the entity is a dropped item, sets the item represented by the entity.
-        // If the entity is a trident, sets the trident item represented by the entity.
-        // If the item is a throwable projectile, sets the display item for that projectile.
-        // If the entity is an eye-of-ender, sets the item to be displayed and dropped by it.
-        // If the entity is a fireball, sets the fireball's display item.
-        // If the entity is an Item Display, sets the entity's display item.
-        // @tags
-        // <EntityTag.item>
-        // -->
         if (mechanism.matches("item") && mechanism.requireObject(ItemTag.class)) {
             ItemStack itemStack = mechanism.valueAsType(ItemTag.class).getItemStack();
             if (item.isCitizensNPC()) {


### PR DESCRIPTION
Requested on [Discord](https://discord.com/channels/315163488085475337/1139236509380264066).

## Additions

- `EntityTag.drops_item` property, controls whether an eye of ender drops an item or shatters when breaking.

## Changes

- Updated `EntityTag.item`'s meta to property meta to cleanly link it in `EntityTag.drops_item`'s meta.

> [!NOTE]
> Should maybe be `drops_item`, `should_drop_item`, `ender_eye_drop_item`, etc. to avoid potential naming conflicts?
> **Edit:** Done