### PR TITLE
Add paper-only PlayerShieldDisable event

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -73,6 +73,9 @@ public class PaperModule {
         ScriptEvent.registerScriptEvent(PlayerSelectsStonecutterRecipeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerLecternPageChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerSpectatesEntityScriptEvent.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            ScriptEvent.registerScriptEvent(PlayerShieldDisableScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(PlayerStopsSpectatingScriptEvent.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             ScriptEvent.registerScriptEvent(PlayerTracksEntityScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerShieldDisableScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerShieldDisableScriptEvent.java
@@ -29,7 +29,7 @@ public class PlayerShieldDisableScriptEvent extends BukkitScriptEvent implements
     //
     // @Context
     // <context.damager> returns an EntityTag of the attacker.
-    // <context.cooldown> returns an ElementTag of the cooldown in ticks.
+    // <context.cooldown> returns a DurationTag of the cooldown.
     //
     // @Determine
     // "COOLDOWN:<DurationTag>" to change the cooldown.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerShieldDisableScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerShieldDisableScriptEvent.java
@@ -1,0 +1,79 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import io.papermc.paper.event.player.PlayerShieldDisableEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerShieldDisableScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // player shield disables
+    //
+    // @Plugin Paper
+    //
+    // @Group Paper
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers When a player shield is disabled.
+    //
+    // @Context
+    // <context.damager> returns an EntityTag of the attacker.
+    // <context.cooldown> returns an ElementTag of the cooldown in ticks.
+    //
+    // @Determine
+    // "COOLDOWN:<DurationTag>" to change the cooldown.
+    //
+    // @Player Always.
+    //
+    // -->
+
+    public PlayerShieldDisableScriptEvent() {
+        registerCouldMatcher("player shield disables");
+        this.<PlayerShieldDisableScriptEvent, DurationTag>registerDetermination("cooldown", DurationTag.class, (evt, context, duration) -> {
+            evt.event.setCooldown(duration.getTicksAsInt());
+        });
+    }
+
+    public PlayerShieldDisableEvent event;
+    public LocationTag location;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "damager" -> new EntityTag(event.getDamager()).getDenizenObject();
+            case "cooldown" -> new DurationTag((long) event.getCooldown());
+            default -> super.getContext(name);
+        };
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @EventHandler
+    public void playerShieldDisableEvent(PlayerShieldDisableEvent event) {
+        location = new LocationTag(event.getPlayer().getLocation());
+        this.event = event;
+        fire(event);
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerShieldDisableScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerShieldDisableScriptEvent.java
@@ -25,11 +25,11 @@ public class PlayerShieldDisableScriptEvent extends BukkitScriptEvent implements
     //
     // @Cancellable true
     //
-    // @Triggers When a player shield is disabled.
+    // @Triggers When a players shield is disabled.
     //
     // @Context
-    // <context.damager> returns an EntityTag of the attacker.
-    // <context.cooldown> returns a DurationTag of the cooldown.
+    // <context.damager> returns an EntityTag of the attacker who disabled the shield.
+    // <context.cooldown> returns a DurationTag of the cooldown the shield is disabled for.
     //
     // @Determine
     // "COOLDOWN:<DurationTag>" to change the cooldown.


### PR DESCRIPTION
This PR adds the new 1.20+ paper-only `PlayerShieldDisableEvent` as "player shield disables" Denizen event with following contexts and determinations.

### Context
`<context.damager>` returns an `EntityTag` of the attacker
`<context.cooldown>` returns a `DurationTag` of the cooldown.

### Determinations
`"COOLDOWN:<DurationTag>"` to change the cooldown.