### PR TITLE
`CustomNBT`: more 1.20.6 updates

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -54,7 +54,7 @@ public abstract class ItemHelper {
     }
 
     public ItemStack setCustomData(ItemStack item, CompoundTag data) { // TODO: once 1.20 is the minimum supported version, remove default impl
-        throw new UnsupportedOperationException();
+        return setNbtData(item, data);
     }
 
     public ItemStack setPartialOldNbt(ItemStack item, CompoundTag oldTag) {

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTag.java
@@ -85,6 +85,10 @@ public abstract class CompoundTag extends Tag {
         return new CompoundTagBuilder(new HashMap<>(value));
     }
 
+    public CompoundTag getCompound(String key) {
+        return value.get(key) instanceof CompoundTag compoundTag ? compoundTag : null;
+    }
+
     /**
      * Get a byte array named with the given key.
      * <p/>

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTagBuilder.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTagBuilder.java
@@ -210,6 +210,10 @@ public class CompoundTagBuilder {
         return new CompoundTagBuilder();
     }
 
+    public static CompoundTagBuilder create(CompoundTag tag) {
+        return tag == null ? new CompoundTagBuilder() : tag.createBuilder();
+    }
+
     private static void checkNotNull(Object object) {
         if (object == null) {
             throw new NullPointerException();

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.utilities.nbt;
 
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
+import com.denizenscript.denizen.nms.util.jnbt.CompoundTagBuilder;
 import com.denizenscript.denizen.nms.util.jnbt.JNBTListTag;
 import com.denizenscript.denizen.nms.util.jnbt.StringTag;
 import com.denizenscript.denizen.objects.properties.entity.EntityDisabledSlots.Action;
@@ -71,22 +72,14 @@ public class CustomNBT {
     }
 
     public static ItemStack addCustomNBT(ItemStack itemStack, String key, String value, String basekey) {
-        if (itemStack == null || itemStack.getType() == Material.AIR) {
+        if (itemStack == null || itemStack.getType().isAir()) {
             return null;
         }
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(itemStack);
-        CompoundTag denizenTag;
-        if (compoundTag.getValue().containsKey(basekey)) {
-            denizenTag = (CompoundTag) compoundTag.getValue().get(basekey);
-        }
-        else {
-            denizenTag = NMSHandler.instance.createCompoundTag(new HashMap<>());
-        }
-        // Add custom NBT
-        denizenTag = denizenTag.createBuilder().putString(CoreUtilities.toLowerCase(key), value).build();
-        compoundTag = compoundTag.createBuilder().put(basekey, denizenTag).build();
-        // Write tag back
-        return NMSHandler.itemHelper.setNbtData(itemStack, compoundTag);
+        CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
+        CompoundTagBuilder denizenDataBuilder = CompoundTagBuilder.create(customData != null ? (CompoundTag) customData.getValue().get(basekey) : null);
+        CompoundTag denizenData = denizenDataBuilder.putString(CoreUtilities.toLowerCase(key), value).build();
+        customData = CompoundTagBuilder.create(customData).put(basekey, denizenData).build();
+        return NMSHandler.itemHelper.setCustomData(itemStack, customData);
     }
 
     public static ItemStack clearNBT(ItemStack itemStack, String key) {
@@ -100,81 +93,70 @@ public class CustomNBT {
     }
 
     public static ItemStack removeCustomNBT(ItemStack itemStack, String key, String basekey) {
-        if (itemStack == null || itemStack.getType() == Material.AIR) {
+        if (itemStack == null || itemStack.getType().isAir()) {
             return null;
         }
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(itemStack);
-        CompoundTag denizenTag;
-        if (compoundTag.getValue().containsKey(basekey)) {
-            denizenTag = (CompoundTag) compoundTag.getValue().get(basekey);
-        }
-        else {
+        CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
+        if (customData == null) {
             return itemStack;
         }
-        // Remove custom NBT
-        denizenTag = denizenTag.createBuilder().remove(CoreUtilities.toLowerCase(key)).build();
-        if (denizenTag.getValue().isEmpty()) {
-            compoundTag = compoundTag.createBuilder().remove(basekey).build();
+        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        if (denizenData == null) {
+            return itemStack;
+        }
+        denizenData = denizenData.createBuilder().remove(CoreUtilities.toLowerCase(key)).build();
+        if (denizenData.isEmpty()) {
+            customData = customData.createBuilder().remove(basekey).build();
         }
         else {
-            compoundTag = compoundTag.createBuilder().put(basekey, denizenTag).build();
+            customData = customData.createBuilder().put(basekey, denizenData).build();
         }
-        // Write tag back
-        return NMSHandler.itemHelper.setNbtData(itemStack, compoundTag);
+        return NMSHandler.itemHelper.setCustomData(itemStack, customData.isEmpty() ? null : customData);
     }
 
     public static boolean hasCustomNBT(ItemStack itemStack, String key, String basekey) {
-        if (itemStack == null || itemStack.getType() == Material.AIR) {
+        if (itemStack == null || itemStack.getType().isAir()) {
             return false;
         }
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(itemStack);
-        CompoundTag denizenTag;
-        if (compoundTag.getValue().containsKey(basekey)) {
-            denizenTag = (CompoundTag) compoundTag.getValue().get(basekey);
-        }
-        else {
+        CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
+        if (customData == null) {
             return false;
         }
-        return denizenTag.getValue().containsKey(CoreUtilities.toLowerCase(key));
+        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        return denizenData != null && denizenData.containsKey(CoreUtilities.toLowerCase(key));
     }
 
     public static String getCustomNBT(ItemStack itemStack, String key, String basekey) {
-        if (itemStack == null || itemStack.getType() == Material.AIR || key == null) {
+        if (itemStack == null || itemStack.getType().isAir() || key == null) {
             return null;
         }
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(itemStack);
-        if (compoundTag.getValue().containsKey(basekey)) {
-            CompoundTag denizenTag = (CompoundTag) compoundTag.getValue().get(basekey);
-            String lowerKey = CoreUtilities.toLowerCase(key);
-            if (denizenTag.containsKey(lowerKey)) {
-                return denizenTag.getString(lowerKey);
-            }
+        CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
+        if (customData == null) {
+            return null;
         }
-        return null;
+        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        if (denizenData == null) {
+            return null;
+        }
+        String lowerKey = CoreUtilities.toLowerCase(key);
+        return denizenData.containsKey(lowerKey) ? denizenData.getString(lowerKey) : null;
     }
 
     public static List<String> listNBT(ItemStack itemStack, String basekey) {
         List<String> nbt = new ArrayList<>();
-        if (itemStack == null || itemStack.getType() == Material.AIR) {
+        if (itemStack == null || itemStack.getType().isAir()) {
             return nbt;
         }
-        CompoundTag compoundTag = NMSHandler.itemHelper.getNbtData(itemStack);
-        if (compoundTag.getValue().containsKey(basekey)) {
-            CompoundTag denizenTag = (CompoundTag) compoundTag.getValue().get(basekey);
-            nbt.addAll(denizenTag.getValue().keySet());
+        CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
+        if (customData == null) {
+            return nbt;
         }
+        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        if (denizenData == null) {
+            return nbt;
+        }
+        nbt.addAll(denizenData.getValue().keySet());
         return nbt;
-    }
-
-    public static void addCustomNBT(Entity entity, String key, String value) {
-        if (entity == null) {
-            return;
-        }
-        CompoundTag compoundTag = NMSHandler.entityHelper.getNbtData(entity);
-        // Add custom NBT
-        compoundTag = compoundTag.createBuilder().putString(key, value).build();
-        // Write tag back
-        NMSHandler.entityHelper.setNbtData(entity, compoundTag);
     }
 
     public static void addCustomNBT(Entity entity, String key, int value) {
@@ -197,24 +179,6 @@ public class CustomNBT {
         compoundTag = compoundTag.createBuilder().remove(key).build();
         // Write tag back
         NMSHandler.entityHelper.setNbtData(entity, compoundTag);
-    }
-
-    public static boolean hasCustomNBT(Entity entity, String key) {
-        if (entity == null) {
-            return false;
-        }
-        CompoundTag compoundTag = NMSHandler.entityHelper.getNbtData(entity);
-        // Check for key
-        return compoundTag.getValue().containsKey(key);
-    }
-
-    public static String getCustomNBT(Entity entity, String key) {
-        if (entity == null) {
-            return null;
-        }
-        CompoundTag compoundTag = NMSHandler.entityHelper.getNbtData(entity);
-        // Return contents of the tag
-        return compoundTag.getString(key);
     }
 
     public static int getCustomIntNBT(Entity entity, String key) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
@@ -76,7 +76,7 @@ public class CustomNBT {
             return null;
         }
         CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
-        CompoundTagBuilder denizenDataBuilder = CompoundTagBuilder.create(customData != null ? (CompoundTag) customData.getValue().get(basekey) : null);
+        CompoundTagBuilder denizenDataBuilder = CompoundTagBuilder.create(customData != null ? customData.getCompound(basekey) : null);
         CompoundTag denizenData = denizenDataBuilder.putString(CoreUtilities.toLowerCase(key), value).build();
         customData = CompoundTagBuilder.create(customData).put(basekey, denizenData).build();
         return NMSHandler.itemHelper.setCustomData(itemStack, customData);
@@ -100,7 +100,7 @@ public class CustomNBT {
         if (customData == null) {
             return itemStack;
         }
-        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        CompoundTag denizenData = customData.getCompound(basekey);
         if (denizenData == null) {
             return itemStack;
         }
@@ -122,7 +122,7 @@ public class CustomNBT {
         if (customData == null) {
             return false;
         }
-        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        CompoundTag denizenData = customData.getCompound(basekey);
         return denizenData != null && denizenData.containsKey(CoreUtilities.toLowerCase(key));
     }
 
@@ -134,7 +134,7 @@ public class CustomNBT {
         if (customData == null) {
             return null;
         }
-        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        CompoundTag denizenData = customData.getCompound(basekey);
         if (denizenData == null) {
             return null;
         }
@@ -151,7 +151,7 @@ public class CustomNBT {
         if (customData == null) {
             return nbt;
         }
-        CompoundTag denizenData = (CompoundTag) customData.getValue().get(basekey);
+        CompoundTag denizenData = customData.getCompound(basekey);
         if (denizenData == null) {
             return nbt;
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
@@ -72,7 +72,7 @@ public class CustomNBT {
     }
 
     public static ItemStack addCustomNBT(ItemStack itemStack, String key, String value, String basekey) {
-        if (itemStack == null || itemStack.getType().isAir()) {
+        if (itemStack == null || itemStack.getType() == Material.AIR) {
             return null;
         }
         CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
@@ -93,7 +93,7 @@ public class CustomNBT {
     }
 
     public static ItemStack removeCustomNBT(ItemStack itemStack, String key, String basekey) {
-        if (itemStack == null || itemStack.getType().isAir()) {
+        if (itemStack == null || itemStack.getType() == Material.AIR) {
             return null;
         }
         CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
@@ -115,7 +115,7 @@ public class CustomNBT {
     }
 
     public static boolean hasCustomNBT(ItemStack itemStack, String key, String basekey) {
-        if (itemStack == null || itemStack.getType().isAir()) {
+        if (itemStack == null || itemStack.getType() == Material.AIR) {
             return false;
         }
         CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
@@ -127,7 +127,7 @@ public class CustomNBT {
     }
 
     public static String getCustomNBT(ItemStack itemStack, String key, String basekey) {
-        if (itemStack == null || itemStack.getType().isAir() || key == null) {
+        if (itemStack == null || itemStack.getType() == Material.AIR || key == null) {
             return null;
         }
         CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);
@@ -144,7 +144,7 @@ public class CustomNBT {
 
     public static List<String> listNBT(ItemStack itemStack, String basekey) {
         List<String> nbt = new ArrayList<>();
-        if (itemStack == null || itemStack.getType().isAir()) {
+        if (itemStack == null || itemStack.getType() == Material.AIR) {
             return nbt;
         }
         CompoundTag customData = NMSHandler.itemHelper.getCustomData(itemStack);


### PR DESCRIPTION
## Changes

- `ItemHelper#setCustomData` now redirects to `setNbtData` on <1.19.
- `CustomNBT`'s custom data related methods now use `ItemHelper#get/setCustomData`.
- Cleaned up several `CustomNBT` methods (replacing `containsKey` & `get` with `get` and a `null` check, the new util methods, etc.).

## Additions

- `CompoundTag#getCompound` - util to get a `CompoundTag` by key.
- `CompoundTagBuilder#create(CompoundTag)` - creates a builder from a `CompoundTag`, or a new builder if it's `null`.

## Removals

- `CustomNBT#hasCustomNBT` & `getCustomNBT` (`Entity` variants) were removed, as they don't seem to be used anymore.