### PR TITLE
`ItemTag.inventory_contents`: update, fix no `BlockState` handling

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ItemTag.java
@@ -574,7 +574,7 @@ public class ItemTag implements ObjectTag, Adjustable, FlaggableObject {
         // <@link mechanism ItemTag.inventory_contents>, and <@link tag ItemTag.inventory_contents>.
         // -->
         tagProcessor.registerTag(ElementTag.class, "has_inventory", (attribute, object) -> {
-            return new ElementTag(ItemInventory.describes(object));
+            return new ElementTag(ItemInventoryContents.describes(object));
         });
 
         // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -218,7 +218,7 @@ public class PropertyRegistry {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             PropertyParser.registerProperty(ItemInstrument.class, ItemTag.class);
         }
-        PropertyParser.registerProperty(ItemInventory.class, ItemTag.class);
+        PropertyParser.registerProperty(ItemInventoryContents.class, ItemTag.class);
         PropertyParser.registerProperty(ItemKnowledgeBookRecipes.class, ItemTag.class);
         PropertyParser.registerProperty(ItemLock.class, ItemTag.class);
         PropertyParser.registerProperty(ItemLodestoneLocation.class, ItemTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInventoryContents.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInventoryContents.java
@@ -69,7 +69,7 @@ public class ItemInventoryContents extends ItemProperty<ListTag> {
             BlockState state = blockStateMeta.getBlockState();
             Inventory inventory = getInventoryFor((InventoryHolder) state);
             if (items.size() > inventory.getSize()) {
-                mechanism.echoError("Input list is too large: expected " + inventory.getSize() + " or less.");
+                mechanism.echoError("Input list is too large: must be " + inventory.getSize() + " or less.");
                 return;
             }
             inventory.setContents(items.toArray(new ItemStack[0]));

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInventoryContents.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInventoryContents.java
@@ -34,7 +34,7 @@ public class ItemInventoryContents extends ItemProperty<ListTag> {
     // -->
 
     public static boolean describes(ItemTag item) {
-        return (item.getItemMeta() instanceof BlockStateMeta stateMeta && stateMeta.getBlockState() instanceof InventoryHolder)
+        return (item.getItemMeta() instanceof BlockStateMeta blockStateMeta && blockStateMeta.getBlockState() instanceof InventoryHolder)
                 || item.getItemMeta() instanceof BundleMeta;
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInventoryContents.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemInventoryContents.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class ItemInventory extends ItemProperty<ListTag> {
+public class ItemInventoryContents extends ItemProperty<ListTag> {
 
     // <--[property]
     // @object ItemTag
@@ -87,21 +87,21 @@ public class ItemInventory extends ItemProperty<ListTag> {
     }
 
     public static void register() {
-        PropertyParser.registerTag(ItemInventory.class, ListTag.class, "inventory_contents", (attribute, prop) -> {
+        PropertyParser.registerTag(ItemInventoryContents.class, ListTag.class, "inventory_contents", (attribute, prop) -> {
             if (prop.getItemMeta() instanceof BlockStateMeta blockStateMeta && !blockStateMeta.hasBlockState()) {
                 return new ListTag();
             }
             return prop.getPropertyValue();
         });
-        PropertyParser.registerMechanism(ItemInventory.class, ListTag.class, "inventory_contents", (prop, mechanism, input) -> {
+        PropertyParser.registerMechanism(ItemInventoryContents.class, ListTag.class, "inventory_contents", (prop, mechanism, input) -> {
             prop.setPropertyValue(input, mechanism);
         });
 
-        PropertyParser.registerTag(ItemInventory.class, InventoryTag.class, "inventory", (attribute, prop) -> {
+        PropertyParser.registerTag(ItemInventoryContents.class, InventoryTag.class, "inventory", (attribute, prop) -> {
             BukkitImplDeprecations.itemInventoryTag.warn(attribute.context);
             return prop.getItemInventory();
         });
-        PropertyParser.registerMechanism(ItemInventory.class, InventoryTag.class, "inventory", (prop, mechanism, input) -> {
+        PropertyParser.registerMechanism(ItemInventoryContents.class, InventoryTag.class, "inventory", (prop, mechanism, input) -> {
             BukkitImplDeprecations.itemInventoryTag.warn(mechanism.context);
             Argument argument = new Argument("");
             argument.unsetValue();


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1180258422512427100).
Only fixes the issue for this property, there's a few other properties that will probably need similar changes later on.

## Changes

- Renamed `ItemInventory` to `ItemInventoryContents`, to match the property name.
- Updated to modern property format.
- General minor code updates (e.g. `instanceof` pattern matching).
- `getPropertyValue` now returns `null` when there's no `BlockState`, as `getBlockState` creates a new one, which ends up with the item getting it's default block state and becoming unstackable; the tag has an override to return an empty list for backwards compact.
- `setPropertyValue` now stores the state as a `BlockState` and casts it to `InvetoryHolder` instead of the other way around.
- `setPropertyValue` now only calls `getInventoryFor` once, and stores the result.
- Changed `setPropertyValue`'s error message a little, to match modern ones more.
- Now uses `editMeta` to edit `BundleMeta`, as it's just a single set operation.