### PR TITLE
Fix vehicle events

### DIFF
--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -13,11 +13,6 @@
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
-        <!--TODO: 1.20.6: Paper 1.20.6 uses a snapshot build of adventure currently, can remove this once that's no longer the case-->
-        <repository>
-            <id>sonatype-oss-snapshots1</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
     </repositories>
 
     <dependencies>

--- a/plugin/src/main/java/com/denizenscript/denizen/events/BukkitScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/BukkitScriptEvent.java
@@ -559,10 +559,10 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "reflect_event": return currentEvent == null ? null : new JavaReflectedObjectTag(currentEvent);
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "reflect_event" -> currentEvent == null ? null : new JavaReflectedObjectTag(currentEvent);
+            default -> super.getContext(name);
+        };
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -113,9 +113,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(EntityDespawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityDropsItemScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityEntersPortalScriptEvent.class);
-        ScriptEvent.registerScriptEvent(EntityEntersVehicleScriptEvent.class);
+        ScriptEvent.registerScriptEvent(NMSHandler.entityHelper.getEntersVehicleEventImpl());
         ScriptEvent.registerScriptEvent(EntityExitsPortalScriptEvent.class);
-        ScriptEvent.registerScriptEvent(EntityExitsVehicleScriptEvent.class);
+        ScriptEvent.registerScriptEvent(NMSHandler.entityHelper.getExistsVehicleEventImpl());
         ScriptEvent.registerScriptEvent(EntityExplodesScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExplosionPrimesScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityFoodLevelChangeScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -115,7 +115,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(EntityEntersPortalScriptEvent.class);
         ScriptEvent.registerScriptEvent(NMSHandler.entityHelper.getEntersVehicleEventImpl());
         ScriptEvent.registerScriptEvent(EntityExitsPortalScriptEvent.class);
-        ScriptEvent.registerScriptEvent(NMSHandler.entityHelper.getExistsVehicleEventImpl());
+        ScriptEvent.registerScriptEvent(NMSHandler.entityHelper.getExitsVehicleEventImpl());
         ScriptEvent.registerScriptEvent(EntityExplodesScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityExplosionPrimesScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityFoodLevelChangeScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityEntersVehicleScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityEntersVehicleScriptEvent.java
@@ -90,7 +90,7 @@ public class EntityEntersVehicleScriptEvent extends BukkitScriptEvent implements
 
     @Override
     public String getName() { // TODO: once 1.20 is the minimum supported version, remove
-        return "EntityEntersVehicleScriptEvent";
+        return "EntityEntersVehicle";
     }
 
     public void fire(EntityEvent event, Entity vehicle) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityEntersVehicleScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityEntersVehicleScriptEvent.java
@@ -1,13 +1,13 @@
 package com.denizenscript.denizen.events.entity;
 
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import org.bukkit.event.EventHandler;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.Listener;
-import org.spigotmc.event.entity.EntityMountEvent;
+import org.bukkit.event.entity.EntityEvent;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -43,8 +43,6 @@ public class EntityEntersVehicleScriptEvent extends BukkitScriptEvent implements
 
     public EntityTag vehicle;
     public EntityTag entity;
-    // TODO: 1.20.6: EntityMountEvent changed packages, might need to register in version-specific modules? or reflection?
-    public EntityMountEvent event;
 
     public static HashSet<String> notRelevantEnterables = new HashSet<>(Arrays.asList("notable", "cuboid", "biome", "bed", "portal"));
 
@@ -90,11 +88,9 @@ public class EntityEntersVehicleScriptEvent extends BukkitScriptEvent implements
         return super.getContext(name);
     }
 
-    @EventHandler
-    public void onEntityEntersVehicle(EntityMountEvent event) {
-        vehicle = new EntityTag(event.getMount());
-        entity = new EntityTag(event.getEntity());
-        this.event = event;
+    public void fire(EntityEvent event, Entity vehicle) {
+        this.entity = new EntityTag(event.getEntity());
+        this.vehicle = new EntityTag(vehicle);
         fire(event);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityEntersVehicleScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityEntersVehicleScriptEvent.java
@@ -88,6 +88,11 @@ public class EntityEntersVehicleScriptEvent extends BukkitScriptEvent implements
         return super.getContext(name);
     }
 
+    @Override
+    public String getName() { // TODO: once 1.20 is the minimum supported version, remove
+        return "EntityEntersVehicleScriptEvent";
+    }
+
     public void fire(EntityEvent event, Entity vehicle) {
         this.entity = new EntityTag(event.getEntity());
         this.vehicle = new EntityTag(vehicle);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExitsVehicleScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExitsVehicleScriptEvent.java
@@ -1,13 +1,13 @@
 package com.denizenscript.denizen.events.entity;
 
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import org.bukkit.event.EventHandler;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.Listener;
-import org.spigotmc.event.entity.EntityDismountEvent;
+import org.bukkit.event.entity.EntityEvent;
 
 public class EntityExitsVehicleScriptEvent extends BukkitScriptEvent implements Listener {
 
@@ -40,8 +40,6 @@ public class EntityExitsVehicleScriptEvent extends BukkitScriptEvent implements 
 
     public EntityTag vehicle;
     public EntityTag entity;
-    // TODO: 1.20.6: EntityDismountEvent changed packages, might need to register in version-specific modules? or reflection?
-    public EntityDismountEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -74,11 +72,9 @@ public class EntityExitsVehicleScriptEvent extends BukkitScriptEvent implements 
         return super.getContext(name);
     }
 
-    @EventHandler
-    public void onEntityExitsVehicle(EntityDismountEvent event) {
-        vehicle = new EntityTag(event.getDismounted());
-        entity = new EntityTag(event.getEntity());
-        this.event = event;
+    public void fire(EntityEvent event, Entity vehicle) {
+        this.entity = new EntityTag(event.getEntity());
+        this.vehicle = new EntityTag(vehicle);
         fire(event);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExitsVehicleScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExitsVehicleScriptEvent.java
@@ -74,7 +74,7 @@ public class EntityExitsVehicleScriptEvent extends BukkitScriptEvent implements 
 
     @Override
     public String getName() { // TODO: once 1.20 is the minimum supported version, remove
-        return "EntityExitsVehicleScriptEvent";
+        return "EntityExitsVehicle";
     }
 
     public void fire(EntityEvent event, Entity vehicle) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExitsVehicleScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExitsVehicleScriptEvent.java
@@ -72,6 +72,11 @@ public class EntityExitsVehicleScriptEvent extends BukkitScriptEvent implements 
         return super.getContext(name);
     }
 
+    @Override
+    public String getName() { // TODO: once 1.20 is the minimum supported version, remove
+        return "EntityExitsVehicleScriptEvent";
+    }
+
     public void fire(EntityEvent event, Entity vehicle) {
         this.entity = new EntityTag(event.getEntity());
         this.vehicle = new EntityTag(vehicle);

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.nms.interfaces;
 
+import com.denizenscript.denizen.events.entity.EntityEntersVehicleScriptEvent;
+import com.denizenscript.denizen.events.entity.EntityExitsVehicleScriptEvent;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -13,9 +15,8 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.*;
-import org.bukkit.event.entity.EntityDamageByBlockEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.*;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.util.BoundingBox;
@@ -475,5 +476,27 @@ public abstract class EntityHelper {
 
     public void modifyRawNBT(Entity entity, CompoundTag tag) {
         throw new UnsupportedOperationException();
+    }
+
+    public static class EntityEntersVehicleScriptEventImpl extends EntityEntersVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityMountEvent event) {
+            fire(event, event.getMount());
+        }
+    }
+
+    public Class<? extends EntityEntersVehicleScriptEvent> getEntersVehicleEventImpl() { // TODO: once 1.20 is the minimum supported version, implement in the ScriptEvent class as usual
+        return EntityEntersVehicleScriptEventImpl.class;
+    }
+
+    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityDismountEvent event) {
+            fire(event, event.getDismounted());
+        }
+    }
+
+    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() { // TODO: once 1.20 is the minimum supported version, implement in the ScriptEvent class as usual
+        return EntityExistsVehicleScriptEventImpl.class;
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -489,14 +489,14 @@ public abstract class EntityHelper {
         return EntityEntersVehicleScriptEventImpl.class;
     }
 
-    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+    public static class EntityExitsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
         @EventHandler
         public void onEntityMount(EntityDismountEvent event) {
             fire(event, event.getDismounted());
         }
     }
 
-    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() { // TODO: once 1.20 is the minimum supported version, implement in the ScriptEvent class as usual
-        return EntityExistsVehicleScriptEventImpl.class;
+    public Class<? extends EntityExitsVehicleScriptEvent> getExitsVehicleEventImpl() { // TODO: once 1.20 is the minimum supported version, implement in the ScriptEvent class as usual
+        return EntityExitsVehicleScriptEventImpl.class;
     }
 }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -1,6 +1,8 @@
 package com.denizenscript.denizen.nms.v1_17.helpers;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.events.entity.EntityEntersVehicleScriptEvent;
+import com.denizenscript.denizen.events.entity.EntityExitsVehicleScriptEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.interfaces.EntityHelper;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
@@ -52,11 +54,14 @@ import org.bukkit.craftbukkit.v1_17_R1.entity.*;
 import org.bukkit.craftbukkit.v1_17_R1.event.CraftEventFactory;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
@@ -699,5 +704,28 @@ public class EntityHelperImpl extends EntityHelper {
     public void openHorseInventory(Player player, AbstractHorse horse) {
         net.minecraft.world.entity.animal.horse.AbstractHorse nmsHorse = ((CraftAbstractHorse) horse).getHandle();
         ((CraftPlayer) player).getHandle().openHorseInventory(nmsHorse, nmsHorse.inventory);
+    }
+
+    public static class EntityEntersVehicleScriptEventImpl extends EntityEntersVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityMountEvent event) {
+            fire(event, event.getMount());
+        }
+    }
+
+    @Override
+    public Class<? extends EntityEntersVehicleScriptEvent> getEntersVehicleEventImpl() {
+        return EntityEntersVehicleScriptEventImpl.class;
+    }
+
+    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityDismountEvent event) {
+            fire(event, event.getDismounted());
+        }
+    }
+
+    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() {
+        return EntityExistsVehicleScriptEventImpl.class;
     }
 }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/EntityHelperImpl.java
