### PR TITLE
Fixes to Schematic Command relating to Entities

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SchematicCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SchematicCommand.java
@@ -104,7 +104,7 @@ public class SchematicCommand extends AbstractCommand implements Holdable, Liste
     // This takes an optional duration as "fake_duration" for how long the fake blocks should remain.
     //
     // The "create" and "paste" options allow the "entities" argument to be specified - when used, entities will be copied or pasted.
-    // At current time, entity types included will be: Paintings, ItemFrames, ArmorStands.
+    // At current time, entity types included will be: Paintings, ItemFrames, GlowItemFrames, ArmorStands, and DisplayEntities.
     //
     // The "create" option allows the "flags" argument to be specified - when used, block location flags will be copied.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/blocks/CuboidBlockSet.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/blocks/CuboidBlockSet.java
@@ -193,7 +193,7 @@ public class CuboidBlockSet implements BlockSet {
             case SOUTH_EAST:
                 return BlockFace.NORTH_EAST;
             default:
-                return BlockFace.SELF;
+                return face;
         }
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/blocks/CuboidBlockSet.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/blocks/CuboidBlockSet.java
@@ -218,7 +218,6 @@ public class CuboidBlockSet implements BlockSet {
                     }
                     MapTag data = new MapTag();
                     data.putObject("entity", entTag.describe(null));
-                    data.putObject("rotation", new ElementTag(0));
                     Vector offset = ent.getLocation().toVector().subtract(center.toVector());
                     data.putObject("offset", new LocationTag((String) null, offset.getX(), offset.getY(), offset.getZ(), ent.getLocation().getYaw(), ent.getLocation().getPitch()));
                     entities.addObject(data);
