### PR TITLE
`1.21` Attribute modifiers updates

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
@@ -217,18 +217,19 @@ public class EntityAttributeModifiers implements Property {
     // These can be modified by such mechanisms as <@link mechanism EntityTag.attribute_base_values>, <@link mechanism EntityTag.attribute_modifiers>, <@link mechanism EntityTag.add_attribute_modifiers>,
     // <@link mechanism EntityTag.remove_attribute_modifiers>, <@link mechanism ItemTag.attribute_modifiers>, <@link mechanism ItemTag.add_attribute_modifiers>, <@link mechanism ItemTag.remove_attribute_modifiers>, ...
     //
-    // The input format of each of the 'add' and set mechanisms is slightly complicated:  a MapTag where the keys are attribute names, and values are a ListTag of modifiers,
+    // The input format of each of the 'add' and set mechanisms is slightly complicated: a MapTag where the keys are attribute names, and values are a ListTag of modifiers,
     // where each modifier is itself a MapTag with required keys 'operation' and 'amount', and additionally:
     // Before MC 1.20.6: optional 'name', 'slot', and 'id' keys.
-    // On MC 1.20.6: optional  'name', 'slot_group', and 'id' keys.
+    // On MC 1.20.6: optional 'name', 'slot_group', and 'id' keys.
+    // The default ID will be randomly generated, the default name will be the attribute name.
     // After MC 1.21: required 'key' key, and optional 'slot_group'.
-    // The 'id' is the attribute's name/identifier in a "namespaced:key" format (defaulting to the "minecraft" namespace), which has to be unique from other modifiers on the object.
+    // The 'key' is the attribute's name/identifier in a "namespaced:key" format (defaulting to the "minecraft" namespace), which has to be unique from other modifiers on the object.
     //
     // Valid operations: ADD_NUMBER, ADD_SCALAR, and MULTIPLY_SCALAR_1
     // Valid slots (used up to MC 1.20.6): HAND, OFF_HAND, FEET, LEGS, CHEST, HEAD, ANY
-    // Valid slot groups (used on MC 1.21+): <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/inventory/EquipmentSlotGroup.html>
+    // Valid slot groups (used on MC 1.20.6+): <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/inventory/EquipmentSlotGroup.html>
     // Valid attribute names are listed at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html>
-    // The default ID will be randomly generated, the default name will be the attribute name, the default slot/slot group is any.
+    // The default slot/slot group is "any".
     //
     // Operation names are based on the Bukkit enum.
     // ADD_NUMBER corresponds to Mojang "ADDITION" - adds on top of the base value.
@@ -250,16 +251,17 @@ public class EntityAttributeModifiers implements Property {
     //
     // See also <@link url https://minecraft.wiki/w/Attribute#Modifiers>
     //
-    // For a quick and dirty in-line input, you can do for example: [generic_max_health=<list[<map[operation=ADD_NUMBER;amount=20;slot=HEAD]>]>]
+    // For a quick and dirty in-line input, you can do for example: [generic_max_health=<list[<map[key=my_project:add_health;operation=ADD_NUMBER;amount=20;slot_group=HEAD]>]>]
     //
     // For more clean/proper input, instead do something like:
     // <code>
     // - definemap attributes:
     //     generic_max_health:
     //         1:
+    //             key: my_project:add_health
     //             operation: ADD_NUMBER
     //             amount: 20
-    //             slot: head
+    //             slot_group: head
     // - inventory adjust slot:head add_attribute_modifiers:<[attributes]>
     // </code>
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
@@ -116,8 +116,7 @@ public class EntityAttributeModifiers implements Property {
             return null;
         }
         ElementTag key = map.getElement("key");
-        boolean is1_21 = NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21);
-        if (!is1_21) {
+        if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
             return parseLegacyModifier(attr, map, amountValue, operationValue);
         }
         if (key == null && map.size() > 2) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
@@ -1,9 +1,6 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.properties.item.ItemAttributeModifiers;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -82,9 +79,7 @@ public class EntityAttributeModifiers implements Property {
         result.putObject("amount", new ElementTag(modifier.getAmount()));
         result.putObject("operation", new ElementTag(modifier.getOperation()));
         result.putObject("slot", new ElementTag(modifier.getSlot() == null ? "any" : modifier.getSlot().name()));
-        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20)) {
-            result.putObject("id", new ElementTag(modifier.getUniqueId().toString()));
-        }
+        result.putObject("id", new ElementTag(modifier.getUniqueId().toString()));
         return result;
     }
 
@@ -93,7 +88,6 @@ public class EntityAttributeModifiers implements Property {
         ElementTag amount = map.getElement("amount");
         ElementTag operation = map.getElement("operation");
         ElementTag slot = map.getElement("slot", "any");
-        // TODO: MC 1.21: ID and name are now the same internal value.
         ElementTag id = map.getElement("id");
         UUID idValue;
         double amountValue;
@@ -316,12 +310,10 @@ public class EntityAttributeModifiers implements Property {
                             instance.addModifier(modifier);
                         }
                         catch (IllegalArgumentException ex) {
-                            if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20) && ex.getMessage().equals("Modifier is already applied on this attribute!")) {
-                                Debug.echoError("Cannot add attribute with ID '" + modifier.getUniqueId() + "' as the entity already has a modifier with the same ID.");
-                            }
-                            else {
+                            if (!ex.getMessage().equals("Modifier is already applied on this attribute!")) {
                                 throw ex;
                             }
+                            Debug.echoError("Cannot add attribute with ID '" + modifier.getUniqueId() + "' as the entity already has a modifier with the same ID.");
                         }
                     }
                 }
