### PR TITLE
Paper only `player changes framed <item>` event

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -45,6 +45,9 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(ExperienceOrbMergeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerAbsorbsExperienceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerBeaconEffectScriptEvent.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+            ScriptEvent.registerScriptEvent(PlayerChangesFramedItemScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerChoosesArrowScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClicksFakeEntityScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerClicksInRecipeBookScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
@@ -46,12 +46,14 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
         registerSwitches("frame", "action");
         this.<PlayerChangesFramedItemScriptEvent, ItemTag>registerDetermination("item", ItemTag.class, (evt, context, item) -> {
             evt.event.setItemStack(item.getItemStack());
+            evt.item = item;
         });
     }
 
-    EntityTag frame;
-    ElementTag action;
-    PlayerItemFrameChangeEvent event;
+    public ItemTag item;
+    public EntityTag frame;
+    public ElementTag action;
+    public PlayerItemFrameChangeEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -74,7 +76,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "frame" -> frame;
-            case "item" -> new ItemTag(event.getItemStack());
+            case "item" -> item;
             case "action" -> action;
             default -> super.getContext(name);
         };
@@ -87,6 +89,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
 
     @EventHandler
     public void onPlayerChangesFramedItem(PlayerItemFrameChangeEvent event) {
+        item = new ItemTag(event.getItemStack());
         frame = new EntityTag(event.getItemFrame());
         action = new ElementTag(event.getAction().name());
         this.event = event;

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
@@ -33,7 +33,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
     // @Context
     // <context.frame> returns the EntityTag of the item frame.
     // <context.item> returns the ItemTag of the item held in the item frame.
-    // <context.action> returns the ElementTag of the action being preformed, based on <@link url https://jd.papermc.io/paper/1.20/io/papermc/paper/event/player/PlayerItemFrameChangeEvent.ItemFrameChangeAction.html>
+    // <context.action> returns the ElementTag of the action being performed, based on <@link url https://jd.papermc.io/paper/1.20/io/papermc/paper/event/player/PlayerItemFrameChangeEvent.ItemFrameChangeAction.html>
     //
     // @Determine
     // "ITEM:<ItemTag>" to change the item held by the item frame. If there is an item already in the frame, it will be replaced. To remove the item, set it to air.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
@@ -46,7 +46,6 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
         registerSwitches("frame", "action");
         this.<PlayerChangesFramedItemScriptEvent, ItemTag>registerDetermination("item", ItemTag.class, (evt, context, item) -> {
             evt.event.setItemStack(item.getItemStack());
-            evt.item = item;
         });
     }
 
@@ -76,7 +75,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "frame" -> frame;
-            case "item" -> item;
+            case "item" -> new ItemTag(event.getItemStack());
             case "action" -> action;
             default -> super.getContext(name);
         };
@@ -91,7 +90,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
     public void onPlayerChangesFramedItem(PlayerItemFrameChangeEvent event) {
         item = new ItemTag(event.getItemStack());
         frame = new EntityTag(event.getItemFrame());
-        action = new ElementTag(event.getAction().name());
+        action = new ElementTag(event.getAction());
         this.event = event;
         fire(event);
     }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
@@ -1,0 +1,95 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import io.papermc.paper.event.player.PlayerItemFrameChangeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player changes framed <item>
+    //
+    // @Location true
+    //
+    // @Plugin Paper
+    //
+    // @Group Paper
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a player interacts with an item frame by adding, removing, or rotating the item held in it.
+    //
+    // @Switch frame:<entity> to only process the event if the item frame entity being matches the input.
+    // @Switch action:<action> to only process the event if the change matches the input.
+    //
+    // @Context
+    // <context.frame> returns the EntityTag of the item frame.
+    // <context.item> returns the ItemTag of the item held in the item frame.
+    // <context.action> returns the ElementTag of the action being preformed, based on <@link url https://jd.papermc.io/paper/1.20/io/papermc/paper/event/player/PlayerItemFrameChangeEvent.ItemFrameChangeAction.html>
+    //
+    // @Determine
+    // "ITEM:<ItemTag>" to change the item held by the item frame. To remove the item, set it to air.
+    //
+    // @Player Always.
+    // -->
+
+    public PlayerChangesFramedItemScriptEvent() {
+        registerCouldMatcher("player changes framed <item>");
+        registerSwitches("frame", "action");
+        this.<PlayerChangesFramedItemScriptEvent, ItemTag>registerDetermination("item", ItemTag.class, (evt, context, item) -> {
+            evt.event.setItemStack(item.getItemStack());
+        });
+    }
+
+    EntityTag frame;
+    ElementTag action;
+    PlayerItemFrameChangeEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!path.tryArgObject(3, new ItemTag(event.getItemStack()))) {
+            return false;
+        }
+        if (!path.tryObjectSwitch("frame", frame)) {
+            return false;
+        }
+        if (!path.tryObjectSwitch("action", action)) {
+            return false;
+        }
+        if (!runInCheck(path, event.getItemFrame().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "frame" -> frame;
+            case "item" -> new ItemTag(event.getItemStack());
+            case "action" -> action;
+            default -> super.getContext(name);
+        };
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerChangesFramedItem(PlayerItemFrameChangeEvent event) {
+        frame = new EntityTag(event.getItemFrame());
+        action = new ElementTag(event.getAction().name());
+        this.event = event;
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
@@ -64,7 +64,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
         if (!path.tryObjectSwitch("action", action)) {
             return false;
         }
-        if (!runInCheck(path, event.getItemFrame().getLocation())) {
+        if (!runInCheck(path, frame.getLocation())) {
             return false;
         }
         return super.matches(path);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
@@ -36,7 +36,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
     // <context.action> returns the ElementTag of the action being preformed, based on <@link url https://jd.papermc.io/paper/1.20/io/papermc/paper/event/player/PlayerItemFrameChangeEvent.ItemFrameChangeAction.html>
     //
     // @Determine
-    // "ITEM:<ItemTag>" to change the item held by the item frame. To remove the item, set it to air.
+    // "ITEM:<ItemTag>" to change the item held by the item frame. If there is an item already in the frame, it will be replaced. To remove the item, set it to air.
     //
     // @Player Always.
     // -->

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerChangesFramedItemScriptEvent.java
@@ -57,7 +57,7 @@ public class PlayerChangesFramedItemScriptEvent extends BukkitScriptEvent implem
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryArgObject(3, new ItemTag(event.getItemStack()))) {
+        if (!path.tryArgObject(3, item)) {
             return false;
         }
         if (!path.tryObjectSwitch("frame", frame)) {


### PR DESCRIPTION
## Paper only `player changes framed <item>` event

Fires when a player interacts with an item frame by adding, removing, or rotating the item held in it.

#### Switches
- `frame:<frame>` - matches an item frame entity
- `action:<action>` - matches the item frame change action

#### Contexts
- `<context.frame>` - returns the item frame's `EntityTag`
- `<context.item>` - returns the item in the item frame
- `<context.action>` - returns an `ElementTag` version of the action being preformed, in case a user needs it (can be removed if needed)

#### Determinations
- `ITEM:<ItemTag>` - changes the item inside the item frame, regardless of the action.

> [!NOTE]
> Let me know if the event line should be changed if you think `<item>` would be better as a switch instead.
> I just thought that it sounded much better when it was apart of the event line.

Requested by [Bailey](https://discord.com/channels/315163488085475337/1225938396766146591)