### PR TITLE
NBT handling update: `EntityTag` & attributes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -48,12 +48,12 @@ public abstract class ItemHelper {
 
     public abstract ItemStack setNbtData(ItemStack itemStack, CompoundTag compoundTag);
 
-    public CompoundTag getEntityTagNbt(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
+    public CompoundTag getEntityData(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
         CompoundTag nbt = getNbtData(item);
         return nbt != null && nbt.getValue().get("EntityTag") instanceof CompoundTag entityNbt ? entityNbt : null;
     }
 
-    public ItemStack setEntityTagNbt(ItemStack item, CompoundTag entityNbt, EntityType entityType) { // TODO: once 1.20 is the minimum supported version, remove default impl
+    public ItemStack setEntityData(ItemStack item, CompoundTag entityNbt, EntityType entityType) { // TODO: once 1.20 is the minimum supported version, remove default impl
         boolean shouldRemove = entityNbt == null || entityNbt.isEmpty();
         CompoundTag nbt = getNbtData(item);
         if (shouldRemove && !nbt.containsKey("EntityTag")) {

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -48,12 +48,12 @@ public abstract class ItemHelper {
 
     public abstract ItemStack setNbtData(ItemStack itemStack, CompoundTag compoundTag);
 
-    public CompoundTag getEntityTagNBT(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
+    public CompoundTag getEntityTagNbt(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
         CompoundTag nbt = getNbtData(item);
-        return nbt != null && nbt.getValue().get("EntityTag") instanceof CompoundTag entityTag ? entityTag : null;
+        return nbt != null && nbt.getValue().get("EntityTag") instanceof CompoundTag entityNbt ? entityNbt : null;
     }
 
-    public ItemStack setEntityTagNBT(ItemStack item, CompoundTag entityNbt, EntityType entityType) { // TODO: once 1.20 is the minimum supported version, remove default impl
+    public ItemStack setEntityTagNbt(ItemStack item, CompoundTag entityNbt, EntityType entityType) { // TODO: once 1.20 is the minimum supported version, remove default impl
         boolean shouldRemove = entityNbt == null || entityNbt.isEmpty();
         CompoundTag nbt = getNbtData(item);
         if (shouldRemove && !nbt.containsKey("EntityTag")) {

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.objects.ItemTag;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -46,6 +47,26 @@ public abstract class ItemHelper {
     public abstract CompoundTag getNbtData(ItemStack itemStack);
 
     public abstract ItemStack setNbtData(ItemStack itemStack, CompoundTag compoundTag);
+
+    public CompoundTag getEntityTagNBT(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
+        CompoundTag nbt = getNbtData(item);
+        return nbt != null && nbt.getValue().get("EntityTag") instanceof CompoundTag entityTag ? entityTag : null;
+    }
+
+    public ItemStack setEntityTagNBT(ItemStack item, CompoundTag entityNbt, EntityType entityType) { // TODO: once 1.20 is the minimum supported version, remove default impl
+        boolean shouldRemove = entityNbt == null || entityNbt.isEmpty();
+        CompoundTag nbt = getNbtData(item);
+        if (shouldRemove && !nbt.containsKey("EntityTag")) {
+            return item;
+        }
+        if (shouldRemove) {
+            nbt = nbt.createBuilder().remove("EntityTag").build();
+        }
+        else {
+            nbt = nbt.createBuilder().put("EntityTag", entityNbt).build();
+        }
+        return setNbtData(item, nbt);
+    }
 
     public abstract void registerSmithingRecipe(String keyName, ItemStack result, ItemStack[] baseItem, boolean baseExact, ItemStack[] upgradeItem, boolean upgradeExact, ItemStack[] templateItem, boolean templateExact);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTag.java
@@ -53,6 +53,14 @@ public abstract class CompoundTag extends Tag {
         return value.containsKey(key);
     }
 
+    public boolean isEmpty() {
+        return getValue().isEmpty();
+    }
+
+    public int size() {
+        return getValue().size();
+    }
+
     @Override
     public Map<String, Tag> getValue() {
         return value;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemArmorPose.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemArmorPose.java
@@ -32,7 +32,7 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
 
     @Override
     public MapTag getPropertyValue() {
-        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNBT(getItemStack());
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(getItemStack());
         if (entityNbt == null) {
             return null;
         }
@@ -53,7 +53,7 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
 
     @Override
     public void setPropertyValue(MapTag param, Mechanism mechanism) {
-        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNBT(getItemStack());
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(getItemStack());
         if (mechanism.hasValue()) {
             if (entityNbt == null) {
                 entityNbt = new CompoundTagBuilder().build();
@@ -82,7 +82,7 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
             }
             entityNbt = entityNbt.createBuilder().remove("Pose").build();
         }
-        ItemStack result = NMSHandler.itemHelper.setEntityTagNBT(getItemStack(), entityNbt, EntityType.ARMOR_STAND);
+        ItemStack result = NMSHandler.itemHelper.setEntityTagNbt(getItemStack(), entityNbt, EntityType.ARMOR_STAND);
         setItemStack(result);
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemArmorPose.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemArmorPose.java
@@ -9,6 +9,7 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -31,15 +32,11 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
 
     @Override
     public MapTag getPropertyValue() {
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(getItemStack());
-        if (compoundTag == null) {
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNBT(getItemStack());
+        if (entityNbt == null) {
             return null;
         }
-        Tag entPart = compoundTag.getValue().get("EntityTag");
-        if (!(entPart instanceof CompoundTag)) {
-            return null;
-        }
-        Tag posePart = ((CompoundTag) entPart).getValue().get("Pose");
+        Tag posePart = entityNbt.getValue().get("Pose");
         if (!(posePart instanceof CompoundTag)) {
             return null;
         }
@@ -56,15 +53,10 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
 
     @Override
     public void setPropertyValue(MapTag param, Mechanism mechanism) {
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(getItemStack());
-        Tag entPart, posePart;
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNBT(getItemStack());
         if (mechanism.hasValue()) {
-            if (compoundTag == null) {
-                compoundTag = new CompoundTagBuilder().build();
-            }
-            entPart = compoundTag.getValue().get("EntityTag");
-            if (!(entPart instanceof CompoundTag)) {
-                entPart = new CompoundTagBuilder().build();
+            if (entityNbt == null) {
+                entityNbt = new CompoundTagBuilder().build();
             }
             CompoundTagBuilder poseBuilder = new CompoundTagBuilder();
             procMechKey(mechanism, poseBuilder, "Head", "head", param);
@@ -75,33 +67,22 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
             procMechKey(mechanism, poseBuilder, "RightLeg", "right_leg", param);
             CompoundTag pose = poseBuilder.build();
             if (pose.getValue().isEmpty()) {
-                entPart = ((CompoundTag) entPart).createBuilder().remove("Pose").build();
+                entityNbt = entityNbt.createBuilder().remove("Pose").build();
             }
             else {
-                entPart = ((CompoundTag) entPart).createBuilder().put("Pose", pose).build();
+                entityNbt = entityNbt.createBuilder().put("Pose", pose).build();
             }
         }
         else {
-            if (compoundTag == null) {
+            if (entityNbt == null) {
                 return;
             }
-            entPart = compoundTag.getValue().get("EntityTag");
-            if (!(entPart instanceof CompoundTag)) {
+            if (!(entityNbt.getValue().get("Pose") instanceof CompoundTag)) {
                 return;
             }
-            posePart = ((CompoundTag) entPart).getValue().get("Pose");
-            if (!(posePart instanceof CompoundTag)) {
-                return;
-            }
-            entPart = ((CompoundTag) entPart).createBuilder().remove("Pose").build();
+            entityNbt = entityNbt.createBuilder().remove("Pose").build();
         }
-        if (((CompoundTag) entPart).getValue().isEmpty()) {
-            compoundTag = compoundTag.createBuilder().remove("EntityTag").build();
-        }
-        else {
-            compoundTag = compoundTag.createBuilder().put("EntityTag", entPart).build();
-        }
-        ItemStack result = NMSHandler.itemHelper.setNbtData(getItemStack(), compoundTag);
+        ItemStack result = NMSHandler.itemHelper.setEntityTagNBT(getItemStack(), entityNbt, EntityType.ARMOR_STAND);
         setItemStack(result);
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemArmorPose.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemArmorPose.java
@@ -32,7 +32,7 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
 
     @Override
     public MapTag getPropertyValue() {
-        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(getItemStack());
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityData(getItemStack());
         if (entityNbt == null) {
             return null;
         }
@@ -53,7 +53,7 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
 
     @Override
     public void setPropertyValue(MapTag param, Mechanism mechanism) {
-        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(getItemStack());
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityData(getItemStack());
         if (mechanism.hasValue()) {
             if (entityNbt == null) {
                 entityNbt = new CompoundTagBuilder().build();
@@ -82,7 +82,7 @@ public class ItemArmorPose extends ItemProperty<MapTag> {
             }
             entityNbt = entityNbt.createBuilder().remove("Pose").build();
         }
-        ItemStack result = NMSHandler.itemHelper.setEntityTagNbt(getItemStack(), entityNbt, EntityType.ARMOR_STAND);
+        ItemStack result = NMSHandler.itemHelper.setEntityData(getItemStack(), entityNbt, EntityType.ARMOR_STAND);
         setItemStack(result);
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemAttributeNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemAttributeNBT.java
@@ -1,19 +1,27 @@
 package com.denizenscript.denizen.objects.properties.item;
 
-import com.denizenscript.denizen.utilities.nbt.CustomNBT;
 import com.denizenscript.denizen.objects.ItemTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.core.EscapeTagUtil;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import com.denizenscript.denizencore.utilities.AsciiMatcher;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 @Deprecated
 public class ItemAttributeNBT implements Property {
@@ -62,12 +70,15 @@ public class ItemAttributeNBT implements Property {
 
     public ListTag getList() {
         ItemStack itemStack = item.getItemStack();
-        List<CustomNBT.AttributeReturn> nbtKeys = CustomNBT.getAttributes(itemStack);
+        ItemMeta meta = itemStack.getItemMeta();
         ListTag list = new ListTag();
-        if (nbtKeys != null) {
-            for (CustomNBT.AttributeReturn atr : nbtKeys) {
-                list.add(EscapeTagUtil.escape(atr.attr) + "/" + EscapeTagUtil.escape(atr.slot) + "/" + atr.op + "/" + atr.amt);
-            }
+        if (meta == null || !meta.hasAttributeModifiers()) {
+            return list;
+        }
+        for (Map.Entry<org.bukkit.attribute.Attribute, AttributeModifier> entry : meta.getAttributeModifiers().entries()) {
+            AttributeModifier modifier = entry.getValue();
+            String slotName = toLegacyName(modifier.getSlot() != null ? modifier.getSlot() : EquipmentSlot.HAND);
+            list.add(EscapeTagUtil.escape(entry.getKey().getKey().getKey()) + "/" + EscapeTagUtil.escape(slotName) + "/" + modifier.getOperation().ordinal() + "/" + modifier.getAmount());
         }
         return list;
     }
@@ -93,20 +104,92 @@ public class ItemAttributeNBT implements Property {
             }
             ListTag list = mechanism.valueAsType(ListTag.class);
             ItemStack itemStack = item.getItemStack();
-            itemStack = CustomNBT.clearNBT(itemStack, CustomNBT.KEY_ATTRIBUTES);
+            ItemMeta meta = itemStack.getItemMeta();
+            if (meta.hasAttributeModifiers()) {
+                meta.getAttributeModifiers().keySet().forEach(meta::removeAttributeModifier);
+            }
             for (String string : list) {
                 String[] split = string.split("/");
                 if (split.length != 4) {
                     mechanism.echoError("Invalid nbt_attributes input: must have 4 values per attribute.");
                     continue;
                 }
-                String attribute = EscapeTagUtil.unEscape(split[0]);
+                String attribute = fixAttributeName1_16(EscapeTagUtil.unEscape(split[0]));
                 String slot = EscapeTagUtil.unEscape(split[1]);
                 int op = new ElementTag(split[2]).asInt();
                 double amt = new ElementTag(split[3]).asDouble();
-                itemStack = CustomNBT.addAttribute(itemStack, attribute, slot, op, amt);
+                long uuidhelp = uuidChoice(itemStack);
+                int attribsSize = meta.hasAttributeModifiers() ? meta.getAttributeModifiers().values().size() : 0;
+                UUID fullUuid = new UUID(uuidhelp + 88512 + attribsSize, uuidhelp * 2 + 1250025L + attribsSize);
+                meta.addAttributeModifier(Registry.ATTRIBUTE.get(NamespacedKey.minecraft(attribute)), new AttributeModifier(fullUuid, attribute, amt, AttributeModifier.Operation.values()[op], fromLegacyName(slot)));
             }
+            itemStack.setItemMeta(meta);
             item.setItemStack(itemStack);
         }
+    }
+
+    public static final AsciiMatcher uppercaseMatcher = new AsciiMatcher(AsciiMatcher.LETTERS_UPPER);
+
+    public static final HashMap<String, String> attributeNameUpdates = new HashMap<>();
+
+    static {
+        attributeNameUpdates.put("generic.maxHealth", "generic.max_health");
+        attributeNameUpdates.put("generic.followRange", "generic.follow_range");
+        attributeNameUpdates.put("generic.knockbackResistance", "generic.knockback_resistance");
+        attributeNameUpdates.put("generic.movementSpeed", "generic.movement_speed");
+        attributeNameUpdates.put("generic.flyingSpeed", "generic.flying_speed");
+        attributeNameUpdates.put("generic.attackDamage", "generic.attack_damage");
+        attributeNameUpdates.put("generic.attackKnockback", "generic.attack_knockback");
+        attributeNameUpdates.put("generic.attackSpeed", "generic.attack_speed");
+        attributeNameUpdates.put("generic.armorToughness", "generic.armor_toughness");
+    }
+
+    public static String fixAttributeName1_16(String input) {
+        if (!uppercaseMatcher.containsAnyMatch(input)) {
+            return input;
+        }
+        String replacement = attributeNameUpdates.get(input);
+        if (replacement != null) {
+            return replacement;
+        }
+        return CoreUtilities.toLowerCase(input);
+    }
+
+    public static long uuidChoice(ItemStack its) {
+        String mat = CoreUtilities.toLowerCase(its.getType().name());
+        if (mat.contains("boots")) {
+            return 1000;
+        }
+        else if (mat.contains("legging")) {
+            return 100000;
+        }
+        else if (mat.contains("helmet")) {
+            return 10000000;
+        }
+        else if (mat.contains("chestp")) {
+            return 1000000000;
+        }
+        else {
+            return 1;
+        }
+    }
+
+    private static EquipmentSlot fromLegacyName(String name) {
+        return switch (name) {
+            case "mainhand" -> EquipmentSlot.HAND;
+            case "offhand" -> EquipmentSlot.OFF_HAND;
+            default -> {
+                EquipmentSlot slot = ElementTag.asEnum(EquipmentSlot.class, name);
+                yield slot != null ? slot : EquipmentSlot.HAND;
+            }
+        };
+    }
+
+    private static String toLegacyName(EquipmentSlot slot) {
+        return switch (slot) {
+            case HAND -> "mainhand";
+            case OFF_HAND -> "offhand";
+            default -> CoreUtilities.toLowerCase(slot.name());
+        };
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemFrameInvisible.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemFrameInvisible.java
@@ -42,7 +42,7 @@ public class ItemFrameInvisible implements Property {
     ItemTag item;
 
     public boolean isInvisible() {
-        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNBT(item.getItemStack());
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(item.getItemStack());
         if (entityNbt == null) {
             return false;
         }
@@ -94,7 +94,7 @@ public class ItemFrameInvisible implements Property {
         // <ItemTag.invisible>
         // -->
         if (mechanism.matches("invisible") && mechanism.requireBoolean()) {
-            CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNBT(item.getItemStack());
+            CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(item.getItemStack());
             boolean invisible = mechanism.getValue().asBoolean();
             if (!invisible && entityNbt == null) {
                 return;
@@ -106,7 +106,7 @@ public class ItemFrameInvisible implements Property {
             else {
                 entityNbt = entityNbt.createBuilder().remove("Invisible").build();
             }
-            item.setItemStack(NMSHandler.itemHelper.setEntityTagNBT(item.getItemStack(), entityNbt, item.getBukkitMaterial() == Material.ITEM_FRAME ? EntityType.ITEM_FRAME : EntityType.GLOW_ITEM_FRAME));
+            item.setItemStack(NMSHandler.itemHelper.setEntityTagNbt(item.getItemStack(), entityNbt, item.getBukkitMaterial() == Material.ITEM_FRAME ? EntityType.ITEM_FRAME : EntityType.GLOW_ITEM_FRAME));
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemFrameInvisible.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemFrameInvisible.java
@@ -42,7 +42,7 @@ public class ItemFrameInvisible implements Property {
     ItemTag item;
 
     public boolean isInvisible() {
-        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(item.getItemStack());
+        CompoundTag entityNbt = NMSHandler.itemHelper.getEntityData(item.getItemStack());
         if (entityNbt == null) {
             return false;
         }
@@ -94,7 +94,7 @@ public class ItemFrameInvisible implements Property {
         // <ItemTag.invisible>
         // -->
         if (mechanism.matches("invisible") && mechanism.requireBoolean()) {
-            CompoundTag entityNbt = NMSHandler.itemHelper.getEntityTagNbt(item.getItemStack());
+            CompoundTag entityNbt = NMSHandler.itemHelper.getEntityData(item.getItemStack());
             boolean invisible = mechanism.getValue().asBoolean();
             if (!invisible && entityNbt == null) {
                 return;
@@ -106,7 +106,7 @@ public class ItemFrameInvisible implements Property {
             else {
                 entityNbt = entityNbt.createBuilder().remove("Invisible").build();
             }
-            item.setItemStack(NMSHandler.itemHelper.setEntityTagNbt(item.getItemStack(), entityNbt, item.getBukkitMaterial() == Material.ITEM_FRAME ? EntityType.ITEM_FRAME : EntityType.GLOW_ITEM_FRAME));
+            item.setItemStack(NMSHandler.itemHelper.setEntityData(item.getItemStack(), entityNbt, item.getBukkitMaterial() == Material.ITEM_FRAME ? EntityType.ITEM_FRAME : EntityType.GLOW_ITEM_FRAME));
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -227,6 +227,11 @@ public class BukkitImplDeprecations {
     public static Warning oldStructureTypes = new SlowWarning("oldStructureTypes", "'server.structure_types' is based on outdated API and doesn't support modern datapack features. Use 'server.structures' instead.");
     public static Warning findStructureTags = new SlowWarning("findStructureTags", "'LocationTag.find.structure' and related tags are deprecated in favor of 'LocationTag.find_structure'.");
 
+    // Added 2021/03/29, made very-slow 2022/12/31, made slow 2024/05/09.
+    // 2022-year-end commonality: #7
+    // 2023-year-end commonality: #31
+    public static Warning legacyAttributeProperties = new SlowWarning("legacyAttributeProperties", "The 'attribute' properties are deprecated in favor of the 'attribute_modifiers' properties which more fully implement the attribute system.");
+
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.
 
@@ -256,11 +261,6 @@ public class BukkitImplDeprecations {
     // Added 2021/10/18, made very-slow 2022/12/31.
     // 2022-year-end commonality: #10
     public static Warning entityMechanismsFormat = new VerySlowWarning("entityMechanismsFormat", "Entity script containers previously allowed mechanisms in the script's root, however they should now be under a 'mechanisms' key.");
-
-    // Added 2021/03/29, made very-slow 2022/12/31.
-    // 2022-year-end commonality: #7
-    // 2023-year-end commonality: #31
-    public static Warning legacyAttributeProperties = new VerySlowWarning("legacyAttributeProperties", "The 'attribute' properties are deprecated in favor of the 'attribute_modifiers' properties which more fully implement the attribute system.");
 
     // Added 2021/08/30, made very-slow 2022/12/31.
     // 2022-year-end commonality: #23

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -250,7 +250,7 @@ public class ItemHelperImpl extends ItemHelper {
     }
 
     @Override
-    public CompoundTag getEntityTagNBT(ItemStack item) {
+    public CompoundTag getEntityTagNbt(ItemStack item) {
         CustomData entityData = CraftItemStack.asNMSCopy(item).get(DataComponents.ENTITY_DATA);
         return entityData != null ? CompoundTagImpl.fromNMSTag(entityData.getUnsafe()) : null;
     }
@@ -258,7 +258,7 @@ public class ItemHelperImpl extends ItemHelper {
     public static final net.minecraft.nbt.CompoundTag EMPTY_TAG = new net.minecraft.nbt.CompoundTag();
 
     @Override
-    public ItemStack setEntityTagNBT(ItemStack item, CompoundTag entityNbt, EntityType entityType) {
+    public ItemStack setEntityTagNbt(ItemStack item, CompoundTag entityNbt, EntityType entityType) {
         net.minecraft.nbt.CompoundTag nmsEntityNbt = EMPTY_TAG;
         if (entityNbt != null && !entityNbt.isEmpty() && (!entityNbt.containsKey("id") || entityNbt.size() > 1)) {
             nmsEntityNbt = ((CompoundTagImpl) entityNbt).toNMSTag();

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -250,7 +250,7 @@ public class ItemHelperImpl extends ItemHelper {
     }
 
     @Override
-    public CompoundTag getEntityTagNbt(ItemStack item) {
+    public CompoundTag getEntityData(ItemStack item) {
         CustomData entityData = CraftItemStack.asNMSCopy(item).get(DataComponents.ENTITY_DATA);
         return entityData != null ? CompoundTagImpl.fromNMSTag(entityData.getUnsafe()) : null;
     }
@@ -258,7 +258,7 @@ public class ItemHelperImpl extends ItemHelper {
     public static final net.minecraft.nbt.CompoundTag EMPTY_TAG = new net.minecraft.nbt.CompoundTag();
 
     @Override
-    public ItemStack setEntityTagNbt(ItemStack item, CompoundTag entityNbt, EntityType entityType) {
+    public ItemStack setEntityData(ItemStack item, CompoundTag entityNbt, EntityType entityType) {
         net.minecraft.nbt.CompoundTag nmsEntityNbt = EMPTY_TAG;
         if (entityNbt != null && !entityNbt.isEmpty() && (!entityNbt.containsKey("id") || entityNbt.size() > 1)) {
             nmsEntityNbt = ((CompoundTagImpl) entityNbt).toNMSTag();

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -63,6 +63,7 @@ import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftRecipe;
 import org.bukkit.craftbukkit.v1_20_R4.map.CraftMapView;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftNamespacedKey;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -245,6 +246,26 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public ItemStack setNbtData(ItemStack itemStack, CompoundTag compoundTag) {
         net.minecraft.world.item.ItemStack nmsItemStack = net.minecraft.world.item.ItemStack.parseOptional(CraftRegistry.getMinecraftRegistry(), ((CompoundTagImpl) compoundTag).toNMSTag());
+        return CraftItemStack.asBukkitCopy(nmsItemStack);
+    }
+
+    @Override
+    public CompoundTag getEntityTagNBT(ItemStack item) {
+        CustomData entityData = CraftItemStack.asNMSCopy(item).get(DataComponents.ENTITY_DATA);
+        return entityData != null ? CompoundTagImpl.fromNMSTag(entityData.getUnsafe()) : null;
+    }
+
+    public static final net.minecraft.nbt.CompoundTag EMPTY_TAG = new net.minecraft.nbt.CompoundTag();
+
+    @Override
+    public ItemStack setEntityTagNBT(ItemStack item, CompoundTag entityNbt, EntityType entityType) {
+        net.minecraft.nbt.CompoundTag nmsEntityNbt = EMPTY_TAG;
+        if (entityNbt != null && !entityNbt.isEmpty() && (!entityNbt.containsKey("id") || entityNbt.size() > 1)) {
+            nmsEntityNbt = ((CompoundTagImpl) entityNbt).toNMSTag();
+            nmsEntityNbt.putString("id", entityType.getKey().toString());
+        }
+        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(item);
+        CustomData.set(DataComponents.ENTITY_DATA, nmsItemStack, nmsEntityNbt);
         return CraftItemStack.asBukkitCopy(nmsItemStack);
     }
 


### PR DESCRIPTION
## Additions

- `ItemHelper#get/setEntityData` - controls an item's entity NBT data (for item frames, armor stands, etc.), both a default impl using the old NBT methods & a 1.20 impl using item components.
- `CompundTag#size` & `#isEmpty` util methods.
- `ItemAttributeNBT#from/toLegacyName` - for managing the old/internal `EquipmentSlot` names it uses.

## Changes

- `ItemArmorPose` and `ItemFrameInvisible` now use the new `ItemHelper#get/setEntityData`
- The legacy `ItemAttributeNBT` property was changed to use API instead of NBT editing (was going to use API anyway for 1.20.6, so might as well just not have the legacy NBT logic - tested on 1.17.1 & 1.20.6).
- `CustomNBT` attribute-related methods were removed/moved to `ItemAttributeNBT`.
- The `legacyAttributeProperties` warning was bumped to `SlowWarning`.