### PR TITLE
`ItemTag.custom_data`, `raw_nbt` deprecation

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -49,6 +49,14 @@ public abstract class ItemHelper {
 
     public abstract ItemStack setNbtData(ItemStack itemStack, CompoundTag compoundTag);
 
+    public CompoundTag getCustomData(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
+        return getNbtData(item);
+    }
+
+    public ItemStack setCustomData(ItemStack item, CompoundTag data) { // TODO: once 1.20 is the minimum supported version, remove default impl
+        throw new UnsupportedOperationException();
+    }
+
     public CompoundTag getEntityData(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
         CompoundTag nbt = getNbtData(item);
         return nbt != null && nbt.getValue().get("EntityTag") instanceof CompoundTag entityNbt ? entityNbt : null;

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -57,6 +57,10 @@ public abstract class ItemHelper {
         throw new UnsupportedOperationException();
     }
 
+    public ItemStack setPartialOldNbt(ItemStack item, CompoundTag oldTag) {
+        throw new UnsupportedOperationException();
+    }
+
     public CompoundTag getEntityData(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
         CompoundTag nbt = getNbtData(item);
         return nbt != null && nbt.getValue().get("EntityTag") instanceof CompoundTag entityNbt ? entityNbt : null;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -214,6 +214,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(ItemCanDestroy.class, ItemTag.class);
         PropertyParser.registerProperty(ItemCanPlaceOn.class, ItemTag.class);
         PropertyParser.registerProperty(ItemColor.class, ItemTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            PropertyParser.registerProperty(ItemCustomData.class, ItemTag.class);
+        }
         PropertyParser.registerProperty(ItemCustomModel.class, ItemTag.class);
         PropertyParser.registerProperty(ItemChargedProjectile.class, ItemTag.class);
         PropertyParser.registerProperty(ItemEnchantments.class, ItemTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBaseColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBaseColor.java
@@ -70,7 +70,7 @@ public class ItemBaseColor extends ItemProperty<ElementTag> {
 
     public void setBaseColor(DyeColor color, TagContext context) {
         if (color == null && getMaterial() == Material.SHIELD) {
-            ItemRawNBT property = ItemRawNBT.getFrom(object);
+            ItemRawNBT property = new ItemRawNBT(object);
             MapTag nbt = property.getFullNBTMap();
             nbt.putObject("BlockEntityTag", null);
             property.setFullNBT(object, nbt, context, false);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCustomData.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCustomData.java
@@ -1,0 +1,106 @@
+package com.denizenscript.denizen.objects.properties.item;
+
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
+import com.denizenscript.denizen.nms.util.jnbt.CompoundTagBuilder;
+import com.denizenscript.denizen.nms.util.jnbt.Tag;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+
+public class ItemCustomData extends ItemProperty<MapTag> {
+
+    // <--[property]
+    // @object ItemTag
+    // @name custom_data
+    // @input MapTag
+    // @description
+    // Controls an item's custom NBT data, if any.
+    // The map is in NBT format, see <@link language Raw NBT Encoding>.
+    // This does not include any normal vanilla data (enchantments, lore, etc.), just extra custom data.
+    // This is useful for integrating with items from external systems (such as custom items from plugins), but item flags should be preferred otherwise.
+    // @mechanism
+    // Provide no input to clear custom data.
+    // @tag-example
+    // # Use to check if an item has custom data from another plugin.
+    // - if <[item].custom_data.get[custom_plugin_data].if_null[null]> == external_custom_item:
+    //   - narrate "You are using an item from an external custom plugin!"
+    // -->
+
+    // Custom data added by Denizen
+    public static final String[] DENIZEN_DATA = new String[] { "Denizen Item Script", "DenizenItemScript", "Denizen NBT", "Denizen" };
+
+    public static boolean describes(ItemTag item) {
+        return !item.getBukkitMaterial().isAir();
+    }
+
+    public ItemCustomData(ItemTag item) {
+        this.object = item;
+    }
+
+    @Override
+    public MapTag getPropertyValue() {
+        CompoundTag customData = NMSHandler.itemHelper.getCustomData(getItemStack());
+        if (customData == null) {
+            return null;
+        }
+        if (customData.isEmpty()) {
+            return new MapTag();
+        }
+        MapTag dataMap = (MapTag) ItemRawNBT.jnbtTagToObject(customData);
+        for (String denizenKey : DENIZEN_DATA) {
+            dataMap.remove(denizenKey);
+        }
+        return dataMap.isEmpty() ? null : dataMap;
+    }
+
+    @Override
+    public void setPropertyValue(MapTag value, Mechanism mechanism) {
+        if (value == null) {
+            setItemStack(NMSHandler.itemHelper.setCustomData(getItemStack(), addDenizenKeys(null)));
+            return;
+        }
+        CompoundTag customData;
+        try {
+            customData = (CompoundTag) ItemRawNBT.convertObjectToNbt(value.identify(), mechanism.context, "(data)");
+        }
+        catch (Exception ex) {
+            mechanism.echoError("Invalid custom data specified:");
+            Debug.echoError(ex);
+            return;
+        }
+        if (customData == null) {
+            mechanism.echoError("Invalid custom data specified.");
+            return;
+        }
+        setItemStack(NMSHandler.itemHelper.setCustomData(getItemStack(), addDenizenKeys(customData)));
+    }
+
+    private CompoundTag addDenizenKeys(CompoundTag tag) {
+        CompoundTag currentData = NMSHandler.itemHelper.getCustomData(getItemStack());
+        if (currentData == null) {
+            return tag;
+        }
+        CompoundTagBuilder tagBuilder = null;
+        for (String denizenKey : DENIZEN_DATA) {
+            Tag denizenValue = currentData.getValue().get(denizenKey);
+            if (denizenValue != null) {
+                if (tagBuilder == null) {
+                    tagBuilder = tag != null ? tag.createBuilder() : CompoundTagBuilder.create();
+                }
+                tagBuilder.put(denizenKey, denizenValue);
+            }
+        }
+        return tagBuilder != null ? tagBuilder.build() : tag;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "custom_data";
+    }
+
+    public static void register() {
+        autoRegisterNullable("custom_data", ItemCustomData.class, MapTag.class, false);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCustomData.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCustomData.java
@@ -24,8 +24,8 @@ public class ItemCustomData extends ItemProperty<MapTag> {
     // Provide no input to clear custom data.
     // @tag-example
     // # Use to check if an item has custom data from another plugin.
-    // - if <[item].custom_data.get[custom_plugin_data].if_null[null]> == external_custom_item:
-    //   - narrate "You are using an item from an external custom plugin!"
+    // - if <[item].custom_data.get[external_plugin_data].if_null[null]> == external_custom_item:
+    //   - narrate "You are using an item from an external plugin!"
     // -->
 
     // Custom data added by Denizen
@@ -79,7 +79,7 @@ public class ItemCustomData extends ItemProperty<MapTag> {
 
     private CompoundTag addDenizenKeys(CompoundTag tag) {
         CompoundTag currentData = NMSHandler.itemHelper.getCustomData(getItemStack());
-        if (currentData == null) {
+        if (currentData == null || currentData.isEmpty()) {
             return tag;
         }
         CompoundTagBuilder tagBuilder = null;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
@@ -8,8 +8,7 @@ import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
@@ -20,32 +19,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ItemRawNBT implements Property {
+public class ItemRawNBT extends ItemProperty<MapTag> {
 
-    public static boolean describes(ObjectTag item) {
+    public static boolean describes(ItemTag item) {
         // All items can have raw NBT
-        return item instanceof ItemTag && ((ItemTag) item).getBukkitMaterial() != Material.AIR;
+        return item.getBukkitMaterial() != Material.AIR;
     }
 
-    public static ItemRawNBT getFrom(ObjectTag _item) {
-        if (!describes(_item)) {
-            return null;
-        }
-        else {
-            return new ItemRawNBT((ItemTag) _item);
-        }
-    }
-
-    public static final String[] handledTags = new String[] {
-            "raw_nbt", "all_raw_nbt"
-    };
-
-    public static final String[] handledMechs = new String[] {
-            "raw_nbt"
-    };
-
-    public ItemRawNBT(ItemTag _item) {
-        item = _item;
+    public ItemRawNBT(ItemTag item) {
+        this.object = item;
     }
 
     public static String[] defaultNbtKeys = new String[] {
@@ -93,7 +75,7 @@ public class ItemRawNBT implements Property {
         for (String key : defaultNbtKeys) {
             result.remove(key);
         }
-        if (item.getBukkitMaterial() == Material.ITEM_FRAME) {
+        if (getMaterial() == Material.ITEM_FRAME) {
             MapTag entityMap = (MapTag) result.getObject("EntityTag");
             if (entityMap != null) {
                 entityMap.putObject("Invisible", null);
@@ -102,7 +84,7 @@ public class ItemRawNBT implements Property {
                 }
             }
         }
-        if (item.getBukkitMaterial() == Material.ARMOR_STAND) {
+        if (getMaterial() == Material.ARMOR_STAND) {
             MapTag entityMap = (MapTag) result.getObject("EntityTag");
             if (entityMap != null) {
                 entityMap.putObject("Pose", null);
@@ -120,7 +102,7 @@ public class ItemRawNBT implements Property {
     }
 
     public MapTag getFullNBTMap() {
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(item.getItemStack());
+        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(getItemStack());
         return (MapTag) jnbtTagToObject(compoundTag);
     }
 
@@ -291,27 +273,40 @@ public class ItemRawNBT implements Property {
         }
     }
 
-    ItemTag item;
-
+    // <--[tag]
+    // @attribute <ItemTag.raw_nbt>
+    // @returns MapTag
+    // @mechanism ItemTag.raw_nbt
+    // @group properties
+    // @description
+    // Returns a map of all non-default raw NBT on this item.
+    // Refer to format details at <@link language Raw NBT Encoding>.
+    // -->
     @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public MapTag getPropertyValue() {
+        MapTag nonDefaultNBT = getNonDefaultNBTMap();
+        return nonDefaultNBT.isEmpty() ? null : nonDefaultNBT;
+    }
 
-        if (attribute == null) {
-            return null;
-        }
+    // <--[mechanism]
+    // @object ItemTag
+    // @name raw_nbt
+    // @input MapTag
+    // @description
+    // Sets the given map of raw NBT keys onto this item.
+    // Note that the input format must be strictly perfect.
+    // Refer to <@link language Raw NBT Encoding> for explanation of the input format.
+    // @tags
+    // <ItemTag.raw_nbt>
+    // <ItemTag.all_raw_nbt>
+    // -->
+    @Override
+    public void setPropertyValue(MapTag value, Mechanism mechanism) {
+        setFullNBT(object, value, mechanism.context, true);
+    }
 
-        // <--[tag]
-        // @attribute <ItemTag.raw_nbt>
-        // @returns MapTag
-        // @mechanism ItemTag.raw_nbt
-        // @group properties
-        // @description
-        // Returns a map of all non-default raw NBT on this item.
-        // Refer to format details at <@link language Raw NBT Encoding>.
-        // -->
-        if (attribute.startsWith("raw_nbt")) {
-            return getNonDefaultNBTMap().getObjectAttribute(attribute.fulfill(1));
-        }
+    public static void register() {
+        autoRegister("raw_nbt", ItemRawNBT.class, MapTag.class, false);
 
         // <--[tag]
         // @attribute <ItemTag.all_raw_nbt>
@@ -322,22 +317,9 @@ public class ItemRawNBT implements Property {
         // Returns a map of all raw NBT on this item, including default values.
         // Refer to format details at <@link language Raw NBT Encoding>.
         // -->
-        if (attribute.startsWith("all_raw_nbt")) {
-            return getFullNBTMap().getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
-    }
-
-    @Override
-    public String getPropertyString() {
-        MapTag nbt = getNonDefaultNBTMap();
-        if (!nbt.isEmpty()) {
-            return nbt.identify();
-        }
-        else {
-            return null;
-        }
+        PropertyParser.registerTag(ItemRawNBT.class, MapTag.class, "all_raw_nbt", (attribute, prop) -> {
+            return prop.getFullNBTMap();
+        });
     }
 
     @Override
@@ -363,26 +345,5 @@ public class ItemRawNBT implements Property {
         }
         compoundTag = NMSHandler.instance.createCompoundTag(result);
         item.setItemStack(NMSHandler.itemHelper.setNbtData(item.getItemStack(), compoundTag));
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-
-        // <--[mechanism]
-        // @object ItemTag
-        // @name raw_nbt
-        // @input MapTag
-        // @description
-        // Sets the given map of raw NBT keys onto this item.
-        // Note that the input format must be strictly perfect.
-        // Refer to <@link language Raw NBT Encoding> for explanation of the input format.
-        // @tags
-        // <ItemTag.raw_nbt>
-        // <ItemTag.all_raw_nbt>
-        // -->
-        if (mechanism.matches("raw_nbt") && mechanism.requireObject(MapTag.class)) {
-            MapTag input = mechanism.valueAsType(MapTag.class);
-            setFullNBT(item, input, mechanism.context, true);
-        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
@@ -291,20 +291,20 @@ public class ItemRawNBT extends ItemProperty<MapTag> {
             return;
         }
         BukkitImplDeprecations.oldNbtProperty.warn(mechanism.context);
-        CompoundTag customData;
+        CompoundTag oldNbtData;
         try {
-            customData = (CompoundTag) ItemRawNBT.convertObjectToNbt(value.identify(), mechanism.context, "(item)");
+            oldNbtData = (CompoundTag) ItemRawNBT.convertObjectToNbt(value.identify(), mechanism.context, "(item)");
         }
         catch (Exception ex) {
-            mechanism.echoError("Invalid custom data specified:");
+            mechanism.echoError("Invalid NBT data specified:");
             Debug.echoError(ex);
             return;
         }
-        if (customData == null) {
-            mechanism.echoError("Invalid custom data specified.");
+        if (oldNbtData == null) {
+            mechanism.echoError("Invalid NBT data specified.");
             return;
         }
-        setItemStack(NMSHandler.itemHelper.setPartialOldNbt(getItemStack(), customData));
+        setItemStack(NMSHandler.itemHelper.setPartialOldNbt(getItemStack(), oldNbtData));
     }
 
     public static void register() {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
@@ -369,7 +369,7 @@ public class ItemScriptHelper implements Listener {
         if (item == null) {
             return null;
         }
-        CompoundTag tag = NMSHandler.itemHelper.getNbtData(item);
+        CompoundTag tag = NMSHandler.itemHelper.getCustomData(item);
         String scriptName = tag.getString("DenizenItemScript");
         if (scriptName != null && !scriptName.equals("")) {
             return scriptName;
@@ -389,7 +389,7 @@ public class ItemScriptHelper implements Listener {
         if (item == null) {
             return null;
         }
-        CompoundTag tag = NMSHandler.itemHelper.getNbtData(item);
+        CompoundTag tag = NMSHandler.itemHelper.getCustomData(item);
         String scriptName = tag.getString("DenizenItemScript");
         if (scriptName != null && !scriptName.equals("")) {
             return item_scripts.get(scriptName);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/containers/core/ItemScriptHelper.java
@@ -370,6 +370,9 @@ public class ItemScriptHelper implements Listener {
             return null;
         }
         CompoundTag tag = NMSHandler.itemHelper.getCustomData(item);
+        if (tag == null) {
+            return null;
+        }
         String scriptName = tag.getString("DenizenItemScript");
         if (scriptName != null && !scriptName.equals("")) {
             return scriptName;
@@ -390,6 +393,9 @@ public class ItemScriptHelper implements Listener {
             return null;
         }
         CompoundTag tag = NMSHandler.itemHelper.getCustomData(item);
+        if (tag == null) {
+            return null;
+        }
         String scriptName = tag.getString("DenizenItemScript");
         if (scriptName != null && !scriptName.equals("")) {
             return item_scripts.get(scriptName);

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -232,6 +232,9 @@ public class BukkitImplDeprecations {
     // 2023-year-end commonality: #31
     public static Warning legacyAttributeProperties = new SlowWarning("legacyAttributeProperties", "The 'attribute' properties are deprecated in favor of the 'attribute_modifiers' properties which more fully implement the attribute system.");
 
+    // Added 2024/05/31
+    public static Warning oldNbtProperty = new SlowWarning("oldNbtProperty", "'ItemTag.raw_nbt' is deprecated in favor of 'ItemTag.custom_data', as item NBT was removed by Mojang in favor of item components.");
+
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -18,6 +18,7 @@ import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.common.collect.*;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+import com.mojang.serialization.Dynamic;
 import net.md_5.bungee.api.ChatColor;
 import net.minecraft.advancements.critereon.BlockPredicate;
 import net.minecraft.core.*;
@@ -25,10 +26,12 @@ import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.datafix.fixes.References;
 import net.minecraft.world.item.AdventureModePredicate;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -266,6 +269,21 @@ public class ItemHelperImpl extends ItemHelper {
             nmsItemStack.set(DataComponents.CUSTOM_DATA, CustomData.of(((CompoundTagImpl) data).toNMSTag()));
         }
         return CraftItemStack.asBukkitCopy(nmsItemStack);
+    }
+
+    public static final int DATA_VERSION_1_20_4 = 3700;
+
+    @Override
+    public ItemStack setPartialOldNbt(ItemStack item, CompoundTag oldTag) {
+        int currentDataVersion = CraftMagicNumbers.INSTANCE.getDataVersion();
+        net.minecraft.nbt.CompoundTag nmsOldTag = new net.minecraft.nbt.CompoundTag();
+        nmsOldTag.putString("id", item.getType().getKey().toString());
+        nmsOldTag.putByte("Count", (byte) item.getAmount());
+        nmsOldTag.put("tag", ((CompoundTagImpl) oldTag).toNMSTag());
+        net.minecraft.nbt.CompoundTag nmsUpdatedTag = (net.minecraft.nbt.CompoundTag) MinecraftServer.getServer().fixerUpper.update(References.ITEM_STACK, new Dynamic<>(NbtOps.INSTANCE, nmsOldTag), DATA_VERSION_1_20_4, currentDataVersion).getValue();
+        net.minecraft.nbt.CompoundTag nmsCurrentTag = (net.minecraft.nbt.CompoundTag) CraftItemStack.asNMSCopy(item).save(CraftRegistry.getMinecraftRegistry());
+        net.minecraft.nbt.CompoundTag nmsMergedTag = nmsCurrentTag.merge(nmsUpdatedTag);
+        return CraftItemStack.asBukkitCopy(net.minecraft.world.item.ItemStack.parse(CraftRegistry.getMinecraftRegistry(), nmsMergedTag).orElseThrow());
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -251,6 +251,24 @@ public class ItemHelperImpl extends ItemHelper {
     }
 
     @Override
+    public CompoundTag getCustomData(ItemStack item) {
+        CustomData customData = CraftItemStack.asNMSCopy(item).get(DataComponents.CUSTOM_DATA);
+        return customData != null ? CompoundTagImpl.fromNMSTag(customData.getUnsafe()) : null;
+    }
+
+    @Override
+    public ItemStack setCustomData(ItemStack item, CompoundTag data) {
+        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(item);
+        if (data == null) {
+            nmsItemStack.remove(DataComponents.CUSTOM_DATA);
+        }
+        else {
+            nmsItemStack.set(DataComponents.CUSTOM_DATA, CustomData.of(((CompoundTagImpl) data).toNMSTag()));
+        }
+        return CraftItemStack.asBukkitCopy(nmsItemStack);
+    }
+
+    @Override
     public CompoundTag getEntityData(ItemStack item) {
         CustomData entityData = CraftItemStack.asNMSCopy(item).get(DataComponents.ENTITY_DATA);
         return entityData != null ? CompoundTagImpl.fromNMSTag(entityData.getUnsafe()) : null;


### PR DESCRIPTION
## Additions

- `ItemHelper#get/setCustomData` - controls an item's `CUSTOM_DATA` component, with `get` returning the item's NBT on older versions.
- `ItemHelper#setPartialOldNbt` - sets pre-components NBT onto an item by running it through the DFU.
- `ItemTag.custom_data` property - manages an item's custom data, replacing `raw_nbt`.
- `oldNbtProperty` `SlowWarning` - for `ItemTag.raw_nbt` being deprecated in favor of `custom_data`.

## Changes

- `ItemTag.raw_nbt` has been updated to modern property format, and is now deprecated in favor of `custom_data` on 1.20+.
- `ItemScriptHelper#getItemScriptNameText/Container` now use the new `ItemHelper#getCustomData`.

> [!NOTE]
> `custom_data` currently removes Denizen data from the value (as it's persisted elsewhere), and adds it back before setting to avoid it getting removed.
> This seemed like the best way to impl it imo, as you can get/set the data as usual without the limitations `raw_nbt` had (e.g. not being able to remove keys), and matches how most properties work without risking Denizen data getting messed up, but lmk if you have any alternative ideas.

> [!NOTE]
> Clearing `custom_data` can probably be optimized a bit more then using the same denizen-key-adding setting custom data uses, but it's a niche enough use case to justify not getting into micro-optimzations (at least right now) imo.

> [!NOTE]
> `raw_nbt` is back-supported by running old values through the DFU - this is the best way I could find to not have old items being stored just break, which might not be perfect since it only gets partial NBT data, but seems to work well enough and is better than nothing.