### PR TITLE
Interfaceification fixes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/VillagerChangesProfessionScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/VillagerChangesProfessionScriptEvent.java
@@ -57,6 +57,7 @@ public class VillagerChangesProfessionScriptEvent extends BukkitScriptEvent impl
 
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        // TODO This technically has registries on all supported versions
         Villager.Profession newProfession = LegacyNamingHelper.convert(Villager.Profession.class, determinationObj.toString());
         if (newProfession != null) {
             event.setProfession(newProfession);
@@ -73,7 +74,6 @@ public class VillagerChangesProfessionScriptEvent extends BukkitScriptEvent impl
             case "reason":
                 return new ElementTag(event.getReason());
             case "profession":
-                // TODO: once 1.21 is the minimum supported version, use proper registry-based logic
                 return new ElementTag(String.valueOf(event.getProfession()), true);
         }
         return super.getContext(name);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/VillagerChangesProfessionScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/VillagerChangesProfessionScriptEvent.java
@@ -71,9 +71,10 @@ public class VillagerChangesProfessionScriptEvent extends BukkitScriptEvent impl
             case "entity":
                 return entity;
             case "reason":
-                return new ElementTag(event.getReason().toString());
+                return new ElementTag(event.getReason());
             case "profession":
-                return new ElementTag(event.getProfession().toString());
+                // TODO: once 1.21 is the minimum supported version, use proper registry-based logic
+                return new ElementTag(String.valueOf(event.getProfession()), true);
         }
         return super.getContext(name);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/VillagerChangesProfessionScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/VillagerChangesProfessionScriptEvent.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.events.entity;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.LegacyNamingHelper;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import org.bukkit.entity.Villager;
