### PR TITLE
Fix `ItemTag.base_color` on 1.20.6+

### DIFF
--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -6,8 +6,10 @@ import com.denizenscript.denizen.nms.util.jnbt.IntArrayTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
+import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.block.Banner;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -15,6 +17,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.map.MapView;
 
 import java.util.List;
@@ -141,5 +144,23 @@ public abstract class ItemHelper {
 
     public int getFoodPoints(Material itemType) {
         throw new UnsupportedOperationException();
+    }
+
+    public DyeColor getShieldColor(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
+        BlockStateMeta stateMeta = (BlockStateMeta) item.getItemMeta();
+        return stateMeta.hasBlockState() ? ((Banner) stateMeta.getBlockState()).getBaseColor() : null;
+    }
+
+    public ItemStack setShieldColor(ItemStack item, DyeColor color) { // TODO: once 1.20 is the minimum supported version, remove default impl
+        if (color == null) {
+            CompoundTag noStateNbt = getNbtData(item).createBuilder().remove("BlockEntityTag").build();
+            return setNbtData(item, noStateNbt);
+        }
+        BlockStateMeta stateMeta = (BlockStateMeta) item.getItemMeta();
+        Banner banner = (Banner) stateMeta.getBlockState();
+        banner.setBaseColor(color);
+        stateMeta.setBlockState(banner);
+        item.setItemMeta(stateMeta);
+        return item;
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBaseColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBaseColor.java
@@ -32,10 +32,10 @@ public class ItemBaseColor extends ItemProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (mechanism.hasValue() && !mechanism.requireEnum(DyeColor.class)) {
+        if (value != null && !mechanism.requireEnum(DyeColor.class)) {
             return;
         }
-        setItemStack(NMSHandler.itemHelper.setShieldColor(getItemStack(), mechanism.hasValue() ? value.asEnum(DyeColor.class) : null));
+        setItemStack(NMSHandler.itemHelper.setShieldColor(getItemStack(), value != null ? value.asEnum(DyeColor.class) : null));
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBaseColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBaseColor.java
@@ -1,18 +1,11 @@
 package com.denizenscript.denizen.objects.properties.item;
 
 import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.core.MapTag;
-import com.denizenscript.denizencore.tags.TagContext;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
-import org.bukkit.block.Banner;
-import org.bukkit.inventory.meta.BannerMeta;
-import org.bukkit.inventory.meta.BlockStateMeta;
-import org.bukkit.inventory.meta.ItemMeta;
 
 public class ItemBaseColor extends ItemProperty<ElementTag> {
 
@@ -33,16 +26,16 @@ public class ItemBaseColor extends ItemProperty<ElementTag> {
 
     @Override
     public ElementTag getPropertyValue() {
-        DyeColor baseColor = getBaseColor();
-        if (baseColor != null) {
-            return new ElementTag(baseColor.name());
-        }
-        return null;
+        DyeColor color = NMSHandler.itemHelper.getShieldColor(getItemStack());
+        return color != null ? new ElementTag(color) : null;
     }
 
     @Override
-    public void setPropertyValue(ElementTag val, Mechanism mechanism) {
-        setBaseColor(mechanism.hasValue() ? val.asEnum(DyeColor.class) : null, mechanism.context);
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (mechanism.hasValue() && !mechanism.requireEnum(DyeColor.class)) {
+            return;
+        }
+        setItemStack(NMSHandler.itemHelper.setShieldColor(getItemStack(), mechanism.hasValue() ? value.asEnum(DyeColor.class) : null));
     }
 
     @Override
@@ -50,47 +43,7 @@ public class ItemBaseColor extends ItemProperty<ElementTag> {
         return "base_color";
     }
 
-    public DyeColor getBaseColor() {
-        ItemMeta itemMeta = getItemMeta();
-        if (itemMeta instanceof BlockStateMeta) {
-            DyeColor color = ((Banner) ((BlockStateMeta) itemMeta).getBlockState()).getBaseColor();
-            if (color == DyeColor.WHITE && getMaterial() == Material.SHIELD) { // Hack to avoid blank shields misdisplaying as white
-                if (new ItemRawNBT(object).getFullNBTMap().getObject("BlockEntityTag") == null) {
-                    return null;
-                }
-            }
-            return color;
-        }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-            // TODO: 1.20.6: Banner color has been part of the item type for a while, and Spigot removed this API
-            return ((BannerMeta) itemMeta).getBaseColor();
-        }
-        return null;
-    }
-
-    public void setBaseColor(DyeColor color, TagContext context) {
-        if (color == null && getMaterial() == Material.SHIELD) {
-            ItemRawNBT property = new ItemRawNBT(object);
-            MapTag nbt = property.getFullNBTMap();
-            nbt.putObject("BlockEntityTag", null);
-            property.setFullNBT(object, nbt, context, false);
-            return;
-        }
-        ItemMeta itemMeta = getItemMeta();
-        if (itemMeta instanceof BlockStateMeta) {
-            Banner banner = (Banner) ((BlockStateMeta) itemMeta).getBlockState();
-            banner.setBaseColor(color);
-            banner.update();
-            ((BlockStateMeta) itemMeta).setBlockState(banner);
-        }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-            // TODO: 1.20.6: Banner color has been part of the item type for a while, and Spigot removed this API
-            ((BannerMeta) itemMeta).setBaseColor(color);
-        }
-        setItemMeta(itemMeta);
-    }
-
     public static void register() {
-        autoRegister("base_color", ItemBaseColor.class, ElementTag.class, false);
+        autoRegisterNullable("base_color", ItemBaseColor.class, ElementTag.class, false);
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/ItemHelperImpl.java
@@ -53,6 +53,7 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.saveddata.maps.MapId;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
@@ -607,5 +608,23 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public int getFoodPoints(Material itemType) {
         return CraftMagicNumbers.getItem(itemType).components().get(DataComponents.FOOD).nutrition();
+    }
+
+    @Override
+    public DyeColor getShieldColor(ItemStack item) {
+        net.minecraft.world.item.DyeColor nmsColor = CraftItemStack.asNMSCopy(item).get(DataComponents.BASE_COLOR);
+        return nmsColor != null ? DyeColor.getByWoolData((byte) nmsColor.getId()) : null;
+    }
+
+    @Override
+    public ItemStack setShieldColor(ItemStack item, DyeColor color) {
+        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(item);
+        if (color != null) {
+            nmsItemStack.set(DataComponents.BASE_COLOR, net.minecraft.world.item.DyeColor.byId(color.getWoolData()));
+        }
+        else {
+            nmsItemStack.remove(DataComponents.BASE_COLOR);
+        }
+        return CraftItemStack.asBukkitCopy(nmsItemStack);
     }
 }

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/ItemHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/ItemHelperImpl.java
@@ -53,6 +53,7 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.saveddata.maps.MapId;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
@@ -607,5 +608,23 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public int getFoodPoints(Material itemType) {
         return CraftMagicNumbers.getItem(itemType).components().get(DataComponents.FOOD).nutrition();
+    }
+
+    @Override
+    public DyeColor getShieldColor(ItemStack item) {
+        net.minecraft.world.item.DyeColor nmsColor = CraftItemStack.asNMSCopy(item).get(DataComponents.BASE_COLOR);
+        return nmsColor != null ? DyeColor.getByWoolData((byte) nmsColor.getId()) : null;
+    }
+
+    @Override
+    public ItemStack setShieldColor(ItemStack item, DyeColor color) {
+        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(item);
+        if (color != null) {
+            nmsItemStack.set(DataComponents.BASE_COLOR, net.minecraft.world.item.DyeColor.byId(color.getWoolData()));
+        }
+        else {
+            nmsItemStack.remove(DataComponents.BASE_COLOR);
+        }
+        return CraftItemStack.asBukkitCopy(nmsItemStack);
     }
 }


### PR DESCRIPTION
## Changes

- Bumped API versions to 1.21
- `ItemBaseColor` now uses the new `ItemHelper#get/setShieldColor`.
- `ItemBaseColor` now uses `autoRegisterNullable`, to allow removing a base color.

## Additions

- `ItemHelper#get/setShieldColor` - for controlling a shield item's base color.

> [!NOTE]
> Decided to just go with NMS, as Spigot's API for this is pretty broken currently - can always go back to the API if/when Spigot fixes it, but would be nice to bump the API version already