### PR TITLE
Fix NMS module loading on Paper

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/InternalEventScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/InternalEventScriptEvent.java
@@ -72,9 +72,9 @@ public class InternalEventScriptEvent extends BukkitScriptEvent implements Liste
                 ListTag result = new ListTag();
                 Class c = currentEvent.getClass();
                 while (c != null && c != Object.class) {
-                    for (Map.Entry<String, Field> field : ReflectionHelper.getFields(c).entrySet()) {
-                        if (!Modifier.isStatic(field.getValue().getModifiers())) {
-                            result.addObject(new ElementTag(field.getKey(), true));
+                    for (Field field : ReflectionHelper.getFields(c).getAllFields()) {
+                        if (!Modifier.isStatic(field.getModifiers())) {
+                            result.addObject(new ElementTag(field.getName(), true));
                         }
                     }
                     c = c.getSuperclass();
@@ -89,12 +89,12 @@ public class InternalEventScriptEvent extends BukkitScriptEvent implements Liste
             String fName = CoreUtilities.toLowerCase(name.substring("field_".length()));
             Class c = currentEvent.getClass();
             while (c != null && c != Object.class) {
-                ReflectionHelper.CheckingFieldMap fields = ReflectionHelper.getFields(c);
-                for (Map.Entry<String, Field> field : fields.entrySet()) {
-                    if (!Modifier.isStatic(field.getValue().getModifiers()) && CoreUtilities.toLowerCase(field.getKey()).equals(fName)) {
+                ReflectionHelper.FieldCache fields = ReflectionHelper.getFields(c);
+                for (Field field : fields.getAllFields()) {
+                    if (!Modifier.isStatic(field.getModifiers()) && CoreUtilities.toLowerCase(field.getName()).equals(fName)) {
                         Object val = null;
                         try {
-                            val = field.getValue().get(currentEvent);
+                            val = field.get(currentEvent);
                         }
                         catch (Throwable ex) {
                             Debug.echoError(ex);

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
@@ -34,13 +34,13 @@ public abstract class NMSHandler {
     public static boolean initialize(JavaPlugin plugin) {
         javaPlugin = plugin;
         String bukkitVersion = Bukkit.getBukkitVersion();
-        int secondDot = bukkitVersion.indexOf('.', bukkitVersion.indexOf('.') + 1);
-        String formattedVersion = 'v' + bukkitVersion.substring(0, secondDot).replace('.', '_');
-        try {
-            // Check if we support this MC version
-            version = NMSVersion.valueOf(formattedVersion);
+        for (NMSVersion potentialVersion : NMSVersion.values()) {
+            if (bukkitVersion.startsWith(potentialVersion.minecraftVersion)) {
+                version = potentialVersion;
+                break;
+            }
         }
-        catch (Exception e) {
+        if (version == null) {
             version = NMSVersion.NOT_SUPPORTED;
             instance = null;
             return false;

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
@@ -5,8 +5,8 @@ import com.denizenscript.denizen.nms.interfaces.*;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
-import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import net.md_5.bungee.api.chat.HoverEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -33,17 +33,12 @@ public abstract class NMSHandler {
 
     public static boolean initialize(JavaPlugin plugin) {
         javaPlugin = plugin;
-        Class<?> serverClass = javaPlugin.getServer().getClass();
-        ReflectionHelper.giveReflectiveAccess(serverClass, ReflectionHelper.class);
-        String packageName = serverClass.getPackage().getName();
-        int indexOfSubRevision = packageName.indexOf('R');
-        if (indexOfSubRevision > 0) {
-            // "v1_14_R1" should become "v1_14"
-            packageName = packageName.substring(0, indexOfSubRevision - 1);
-        }
+        String bukkitVersion = Bukkit.getBukkitVersion();
+        int secondDot = bukkitVersion.indexOf('.', bukkitVersion.indexOf('.') + 1);
+        String formattedVersion = 'v' + bukkitVersion.substring(0, secondDot).replace('.', '_');
         try {
             // Check if we support this MC version
-            version = NMSVersion.valueOf(packageName.substring(packageName.lastIndexOf('.') + 1));
+            version = NMSVersion.valueOf(formattedVersion);
         }
         catch (Exception e) {
             version = NMSVersion.NOT_SUPPORTED;
@@ -55,7 +50,7 @@ public abstract class NMSHandler {
             final Class<?> clazz = Class.forName("com.denizenscript.denizen.nms." + version.name() + ".Handler");
             if (NMSHandler.class.isAssignableFrom(clazz)) {
                 // Found and loaded - good to go!
-                instance = (NMSHandler) clazz.newInstance();
+                instance = (NMSHandler) clazz.getDeclaredConstructor().newInstance();
                 return true;
             }
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSVersion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSVersion.java
@@ -2,11 +2,17 @@ package com.denizenscript.denizen.nms;
 
 public enum NMSVersion {
 
-    NOT_SUPPORTED,
-    v1_17,
-    v1_18,
-    v1_19,
-    v1_20;
+    NOT_SUPPORTED("not_supported"),
+    v1_17("1.17"),
+    v1_18("1.18"),
+    v1_19("1.19"),
+    v1_20("1.20");
+
+    final String minecraftVersion;
+
+    NMSVersion(String minecraftVersion) {
+        this.minecraftVersion = minecraftVersion;
+    }
 
     public boolean isAtLeast(NMSVersion version) {
         return ordinal() >= version.ordinal();

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/network/packets/PacketOutSetSlotImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/network/packets/PacketOutSetSlotImpl.java
@@ -44,7 +44,6 @@ public class PacketOutSetSlotImpl implements PacketOutSetSlot {
     private static final Field ITEM_STACK;
 
     static {
-        Map<String, Field> fields = ReflectionHelper.getFields(ClientboundContainerSetSlotPacket.class);
-        ITEM_STACK = fields.get("c");
+        ITEM_STACK = ReflectionHelper.getFields(ClientboundContainerSetSlotPacket.class).get("c");
     }
 }


### PR DESCRIPTION
## Changes

- `NMSVersion` now has a string for the version name (I.e. `1.20`).
- `NMSHandler#initialize` now uses `Bukkit#getBukkitVersion` instead of getting it from the package name, and compares it against `NMSVersion`'s version name strings.
- Replaced deprecated `Class#newInstance` usage with `Class#getDeclaredConstructor#newInstance`.

> [!NOTE]
> Could parse the version string directly into the `NMSVersion`, but that'd be a bit messy with handling patch/release versions and all - let me know if that'd be preferred though.

> [!NOTE]
> There's technically more "correct" API to use for this (`Bukkit#getMinecraftVersion`), but that's Paper only and probably not worth the mess? (as the Paper module is obviously not initialized at that point)