@@ -56,8 +57,8 @@ public class VillagerChangesProfessionScriptEvent extends BukkitScriptEvent impl
 
     @Override
     public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (exactMatchesEnum(determinationObj.toString(), Villager.Profession.values())) {
-            Villager.Profession newProfession = Villager.Profession.valueOf(determinationObj.toString().toUpperCase());
+        Villager.Profession newProfession = LegacyNamingHelper.convert(Villager.Profession.class, determinationObj.toString());
+        if (newProfession != null) {
             event.setProfession(newProfession);
             return true;
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -268,7 +268,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
 
     // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
     @SuppressWarnings({"unchecked", "DataFlowIssue"})
-    public static ListTag listForEnum(Class<?> clazz) {
+    public static ListTag listTypes(Class<?> clazz) {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && Keyed.class.isAssignableFrom(clazz)) {
             return Utilities.registryKeys(Bukkit.getRegistry((Class<? extends Keyed>) clazz));
         }
@@ -281,34 +281,34 @@ public class EntityColor extends EntityProperty<ElementTag> {
             return MultiVersionHelper1_19.getAllowedColors(type);
         }
         if (type == MOOSHROOM_ENTITY_TYPE) {
-            return listForEnum(MushroomCow.Variant.class);
+            return listTypes(MushroomCow.Variant.class);
         }
         return switch (type) {
             case HORSE -> {
-                ListTag horseColors = listForEnum(Horse.Color.class);
-                horseColors.addAll(listForEnum(Horse.Style.class));
+                ListTag horseColors = listTypes(Horse.Color.class);
+                horseColors.addAll(listTypes(Horse.Style.class));
                 yield horseColors;
             }
-            case SHEEP, WOLF, SHULKER -> listForEnum(DyeColor.class);
-            case RABBIT -> listForEnum(Rabbit.Type.class);
-            case LLAMA, TRADER_LLAMA -> listForEnum(Llama.Color.class);
-            case PARROT -> listForEnum(Parrot.Variant.class);
+            case SHEEP, WOLF, SHULKER -> listTypes(DyeColor.class);
+            case RABBIT -> listTypes(Rabbit.Type.class);
+            case LLAMA, TRADER_LLAMA -> listTypes(Llama.Color.class);
+            case PARROT -> listTypes(Parrot.Variant.class);
             case TROPICAL_FISH -> {
-                ListTag patterns = listForEnum(TropicalFish.Pattern.class);
-                patterns.addAll(listForEnum(DyeColor.class));
+                ListTag patterns = listTypes(TropicalFish.Pattern.class);
+                patterns.addAll(listTypes(DyeColor.class));
                 yield patterns;
             }
-            case FOX -> listForEnum(Fox.Type.class);
-            case CAT -> listForEnum(Cat.Type.class);
-            case PANDA -> listForEnum(Panda.Gene.class);
-            case VILLAGER, ZOMBIE_VILLAGER -> listForEnum(Villager.Type.class);
+            case FOX -> listTypes(Fox.Type.class);
+            case CAT -> listTypes(Cat.Type.class);
+            case PANDA -> listTypes(Panda.Gene.class);
+            case VILLAGER, ZOMBIE_VILLAGER -> listTypes(Villager.Type.class);
             case GOAT -> {
                 ListTag result = new ListTag();
                 result.add("screaming");
                 result.add("normal");
                 yield result;
             }
-            case AXOLOTL -> EntityColor.listForEnum(Axolotl.Variant.class);
+            case AXOLOTL -> EntityColor.listTypes(Axolotl.Variant.class);
             default -> null; // includes Ocelot (deprecated) and arrow (ColorTag)
         };
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -269,11 +269,11 @@ public class EntityColor extends EntityProperty<ElementTag> {
 
     // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
     @SuppressWarnings({"unchecked", "DataFlowIssue"})
-    public static ListTag listTypes(Class<?> clazz) {
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && Keyed.class.isAssignableFrom(clazz)) {
-            return Utilities.registryKeys(Bukkit.getRegistry((Class<? extends Keyed>) clazz));
+    public static ListTag listTypes(Class<?> type) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && Keyed.class.isAssignableFrom(type)) {
+            return Utilities.registryKeys(Bukkit.getRegistry((Class<? extends Keyed>) type));
         }
-        return new ListTag(Arrays.asList(((Class<? extends Enum<?>>) clazz).getEnumConstants()), ElementTag::new);
+        return new ListTag(Arrays.asList(((Class<? extends Enum<?>>) type).getEnumConstants()), ElementTag::new);
     }
 
     public ListTag getAllowedColors() {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -187,6 +187,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 }
             }
         }
+        // TODO This technically has registries on all supported versions
         else if (type == EntityType.VILLAGER) {
             LegacyNamingHelper.requireType(mechanism, Villager.Type.class).ifPresent(as(Villager.class)::setVillagerType);
         }
@@ -249,7 +250,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 Panda panda = as(Panda.class);
                 yield panda.getMainGene().name() + "|" + panda.getHiddenGene().name();
             }
