### PR TITLE
Fix `PacketHelper#resetEquipment` on 1.20.6+

### DIFF
--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -25,6 +25,7 @@ import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -376,5 +377,10 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     public String getClientBrand(Player player) {
         String clientBrand = player.getClientBrandName();
         return clientBrand != null ? clientBrand : "unknown";
+    }
+
+    @Override
+    public boolean canUseEquipmentSlot(LivingEntity entity, EquipmentSlot slot) {
+        return NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) ? entity.canUseEquipmentSlot(slot) : super.canUseEquipmentSlot(entity, slot);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.nms.interfaces;
 
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.scripts.commands.entity.TeleportCommand;
+import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.maps.MapImage;
 import com.denizenscript.denizencore.objects.core.ColorTag;
 import org.bukkit.Bukkit;
@@ -93,7 +94,9 @@ public interface PacketHelper {
         EntityEquipment equipment = entity.getEquipment();
         Map<EquipmentSlot, ItemStack> equipmentMap = new EnumMap<>(EquipmentSlot.class);
         for (EquipmentSlot slot : EquipmentSlot.values()) {
-            equipmentMap.put(slot, equipment.getItem(slot));
+            if (PaperAPITools.instance.canUseEquipmentSlot(entity, slot)) {
+                equipmentMap.put(slot, equipment.getItem(slot));
+            }
         }
         player.sendEquipmentChange(entity, equipmentMap);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -12,6 +12,7 @@ import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -211,5 +212,9 @@ public class PaperAPITools {
     public String getClientBrand(Player player) {
         NetworkInterceptHelper.enable();
         return NMSHandler.playerHelper.getClientBrand(player);
+    }
+
+    public boolean canUseEquipmentSlot(LivingEntity entity, EquipmentSlot slot) {
+        return true;
     }
 }


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1254663551726129215).

## Changes

- Bumped Paper API dep to 1.21.
- `PacketHelper#resetEquipment` (default impl) now uses the new `PaperAPITools#canUseEquipmentSlot`.

## Additions

- `PaperAPITools#canUseEquipmentSlot(LivingEntity, EquipmentSlot)` - checks whether an equipment slot is valid for an entity.