@@ -234,38 +233,17 @@ public class CuboidBlockSet implements BlockSet {
         for (MapTag data : entities.filter(MapTag.class, CoreUtilities.noDebugContext)) {
             try {
                 LocationTag offset = data.getObjectAs("offset", LocationTag.class, CoreUtilities.noDebugContext);
-                int rotation = data.getElement("rotation").asInt();
                 EntityTag entity = data.getObjectAs("entity", EntityTag.class, CoreUtilities.noDebugContext);
                 if (entity == null || offset == null) {
                     continue;
                 }
                 entity = entity.duplicate();
                 offset = offset.clone();
-                if (rotation != 0) {
-                    ArrayList<Mechanism> mechs = new ArrayList<>(entity.getWaitingMechanisms().size());
-                    for (Mechanism mech : entity.getWaitingMechanisms()) {
-                        if (mech.getName().equals("rotation")) {
-                            String rotationName = mech.getValue().asString();
-                            BlockFace face = BlockFace.valueOf(rotationName.toUpperCase());
-                            for (int i = 0; i < rotation; i += 90) {
-                                face = rotateFaceOne(face);
-                            }
-                            offset.add(face.getDirection().multiply(0.1)); // Compensate for hanging locations being very stupid
-                            mechs.add(new Mechanism("rotation", new ElementTag(face), CoreUtilities.noDebugContext));
-                        }
-                        else {
-                            mechs.add(new Mechanism(mech.getName(), mech.value, CoreUtilities.noDebugContext));
-                        }
-                    }
-                    entity.mechanisms = mechs;
-                }
-                else {
-                    for (Mechanism mechanism : entity.mechanisms) {
-                        mechanism.context = CoreUtilities.noDebugContext;
-                    }
+                for (Mechanism mechanism : entity.mechanisms) {
+                    mechanism.context = CoreUtilities.noDebugContext;
                 }
                 Location spawnLoc = relative.clone().add(offset);
-                spawnLoc.setYaw(offset.getYaw() - rotation);
+                spawnLoc.setYaw(offset.getYaw());
                 spawnLoc.setPitch(offset.getPitch());
                 entity.spawnAt(spawnLoc);
             }
@@ -349,15 +327,24 @@ public class CuboidBlockSet implements BlockSet {
         ListTag outEntities = new ListTag();
         for (MapTag data : entities.filter(MapTag.class, CoreUtilities.noDebugContext)) {
             LocationTag offset = data.getObjectAs("offset", LocationTag.class, CoreUtilities.noDebugContext);
-            int rotation = data.getElement("rotation").asInt();
-            offset = new LocationTag((String) null, offset.getZ(), offset.getY(), -offset.getX() + 1, offset.getYaw(), offset.getPitch());
-            rotation += 90;
-            while (rotation >= 360) {
-                rotation -= 360;
+            EntityTag entity = data.getObjectAs("entity", EntityTag.class, CoreUtilities.noDebugContext);
+            offset = new LocationTag((String) null, offset.getZ(), offset.getY(), -offset.getX() + 1, normalizeYaw(offset.getYaw() - 90), offset.getPitch());
+            ArrayList<Mechanism> mechs = new ArrayList<>(entity.getWaitingMechanisms().size());
+            for (Mechanism mech : entity.getWaitingMechanisms()) {
+                if (mech.getName().equals("rotation")) {
+                    String rotationName = mech.getValue().asString();
+                    BlockFace face = BlockFace.valueOf(rotationName.toUpperCase());
+                    face = rotateFaceOne(face);
+                    mechs.add(new Mechanism("rotation", new ElementTag(face), CoreUtilities.noDebugContext));
+                }
+                else {
+                    mechs.add(new Mechanism(mech.getName(), mech.value, CoreUtilities.noDebugContext));
+                }
             }
+            entity.mechanisms = mechs;
             data = data.duplicate();
             data.putObject("offset", offset);
-            data.putObject("rotation", new ElementTag(rotation));
+            data.putObject("entity", entity);
             outEntities.addObject(data);
         }
         entities = outEntities;
@@ -389,15 +376,26 @@ public class CuboidBlockSet implements BlockSet {
         }
         ListTag outEntities = new ListTag();
         for (MapTag data : entities.filter(MapTag.class, CoreUtilities.noDebugContext)) {
-            int rotation = data.getElement("rotation").asInt();
+            EntityTag entity = data.getObjectAs("entity", EntityTag.class, CoreUtilities.noDebugContext);
             LocationTag offset = data.getObjectAs("offset", LocationTag.class, CoreUtilities.noDebugContext);
-            int newYaw = normalizeAngle((int)offset.getYaw() - rotation);
-            newYaw = -(newYaw - 90) + 270;
-            rotation = normalizeAngle((int)(newYaw - offset.getYaw()));
+            offset.setYaw(normalizeYaw(180 - (offset.getYaw() - 90) + 90));
             offset.setX(-offset.getX() + 1);
+            ArrayList<Mechanism> mechs = new ArrayList<>(entity.getWaitingMechanisms().size());
+            for (Mechanism mech : entity.getWaitingMechanisms()) {
+                if (mech.getName().equals("rotation")) {
+                    String rotationName = mech.getValue().asString();
+                    BlockFace face = BlockFace.valueOf(rotationName.toUpperCase());
+                    face = FullBlockData.flipFaceX(face);
+                    mechs.add(new Mechanism("rotation", new ElementTag(face), CoreUtilities.noDebugContext));
+                }
+                else {
+                    mechs.add(new Mechanism(mech.getName(), mech.value, CoreUtilities.noDebugContext));
+                }
+            }
+            entity.mechanisms = mechs;
             data = data.duplicate();
             data.putObject("offset", offset);
-            data.putObject("rotation", new ElementTag(rotation));
+            data.putObject("entity", entity);
             outEntities.addObject(data);
         }
         entities = outEntities;
@@ -409,29 +407,40 @@ public class CuboidBlockSet implements BlockSet {
         }
         ListTag outEntities = new ListTag();
         for (MapTag data : entities.filter(MapTag.class, CoreUtilities.noDebugContext)) {
-            int rotation = data.getElement("rotation").asInt();
+            EntityTag entity = data.getObjectAs("entity", EntityTag.class, CoreUtilities.noDebugContext);
             LocationTag offset = data.getObjectAs("offset", LocationTag.class, CoreUtilities.noDebugContext);
-            int newYaw = normalizeAngle((int)offset.getYaw() - rotation);
-            newYaw = 180 - newYaw;
-            rotation = normalizeAngle((int)(newYaw - offset.getYaw()));
             offset.setZ(-offset.getZ() + 1);
+            offset.setYaw(normalizeYaw(180 - offset.getYaw()));
+            ArrayList<Mechanism> mechs = new ArrayList<>(entity.getWaitingMechanisms().size());
+            for (Mechanism mech : entity.getWaitingMechanisms()) {
+                if (mech.getName().equals("rotation")) {
+                    String rotationName = mech.getValue().asString();
+                    BlockFace face = BlockFace.valueOf(rotationName.toUpperCase());
+                    face = FullBlockData.flipFaceZ(face);
+                    mechs.add(new Mechanism("rotation", new ElementTag(face), CoreUtilities.noDebugContext));
+                }
+                else {
+                    mechs.add(new Mechanism(mech.getName(), mech.value, CoreUtilities.noDebugContext));
+                }
+            }
+            entity.mechanisms = mechs;
             data = data.duplicate();
             data.putObject("offset", offset);
-            data.putObject("rotation", new ElementTag(rotation));
+            data.putObject("entity", entity);
             outEntities.addObject(data);
         }
         entities = outEntities;
     }
 
-    public int normalizeAngle(int angle){
-        while (angle < 0 || angle >= 360) {
-            if (angle >= 360) {
-                angle -= 360;
+    public float normalizeYaw(float yaw){
+        while (yaw < 0 || yaw >= 360) {
+            if (yaw >= 360) {
+                yaw -= 360;
             } else {
-                angle += 360;
+                yaw += 360;
             }
         }
-        return angle;
+        return yaw;
     }
 
     public void flipX() {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/blocks/CuboidBlockSet.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/blocks/CuboidBlockSet.java
@@ -197,7 +197,7 @@ public class CuboidBlockSet implements BlockSet {
         }
     }
 
-    public static HashSet<EntityType> copyTypes = new HashSet<>(Arrays.asList(EntityType.PAINTING, EntityType.ITEM_FRAME, EntityType.ARMOR_STAND));
+    public static HashSet<EntityType> copyTypes = new HashSet<>(Arrays.asList(EntityType.PAINTING, EntityType.ITEM_FRAME, EntityType.ARMOR_STAND, EntityType.GLOW_ITEM_FRAME));
 
     static {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {


### PR DESCRIPTION
**Fixes Schematic Command relating to Entities**
- Add missing "glow_item_frame" entity to copied entities.
- Fix for Entity being pasted 1 block off of expected position after schematic is flipped.
- Fix for Entity being pasted with incorrect Yaw value after schematic is flipped.
- Fix for exception thrown when non-rotatable entity is rotated.
- Update command meta with missing supported entity types.

**Notable potential issues**
- Removed "rotation" value being tracked for entities in a schematic (note: this is not the "entity rotation" mechanism).
    - The "rotation" value was tracking "how much should the entity rotate when being pasted", however complicated logic figuring out "how far to rotate" when flipping schematics correctly.
    - Yaw and the entity rotation mechanism are now changed during schematic flip/rotate, aligning more with how blocks flip/rotate for schematics.
    - This should only be an issue for users who have created a schematic, flipped/rotated, then saved that schematic - however the saved rotation value would have also been incorrect when saved.