### PR TITLE
add context and switches to PlayerQuitEvent

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -78,6 +78,7 @@ public class PaperModule {
             ScriptEvent.registerScriptEvent(PlayerTracksEntityScriptEvent.class);
         }
         ScriptEvent.registerScriptEvent(PlayerTradesWithMerchantScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerQuitsScriptEventPaperImpl.class);
         ScriptEvent.registerScriptEvent(PreEntitySpawnScriptEvent.class);
         ScriptEvent.registerScriptEvent(ProjectileCollideScriptEvent.class);
         ScriptEvent.registerScriptEvent(ServerListPingScriptEventPaperImpl.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
@@ -1,7 +1,6 @@
 package com.denizenscript.denizen.paper.events;
 
 import com.denizenscript.denizen.events.player.PlayerQuitsScriptEvent;
-import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
@@ -36,8 +36,4 @@ public class PlayerQuitsScriptEventPaperImpl extends PlayerQuitsScriptEvent {
             default -> super.getContext(name);
         };
     }
-
-
-
-
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
@@ -4,20 +4,12 @@ import com.denizenscript.denizen.events.player.PlayerQuitsScriptEvent;
 import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import net.md_5.bungee.api.ChatColor;
 
 
 public class PlayerQuitsScriptEventPaperImpl extends PlayerQuitsScriptEvent {
 
     public PlayerQuitsScriptEventPaperImpl() {
         registerSwitches("cause");
-        this.<PlayerQuitsScriptEventPaperImpl>registerTextDetermination("none", (evt) -> {
-            event.quitMessage(null);
-        });
-        this.<PlayerQuitsScriptEventPaperImpl, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, determination) -> {
-            event.quitMessage(PaperModule.parseFormattedText(determination.toString(), ChatColor.WHITE));
-            return true;
-        });
     }
 
     @Override
@@ -31,7 +23,6 @@ public class PlayerQuitsScriptEventPaperImpl extends PlayerQuitsScriptEvent {
     @Override
     public ObjectTag getContext(String name) {
         return switch (name) {
-            case "message" -> new ElementTag(PaperModule.stringifyComponent(event.quitMessage()));
             case "cause" -> new ElementTag(event.getReason());
             default -> super.getContext(name);
         };

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
@@ -1,14 +1,23 @@
 package com.denizenscript.denizen.paper.events;
 
 import com.denizenscript.denizen.events.player.PlayerQuitsScriptEvent;
+import com.denizenscript.denizen.paper.PaperModule;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.md_5.bungee.api.ChatColor;
 
 
 public class PlayerQuitsScriptEventPaperImpl extends PlayerQuitsScriptEvent {
 
     public PlayerQuitsScriptEventPaperImpl() {
         registerSwitches("cause");
+        this.<PlayerQuitsScriptEventPaperImpl>registerTextDetermination("none", (evt) -> {
+            event.quitMessage(null);
+        });
+        this.<PlayerQuitsScriptEventPaperImpl, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, determination) -> {
+            event.quitMessage(PaperModule.parseFormattedText(determination.toString(), ChatColor.WHITE));
+            return true;
+        });
     }
 
     @Override
@@ -22,6 +31,7 @@ public class PlayerQuitsScriptEventPaperImpl extends PlayerQuitsScriptEvent {
     @Override
     public ObjectTag getContext(String name) {
         return switch (name) {
+            case "message" -> new ElementTag(PaperModule.stringifyComponent(event.quitMessage()));
             case "cause" -> new ElementTag(event.getReason());
             default -> super.getContext(name);
         };

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
@@ -1,0 +1,43 @@
+package com.denizenscript.denizen.paper.events;
+
+import com.denizenscript.denizen.events.player.PlayerQuitsScriptEvent;
+import com.denizenscript.denizen.paper.PaperModule;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.md_5.bungee.api.ChatColor;
+
+
+public class PlayerQuitsScriptEventPaperImpl extends PlayerQuitsScriptEvent {
+
+    public PlayerQuitsScriptEventPaperImpl() {
+        registerSwitches("cause");
+        this.<PlayerQuitsScriptEventPaperImpl>registerTextDetermination("none", (evt) -> {
+            event.quitMessage(null);
+        });
+        this.<PlayerQuitsScriptEventPaperImpl, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, determination) -> {
+            event.quitMessage(PaperModule.parseFormattedText(determination.toString(), ChatColor.WHITE));
+            return true;
+        });
+    }
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runGenericSwitchCheck(path, "cause", event.getReason().name())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "message" -> new ElementTag(PaperModule.stringifyComponent(event.quitMessage()));
+            case "cause" -> new ElementTag(event.getReason());
+            default -> super.getContext(name);
+        };
+    }
+
+
+
+
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/PlayerQuitsScriptEventPaperImpl.java
@@ -14,9 +14,8 @@ public class PlayerQuitsScriptEventPaperImpl extends PlayerQuitsScriptEvent {
         this.<PlayerQuitsScriptEventPaperImpl>registerTextDetermination("none", (evt) -> {
             event.quitMessage(null);
         });
-        this.<PlayerQuitsScriptEventPaperImpl, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, determination) -> {
+        this.<PlayerQuitsScriptEventPaperImpl, ElementTag>registerDetermination(null, ElementTag.class, (evt, context, determination) -> {
             event.quitMessage(PaperModule.parseFormattedText(determination.toString(), ChatColor.WHITE));
-            return true;
         });
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -220,7 +220,9 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(PlayerPreLoginScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesAnvilCraftScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerPreparesEnchantScriptEvent.class);
-        ScriptEvent.registerScriptEvent(PlayerQuitsScriptEvent.class);
+        if (!Denizen.supportsPaper) {
+            ScriptEvent.registerScriptEvent(PlayerQuitsScriptEvent.class);
+        }
         if (!Denizen.supportsPaper || NMSHandler.getVersion().isAtMost(NMSVersion.v1_17)) {
             ScriptEvent.registerScriptEvent(PlayerRaiseLowerItemScriptEvent.PlayerRaiseLowerItemScriptEventSpigotImpl.class);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerQuitsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerQuitsScriptEvent.java
@@ -1,6 +1,7 @@
 package com.denizenscript.denizen.events.player;
 
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -18,16 +19,19 @@ public class PlayerQuitsScriptEvent extends BukkitScriptEvent implements Listene
     // player quits
     // player quit
     //
-    // @Regex ^on player (quit|quits)$
-    //
     // @Synonyms Player Disconnects,Player Logs Off,Player Leaves
     //
     // @Group Player
+    //
+    // @Switch cause:<cause> to only process the event when it matches the specific cause (only on Paper).
+    //
+    // @Location true
     //
     // @Triggers when a player quit the server.
     //
     // @Context
     // <context.message> returns an ElementTag of the quit message.
+    // <context.cause> returns an ElementTag of the cause of the quit (only on Paper): <@link url https://jd.papermc.io/paper/1.21.1/org/bukkit/event/player/PlayerQuitEvent.QuitReason.html>.
     //
     // @Determine
     // ElementTag to change the quit message.
@@ -38,27 +42,25 @@ public class PlayerQuitsScriptEvent extends BukkitScriptEvent implements Listene
     // -->
 
     public PlayerQuitsScriptEvent() {
+        registerCouldMatcher("player quits|quit");
+        this.<PlayerQuitsScriptEvent>registerTextDetermination("none", (evt) -> {
+            event.setQuitMessage(null);
+        });
+        this.<PlayerQuitsScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, determination) -> {
+            event.setQuitMessage(determination.asString());
+            return true;
+        });
     }
 
     public PlayerQuitEvent event;