@@ -363,13 +355,14 @@ public class EntityAttributeModifiers implements Property {
                 }
             }
             for (String toRemove : inputList) {
+                UUID id = UUID.fromString(toRemove);
                 for (Attribute attr : Attribute.values()) {
                     AttributeInstance instance = ent.getAttribute(attr);
                     if (instance == null) {
                         continue;
                     }
                     for (AttributeModifier modifer : instance.getModifiers()) {
-                        if (ItemAttributeModifiers.getIdString(modifer).equals(toRemove)) {
+                        if (modifer.getUniqueId().equals(id)) {
                             instance.removeModifier(modifer);
                             break;
                         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAttributeModifiers.java
@@ -136,7 +136,8 @@ public class EntityAttributeModifiers implements Property {
         return new AttributeModifier(Utilities.parseNamespacedKey(key.asString()), amountValue, operationValue, group);
     }
 
-    private static AttributeModifier parseLegacyModifier(Attribute attr, MapTag map, double amount, AttributeModifier.Operation operation) {
+    @Deprecated(forRemoval = true)
+    public static AttributeModifier parseLegacyModifier(Attribute attr, MapTag map, double amount, AttributeModifier.Operation operation) {
         ElementTag name = map.getElement("name");
         ElementTag slot = map.getElement("slot", "any");
         ElementTag id = map.getElement("id");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemAttributeModifiers.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemAttributeModifiers.java
@@ -159,10 +159,11 @@ public class ItemAttributeModifiers extends ItemProperty<MapTag> {
                 }
             }
             for (String toRemove : inputList) {
+                UUID id = UUID.fromString(toRemove);
                 Multimap<org.bukkit.attribute.Attribute, AttributeModifier> metaMap = meta.getAttributeModifiers();
                 for (org.bukkit.attribute.Attribute attribute : metaMap.keys()) {
                     for (AttributeModifier modifer : metaMap.get(attribute)) {
-                        if (getIdString(modifer).equals(toRemove)) {
+                        if (modifer.getUniqueId().equals(id)) {
                             meta.removeAttributeModifier(attribute, modifer);
                             break;
                         }
@@ -171,14 +172,5 @@ public class ItemAttributeModifiers extends ItemProperty<MapTag> {
             }
             prop.setItemMeta(meta);
         });
-    }
-
-    public static String getIdString(AttributeModifier modifier) {
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-            return modifier.getName();
-        }
-        else {
-            return modifier.getUniqueId().toString();
-        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -310,7 +310,7 @@ public class BukkitImplDeprecations {
     // Good candidate for SlowWarning, due to ease of update and the newer names already being more "normal"/well-known
     public static Warning oldSpigotNames = new VerySlowWarning("oldSpigotNames", "Several features (particles, entities, etc.) had alternative naming added by Spigot, which is now deprecated in favor of the official Minecraft naming; see relevant feature's meta docs for more information.");
 
-    // Added 2024/7/13
+    // Added 2024/07/13
     public static Warning pre1_21AttributeFormat = new VerySlowWarning("pre1_21AttributeFormat", "Attribute modifiers were changed in 1.21, now using slot groups instead of slots and namespaced keys instead of UUIDS; check relevant meta docs for more information.");
 
     // ==================== FUTURE deprecations ====================

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -310,6 +310,9 @@ public class BukkitImplDeprecations {
     // Good candidate for SlowWarning, due to ease of update and the newer names already being more "normal"/well-known
     public static Warning oldSpigotNames = new VerySlowWarning("oldSpigotNames", "Several features (particles, entities, etc.) had alternative naming added by Spigot, which is now deprecated in favor of the official Minecraft naming; see relevant feature's meta docs for more information.");
 
+    // Added 2024/7/13
+    public static Warning pre1_21AttributeFormat = new VerySlowWarning("pre1_21AttributeFormat", "Attribute modifiers were changed in 1.21, now using slot groups instead of slots and namespaced keys instead of UUIDS; check relevant meta docs for more information.");
+
     // ==================== FUTURE deprecations ====================
 
     // Added 2023/01/15, deprecate officially by 2026


### PR DESCRIPTION
## Changes

- `EntityAttributeModifiers#mapify` now includes a `slot_group` key on 1.20+ and a `key` key on 1.21+; the `id` key is in a `try/catch` to still supply it where possible for legacy attributes and silently fail for other ones.
- `EntityAttributeModifiers#modiferForMap` now takes in a `TagContext` and has been updated for the new keys & calling `#parseLegacyModifier` when needed.
- `EntityTag.add_attribute_modifiers`'s "modifier already exists" message now properly shows the key on 1.21+ & uses `Mecahnism#echoError`.
- `remove_attribute_modifiers` mechanisms now remove modifiers by key instead of UUID on 1.21+ (which technically back-supports legacy ones, since they get updated to `minecraft:<UUID>` it seems.
- Removed `ItemAttributeModifiers#getIdString` as it wasn't used anymore.

## Additions

- `EntityAttributeModifiers#parseLegacyModifier` - parses a pre-1.21 attribute modifier from a map, optionally allowing a `slot_group` on 1.20+ - just to nicely split the modern and legacy code.
- `pre1_21AttributeFormat` `VerySlowWarning` - deprecation warning for these attribute changes.

> [!NOTE]
> The way `slot_group`s are represented there isn't great - it works, but you can't really do anything with them other then knowing their name (e.g. mainly checking if they contain a slot); The only way I can really see to cleanly solve this is a `EquipmentSlotGroup` tag, but lmk what do you think.

> [!NOTE]
> Not sure if the tern-in-if in I did in `remove_attribute_modifiers` mechanisms is the best approach? seemed nicer then having both if statements.