@@ -718,14 +718,14 @@ public class EntityHelperImpl extends EntityHelper {
         return EntityEntersVehicleScriptEventImpl.class;
     }
 
-    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+    public static class EntityExitsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
         @EventHandler
         public void onEntityMount(EntityDismountEvent event) {
             fire(event, event.getDismounted());
         }
     }
 
-    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() {
-        return EntityExistsVehicleScriptEventImpl.class;
+    public Class<? extends EntityExitsVehicleScriptEvent> getExitsVehicleEventImpl() {
+        return EntityExitsVehicleScriptEventImpl.class;
     }
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -795,14 +795,14 @@ public class EntityHelperImpl extends EntityHelper {
         return EntityEntersVehicleScriptEventImpl.class;
     }
 
-    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+    public static class EntityExitsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
         @EventHandler
         public void onEntityMount(EntityDismountEvent event) {
             fire(event, event.getDismounted());
         }
     }
 
-    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() {
-        return EntityExistsVehicleScriptEventImpl.class;
+    public Class<? extends EntityExitsVehicleScriptEvent> getExitsVehicleEventImpl() {
+        return EntityExitsVehicleScriptEventImpl.class;
     }
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/EntityHelperImpl.java
@@ -1,6 +1,8 @@
 package com.denizenscript.denizen.nms.v1_18.helpers;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.events.entity.EntityEntersVehicleScriptEvent;
+import com.denizenscript.denizen.events.entity.EntityExitsVehicleScriptEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.interfaces.EntityHelper;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
@@ -59,11 +61,14 @@ import org.bukkit.craftbukkit.v1_18_R2.entity.*;
 import org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
@@ -776,5 +781,28 @@ public class EntityHelperImpl extends EntityHelper {
     public void openHorseInventory(Player player, AbstractHorse horse) {
         net.minecraft.world.entity.animal.horse.AbstractHorse nmsHorse = ((CraftAbstractHorse) horse).getHandle();
         ((CraftPlayer) player).getHandle().openHorseInventory(nmsHorse, nmsHorse.inventory);
+    }
+
+    public static class EntityEntersVehicleScriptEventImpl extends EntityEntersVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityMountEvent event) {
+            fire(event, event.getMount());
+        }
+    }
+
+    @Override
+    public Class<? extends EntityEntersVehicleScriptEvent> getEntersVehicleEventImpl() {
+        return EntityEntersVehicleScriptEventImpl.class;
+    }
+
+    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityDismountEvent event) {
+            fire(event, event.getDismounted());
+        }
+    }
+
+    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() {
+        return EntityExistsVehicleScriptEventImpl.class;
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -1,6 +1,8 @@
 package com.denizenscript.denizen.nms.v1_19.helpers;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.events.entity.EntityEntersVehicleScriptEvent;
+import com.denizenscript.denizen.events.entity.EntityExitsVehicleScriptEvent;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.interfaces.EntityHelper;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
@@ -68,11 +70,14 @@ import org.bukkit.craftbukkit.v1_19_R3.entity.*;
 import org.bukkit.craftbukkit.v1_19_R3.event.CraftEventFactory;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
@@ -829,5 +834,28 @@ public class EntityHelperImpl extends EntityHelper {
     public void openHorseInventory(Player player, AbstractHorse horse) {
         net.minecraft.world.entity.animal.horse.AbstractHorse nmsHorse = ((CraftAbstractHorse) horse).getHandle();
         ((CraftPlayer) player).getHandle().openHorseInventory(nmsHorse, nmsHorse.inventory);
+    }
+
+    public static class EntityEntersVehicleScriptEventImpl extends EntityEntersVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityMountEvent event) {
+            fire(event, event.getMount());
+        }
+    }
+
+    @Override
+    public Class<? extends EntityEntersVehicleScriptEvent> getEntersVehicleEventImpl() {
+        return EntityEntersVehicleScriptEventImpl.class;
+    }
+
+    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+        @EventHandler
+        public void onEntityMount(EntityDismountEvent event) {
+            fire(event, event.getDismounted());
+        }
+    }
+
+    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() {
+        return EntityExistsVehicleScriptEventImpl.class;
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/EntityHelperImpl.java
@@ -848,14 +848,14 @@ public class EntityHelperImpl extends EntityHelper {
         return EntityEntersVehicleScriptEventImpl.class;
     }
 
-    public static class EntityExistsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
+    public static class EntityExitsVehicleScriptEventImpl extends EntityExitsVehicleScriptEvent {
         @EventHandler
         public void onEntityMount(EntityDismountEvent event) {
             fire(event, event.getDismounted());
         }
     }
 
-    public Class<? extends EntityExitsVehicleScriptEvent> getExistsVehicleEventImpl() {
-        return EntityExistsVehicleScriptEventImpl.class;
+    public Class<? extends EntityExitsVehicleScriptEvent> getExitsVehicleEventImpl() {
+        return EntityExitsVehicleScriptEventImpl.class;
     }
 }


### PR DESCRIPTION
## Removals

- Removed the `sonatype` snapshots repo from the Paper module as adventure is properly released now.

## Changes

- Updated the default `BukkitScriptEvent#getContext` impl to use modern switch expressions.
- `ScriptEventRegistrty` now uses the new `EntityHelper#getEnters/ExistsVehicleEventImpl` methods.
- `EntityEnters/ExistsVehicleScriptEvent` now have a `fire` method for their impls instead of a listener, and don't store the event anymore (doesn't look like it was used either way?).

## Additions

- `EntityHelper#getEnters/ExistsVehicleEventImpl` - to get the version-specific listener impls for these events.
- `EntityHelper$EntityEnters/ExistsVehicleScriptEventImpl` - default impls with the 1.20+ API.
- `EntityEnters/ExistsVehicleScriptEvent#getName` like in the good old days™️ - didn't want to adjust the whole `notNameParts` logic for a temporary patch, so just implemented these manually for now.