-            // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
+            // TODO This technically has registries on all supported versions
             case VILLAGER -> String.valueOf(as(Villager.class).getVillagerType());
             case ZOMBIE_VILLAGER -> String.valueOf(as(ZombieVillager.class).getVillagerType());
             case ARROW -> {
@@ -301,6 +302,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
             case FOX -> listTypes(Fox.Type.class);
             case CAT -> listTypes(Cat.Type.class);
             case PANDA -> listTypes(Panda.Gene.class);
+            // TODO This technically has registries on all supported versions
             case VILLAGER, ZOMBIE_VILLAGER -> listTypes(Villager.Type.class);
             case GOAT -> {
                 ListTag result = new ListTag();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -242,14 +242,16 @@ public class EntityColor extends EntityProperty<ElementTag> {
             case FOX -> as(Fox.class).getFoxType().name();
             case CAT -> {
                 Cat cat = as(Cat.class);
-                yield cat.getCatType().name() + "|" + cat.getCollarColor().name();
+                // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
+                yield cat.getCatType() + "|" + cat.getCollarColor().name();
             }
             case PANDA -> {
                 Panda panda = as(Panda.class);
                 yield panda.getMainGene().name() + "|" + panda.getHiddenGene().name();
             }
-            case VILLAGER -> as(Villager.class).getVillagerType().name();
-            case ZOMBIE_VILLAGER -> as(ZombieVillager.class).getVillagerType().name();
+            // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
+            case VILLAGER -> String.valueOf(as(Villager.class).getVillagerType());
+            case ZOMBIE_VILLAGER -> String.valueOf(as(ZombieVillager.class).getVillagerType());
             case ARROW -> {
                 try {
                     yield BukkitColorExtensions.fromColor(as(Arrow.class).getColor()).identify();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.LegacyNamingHelper;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -88,7 +89,7 @@ public class EntityProfession implements Property {
         // For the list of possible professions, refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Villager.Profession.html>
         // -->
         if (attribute.startsWith("profession")) {
-            return new ElementTag(getProfession())
+            return new ElementTag(String.valueOf(getProfession()), true)
                     .getObjectAttribute(attribute.fulfill(1));
         }
 
@@ -109,8 +110,8 @@ public class EntityProfession implements Property {
         // @tags
         // <EntityTag.profession>
         // -->
-        if (mechanism.matches("profession") && mechanism.requireEnum(Villager.Profession.class)) {
-            setProfession(Villager.Profession.valueOf(mechanism.getValue().asString().toUpperCase()));
+        if (mechanism.matches("profession")) {
+            LegacyNamingHelper.requireType(mechanism, Villager.Profession.class).ifPresent(this::setProfession);
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.ZombieVillager;
 
 public class EntityProfession implements Property {
 
+    // TODO This technically has registries on all supported versions
     public static boolean describes(ObjectTag entity) {
         if (!(entity instanceof EntityTag)) {
             return false;
@@ -63,7 +64,6 @@ public class EntityProfession implements Property {
 
     @Override
     public String getPropertyString() {
-        // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
         return CoreUtilities.toLowerCase(String.valueOf(getProfession()));
     }
 
@@ -90,7 +90,6 @@ public class EntityProfession implements Property {
         // For the list of possible professions, refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Villager.Profession.html>
         // -->
         if (attribute.startsWith("profession")) {
-            // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
             return new ElementTag(String.valueOf(getProfession()), true)
                     .getObjectAttribute(attribute.fulfill(1));
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
@@ -63,7 +63,8 @@ public class EntityProfession implements Property {
 
     @Override
     public String getPropertyString() {
-        return CoreUtilities.toLowerCase(getProfession().name());
+        // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
+        return CoreUtilities.toLowerCase(String.valueOf(getProfession()));
     }
 
     @Override
@@ -89,6 +90,7 @@ public class EntityProfession implements Property {
         // For the list of possible professions, refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Villager.Profession.html>
         // -->
         if (attribute.startsWith("profession")) {
+            // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
             return new ElementTag(String.valueOf(getProfession()), true)
                     .getObjectAttribute(attribute.fulfill(1));
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -913,7 +913,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // This is only their Bukkit enum names, as seen at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/map/MapCursor.Type.html>.
         // -->
         // TODO once 1.20 is the minimum supported version, replace with direct registry-based handling
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
             tagProcessor.registerStaticTag(ListTag.class, "map_cursor_types", (attribute, object) -> {
                 listDeprecateWarn(attribute);
                 return Utilities.registryKeys(Registry.MAP_DECORATION_TYPE);

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -981,7 +981,7 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
             // For locating specific structures, see <@link language Structure lookups>.
             // -->
             tagProcessor.registerTag(ListTag.class, "structures", (attribute, object) -> {
-                return new ListTag(Registry.STRUCTURE.stream().toList(), structure -> new ElementTag(Utilities.namespacedKeyToString(structure.getKey()), true));
+                return Utilities.registryKeys(Registry.STRUCTURE);
             });
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/tags/core/ServerTagBase.java
@@ -912,7 +912,16 @@ public class ServerTagBase extends PseudoObjectTagBase<ServerTagBase> {
         // Generally used with <@link command map> and <@link language Map Script Containers>.
         // This is only their Bukkit enum names, as seen at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/map/MapCursor.Type.html>.
         // -->
-        registerEnumListTag("map_cursor_types", MapCursor.Type.class, "list_map_cursor_types");
+        // TODO once 1.20 is the minimum supported version, replace with direct registry-based handling
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            tagProcessor.registerStaticTag(ListTag.class, "map_cursor_types", (attribute, object) -> {
+                listDeprecateWarn(attribute);
+                return Utilities.registryKeys(Registry.MAP_DECORATION_TYPE);
+            }, "list_map_cursor_types");
+        }
+        else {
+            registerEnumListTag("map_cursor_types", (Class<? extends Enum<?>>) (Class<?>) MapCursor.Type.class, "list_map_cursor_types");
+        }
 
         // <--[tag]
         // @attribute <server.world_types>

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
@@ -17,10 +17,10 @@ import java.util.Set;
 public class LegacyNamingHelper<T extends Enum<T>> {
 
     // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes", "DataFlowIssue"})
     public static <T extends Keyed> T convert(Class<T> type, String string) {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-            return Bukkit.getRegistry(type).get(Utilities.parseNamespacedKey(CoreUtilities.toLowerCase(string)));
+            return Bukkit.getRegistry(type).get(Utilities.parseNamespacedKey(string));
         }
         return (T) ElementTag.asEnum((Class<? extends Enum>) type, string);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
@@ -21,7 +21,7 @@ public class LegacyNamingHelper<T extends Enum<T>> {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T extends Keyed> T convert(Class<T> type, String string) {
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-            return Bukkit.getRegistry(type).get(NamespacedKey.minecraft(CoreUtilities.toLowerCase(string)));
+            return Bukkit.getRegistry(type).get(Utilities.parseNamespacedKey(CoreUtilities.toLowerCase(string)));
         }
         return (T) ElementTag.asEnum((Class<? extends Enum>) type, string);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
@@ -9,7 +9,6 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
 
 import java.util.HashSet;
 import java.util.Optional;

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/LegacyNamingHelper.java
@@ -2,13 +2,38 @@ package com.denizenscript.denizen.utilities;
 
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
+import org.bukkit.Bukkit;
+import org.bukkit.Keyed;
+import org.bukkit.NamespacedKey;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public class LegacyNamingHelper<T extends Enum<T>> {
+
+    // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T extends Keyed> T convert(Class<T> type, String string) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            return Bukkit.getRegistry(type).get(NamespacedKey.minecraft(CoreUtilities.toLowerCase(string)));
+        }
+        return (T) ElementTag.asEnum((Class<? extends Enum>) type, string);
+    }
+
+    public static <T extends Keyed> Optional<T> requireType(Mechanism mechanism, Class<T> type) {
+        T converted = convert(type, mechanism.getValue().asString());
+        if (converted == null) {
+            mechanism.echoError("Invalid " + DebugInternals.getClassNameOpti(type) + " specified: must specify a valid name.");
+            return Optional.empty();
+        }
+        return Optional.of(converted);
+    }
 
     private final Set<String> modernNames;
     private final Class<T> enumType;

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -28,6 +28,7 @@ public class MultiVersionHelper1_19 {
     }
 
     public static ListTag getAllowedColors(EntityType type) {
+        // TODO This technically has registries on all supported versions
         if (type == EntityType.FROG) {
             return EntityColor.listTypes(Frog.Variant.class);
         }
@@ -39,6 +40,7 @@ public class MultiVersionHelper1_19 {
 
     public static void setColor(Entity entity, Mechanism mech) {
         if (entity instanceof Frog frog) {
+            // TODO This technically has registries on all supported versions
             LegacyNamingHelper.requireType(mech, Frog.Variant.class).ifPresent(frog::setVariant);
         }
         else if (entity instanceof Boat boat && mech.requireEnum(Boat.Type.class)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -18,7 +18,8 @@ public class MultiVersionHelper1_19 {
 
     public static String getColor(Entity entity) {
         if (entity instanceof Frog frog) {
-            return frog.getVariant().name();
+            // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
+            return String.valueOf(frog.getVariant());
         }
         else if (entity instanceof Boat boat) {
             return boat.getBoatType().name();

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -29,10 +29,10 @@ public class MultiVersionHelper1_19 {
 
     public static ListTag getAllowedColors(EntityType type) {
         if (type == EntityType.FROG) {
-            return EntityColor.listForEnum(Frog.Variant.class);
+            return EntityColor.listTypes(Frog.Variant.class);
         }
         else if (type == EntityType.BOAT || type == EntityType.CHEST_BOAT) {
-            return EntityColor.listForEnum(Boat.Type.class);
+            return EntityColor.listTypes(Boat.Type.class);
         }
         return null;
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -16,9 +16,9 @@ public class MultiVersionHelper1_19 {
         return type == EntityType.FROG || type == EntityType.BOAT || type == EntityType.CHEST_BOAT;
     }
 
+    // TODO Frog variants technically have registries on all supported versions
     public static String getColor(Entity entity) {
         if (entity instanceof Frog frog) {
-            // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
             return String.valueOf(frog.getVariant());
         }
         else if (entity instanceof Boat boat) {
@@ -28,7 +28,6 @@ public class MultiVersionHelper1_19 {
     }
 
     public static ListTag getAllowedColors(EntityType type) {
-        // TODO This technically has registries on all supported versions
         if (type == EntityType.FROG) {
             return EntityColor.listTypes(Frog.Variant.class);
         }
@@ -40,7 +39,6 @@ public class MultiVersionHelper1_19 {
 
     public static void setColor(Entity entity, Mechanism mech) {
         if (entity instanceof Frog frog) {
-            // TODO This technically has registries on all supported versions
             LegacyNamingHelper.requireType(mech, Frog.Variant.class).ifPresent(frog::setVariant);
         }
         else if (entity instanceof Boat boat && mech.requireEnum(Boat.Type.class)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -28,17 +28,17 @@ public class MultiVersionHelper1_19 {
 
     public static ListTag getAllowedColors(EntityType type) {
         if (type == EntityType.FROG) {
-            return EntityColor.listForEnum(Frog.Variant.values());
+            return EntityColor.listForEnum(Frog.Variant.class);
         }
         else if (type == EntityType.BOAT || type == EntityType.CHEST_BOAT) {
-            return EntityColor.listForEnum(Boat.Type.values());
+            return EntityColor.listForEnum(Boat.Type.class);
         }
         return null;
     }
 
     public static void setColor(Entity entity, Mechanism mech) {
-        if (entity instanceof Frog frog && mech.requireEnum(Frog.Variant.class)) {
-            frog.setVariant(mech.getValue().asEnum(Frog.Variant.class));
+        if (entity instanceof Frog frog) {
+            LegacyNamingHelper.requireType(mech, Frog.Variant.class).ifPresent(frog::setVariant);
         }
         else if (entity instanceof Boat boat && mech.requireEnum(Boat.Type.class)) {
             boat.setBoatType(mech.getValue().asEnum(Boat.Type.class));

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -9,6 +9,8 @@ import com.denizenscript.denizen.scripts.commands.world.SignCommand;
 import com.denizenscript.denizen.tags.BukkitTagContext;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.ScriptTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.tags.TagManager;
@@ -52,6 +54,10 @@ public class Utilities {
 
     public static String namespacedKeyToString(NamespacedKey key) {
         return key.getNamespace().equals(NamespacedKey.MINECRAFT) ? key.getKey() : key.toString();
+    }
+
+    public static ListTag registryKeys(Registry<?> registry) {
+        return new ListTag(registry.stream().toList(), keyed -> new ElementTag(namespacedKeyToString(keyed.getKey()), true));
     }
 
     public static boolean matchesNamespacedKeyButCaseInsensitive(String input) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/MapCursor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/MapCursor.java
@@ -27,7 +27,7 @@ public class MapCursor extends MapObject {
     }
 
     public org.bukkit.map.MapCursor.Type getType(PlayerTag player) {
-        return LegacyNamingHelper.convert(org.bukkit.map.MapCursor.Type.class, tag(typeTag, player).toUpperCase());
+        return LegacyNamingHelper.convert(org.bukkit.map.MapCursor.Type.class, tag(typeTag, player));
     }
 
     private byte yawToDirection(double yaw) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/MapCursor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/maps/MapCursor.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.utilities.maps;
 
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.LegacyNamingHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapView;
@@ -26,7 +27,7 @@ public class MapCursor extends MapObject {
     }
 
     public org.bukkit.map.MapCursor.Type getType(PlayerTag player) {
-        return org.bukkit.map.MapCursor.Type.valueOf(tag(typeTag, player).toUpperCase());
+        return LegacyNamingHelper.convert(org.bukkit.map.MapCursor.Type.class, tag(typeTag, player).toUpperCase());
     }
 
     private byte yawToDirection(double yaw) {


### PR DESCRIPTION
## Changes

- Changed usages of `valueOf`, `asEnum`, etc. with old enums to `LegacyNamingHelper#convert`.
- Changed uses of `#name/toString`, the `ElementTag` enum constructor, etc. with old enums to `String#valueOf` (since it doesn't contain any explicit method calls on the instance, it doesn't blow up about having the wrong invoke instructions on old versions).
- Changed usages of `Mechanism#requireEnum` with old enums to `LegacyNamingHelper#requireType`.
- `VillagerChangesProfessionScriptEvent`: enum constructor in `getContext` (unrelated cleanup).
- Renamed `EntityColor#listForEnum` to `listTypes`, and changed it to take a class for the type instead of an enum array, and get the types list from the registry with `Utilities#registryKeys` for no-longer-enum types.
- `server.map_cursor_types` now uses different registry-based logic on 1.20+.
- `server.structures` now uses the new `Utilities#registryKeys`.

## Additions

- `LegacyNamingHelper#convert` - takes in a class and string, and converts that string to the type of the class with either registries or enum conversions.
- `LegacyNamingHelper#requireType` - `Mechanism#requireEnum` but for no-longer-enums.
- `Utilities#registryKeys` - returns a `ListTag` of a registry's keys.

> [!NOTE]
> Used an `Optional` for `LegacyNamingHelper#requireType`, since it just seemed like a good place to use it and have slightly cleaner & maybe faster code using it, with the alternatives being
> ```java
> if (mechanism.matches("profession") && LegacyNamingHelper.matches(Villager.Profession.class, mechanism.getValue().asString())) {
>     setProfession(LegacyNamingHelper.convet(Villager.Profession.class, mechanism.getValue().asString()));
> }
> ```
> or
> ```java
> if (mechanism.matches("profession")) {
>     Villager.Profession profession = LegacyNamingHelper.requireType(mechanism, Villager.Profession.class);
>     if (profession != null) {
>         setProfession(profession);
>     }
> }
> ```
> Which are messier, especially when there's a bunch, I.e. in `EntityColor` (and since this is a temporary thing till 1.21 is the min version anyway) - let me know if you'd still prefer one of the other approaches though.

> [!NOTE]
> Some of these technically have registries on all supported versions, but can't really cleanly make them use these as it'd still involve method calls on interfaces that are enums in older versions - can have a separate set of utils for handling registry stuff in mechs/tags which'll probably be needed anyway as more stuff move to registries, but that's for a different PR.