+    public LocationTag location;
 
     @Override
-    public boolean couldMatch(ScriptPath path) {
-        return path.eventLower.startsWith("player quit");
-    }
-
-    @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag) {
-            String determination = determinationObj.toString();
-            if (CoreUtilities.equalsIgnoreCase(determination, "none")) {
-                event.setQuitMessage(null);
-                return true;
-            }
-            event.setQuitMessage(determination);
-            return true;
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
         }
-        return super.applyDetermination(path, determinationObj);
+        return super.matches(path);
     }
 
     @Override
@@ -68,10 +70,10 @@ public class PlayerQuitsScriptEvent extends BukkitScriptEvent implements Listene
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("message")) {
-            return new ElementTag(event.getQuitMessage());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "message" -> new ElementTag(event.getQuitMessage());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler
@@ -82,6 +84,7 @@ public class PlayerQuitsScriptEvent extends BukkitScriptEvent implements Listene
         if (!event.getPlayer().isOnline()) { // Workaround: Paper event misfire - refer to comments in NetworkInterceptHelper
             return;
         }
+        location = new LocationTag(event.getPlayer().getLocation());
         this.event = event;
         fire(event);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerQuitsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerQuitsScriptEvent.java
@@ -7,7 +7,6 @@ import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -87,6 +86,5 @@ public class PlayerQuitsScriptEvent extends BukkitScriptEvent implements Listene
         location = new LocationTag(event.getPlayer().getLocation());
         this.event = event;
         fire(event);
-
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerQuitsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerQuitsScriptEvent.java
@@ -45,9 +45,8 @@ public class PlayerQuitsScriptEvent extends BukkitScriptEvent implements Listene
         this.<PlayerQuitsScriptEvent>registerTextDetermination("none", (evt) -> {
             event.setQuitMessage(null);
         });
-        this.<PlayerQuitsScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, determination) -> {
+        this.<PlayerQuitsScriptEvent, ElementTag>registerDetermination(null, ElementTag.class, (evt, context, determination) -> {
             event.setQuitMessage(determination.asString());
-            return true;
         });
     }
 


### PR DESCRIPTION
This PR modernizes the PlayerQuitEvent. Additionally to that it adds the following:

### Switches
`@Location true`, requested by Chaps79 on Discord.
`cause:<cause>` to only process the event when it matches the specific cause (only on Paper).`
### Context
`<context.cause>` returns an ElementTag of the cause of the quit (only on Paper)

The PaperImplementation makes also use of the non-deprecated Methods 
- quitMessage() to return the quit message
- quitMessage(component) to set the quit message.