### PR TITLE
Add MoistureChangeEvent

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -84,6 +84,7 @@ public class ScriptEventRegistry {
         ScriptEvent.registerScriptEvent(LeafDecaysScriptEvent.class);
         ScriptEvent.registerScriptEvent(LiquidLevelChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(LiquidSpreadScriptEvent.class);
+        ScriptEvent.registerScriptEvent(MoistureChangeScriptEvent.class);
         ScriptEvent.registerScriptEvent(NoteBlockPlaysNoteScriptEvent.class);
         ScriptEvent.registerScriptEvent(PistonExtendsScriptEvent.class);
         ScriptEvent.registerScriptEvent(PistonRetractsScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
@@ -20,16 +20,16 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     //
     // @Location true
     //
-    // @Triggers when a farmland moisture level changes
+    // @Triggers when a farmland's moisture level changes.
     //
     // @Switch from:<level> to only process the event when the previous moisture level matches the input.
     // @Switch to:<level> to only process the event when the new moisture level matches the input.
     //
     // @Context
     // <context.location> returns the LocationTag of the farmland.
-    // <context.material> returns the MaterialTag of the farmland.
-    // <context.old_level> returns the ElementTag of the previous moisture level.
-    // <context.new_level> returns the ElementTag of the new moisture level.
+    // <context.material> returns the MaterialTag of the new farmland.
+    // <context.old_level> returns the ElementTag(Number) of the previous moisture level.
+    // <context.new_level> returns the ElementTag(Number) of the new moisture level.
     //
     // @Cancellable true
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
@@ -1,0 +1,91 @@
+package com.denizenscript.denizen.events.block;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.block.data.type.Farmland;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.MoistureChangeEvent;
+
+public class MoistureChangeScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // farmland moisture level changes
+    //
+    // @Group Block
+    //
+    // @Location true
+    //
+    // @Triggers when a farmland moisture level changes
+    //
+    // @Switch from:<level> to only process the event when the previous moisture level matches the input.
+    // @Switch to:<level> to only process the event when the new moisture level matches the input.
+    //
+    // @Context
+    // <context.location> returns the LocationTag of the farmland.
+    // <context.material> returns the MaterialTag of the farmland.
+    // <context.old_level> returns the ElementTag of the previous moisture level.
+    // <context.new_level> returns the ElementTag of the new moisture level.
+    //
+    // @Cancellable true
+    //
+    // @Example
+    // # Announce when farmland begins to dry out.
+    // on farmland moisture level changes from:7 to:6:
+    // - announce "Farmland at location <context.location.simple> lost its water source and began to dry!"
+    //
+    // -->
+
+    public MoistureChangeScriptEvent() {
+        registerCouldMatcher("farmland moisture level changes");
+        registerSwitches("from", "to");
+    }
+
+    public MoistureChangeEvent event;
+    public MaterialTag material;
+    public LocationTag location;
+    public Farmland oldFarmland;
+    public Farmland newFarmland;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!path.tryArgObject(0, material)) {
+            return false;
+        }
+        if (!path.checkSwitch("from", String.valueOf(oldFarmland.getMoisture()))) {
+            return false;
+        }
+        if (!path.checkSwitch("to", String.valueOf(newFarmland.getMoisture()))) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "location" -> location;
+            case "material" -> material;
+            case "old_level" -> new ElementTag(oldFarmland.getMoisture());
+            case "new_level" -> new ElementTag(newFarmland.getMoisture());
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void onMoistureChange(MoistureChangeEvent event) {
+        location = new LocationTag(event.getBlock().getLocation());
+        oldFarmland = (Farmland) event.getBlock().getBlockData();
+        newFarmland = (Farmland) event.getNewState().getBlockData();
+        material = new MaterialTag(newFarmland);
+        this.event = event;
+        fire(event);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
@@ -47,7 +47,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     }
 
     public MoistureChangeEvent event;
-    public MaterialTag old_material;
+    public MaterialTag newMaterial;
     public LocationTag location;
     public Farmland oldFarmland;
     public Farmland newFarmland;
@@ -57,7 +57,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
         if (!runInCheck(path, location)) {
             return false;
         }
-        if (!path.tryArgObject(0, old_material)) {
+        if (!path.tryArgObject(0, newMaterial)) {
             return false;
         }
         if (!path.checkSwitch("from", String.valueOf(oldFarmland.getMoisture()))) {
@@ -73,8 +73,8 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "location" -> location;
-            case "old_material" -> old_material;
-            case "new_material" -> new MaterialTag(event.getBlock().getBlockData());
+            case "old_material" -> new MaterialTag(event.getBlock().getBlockData());
+            case "new_material" -> newMaterial;
             case "old_level" -> new ElementTag(oldFarmland.getMoisture());
             case "new_level" -> new ElementTag(newFarmland.getMoisture());
             default -> super.getContext(name);
@@ -86,7 +86,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
         location = new LocationTag(event.getBlock().getLocation());
         oldFarmland = (Farmland) event.getBlock().getBlockData();
         newFarmland = (Farmland) event.getNewState().getBlockData();
-        old_material = new MaterialTag(newFarmland);
+        newMaterial = new MaterialTag(newFarmland);
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
@@ -68,7 +68,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "location" -> location;
-            case "material" -> new MaterialTag(event.getBlock().getBlockData());
+            case "material" -> new MaterialTag(oldFarmland);
             case "old_level" -> new ElementTag(oldFarmland.getMoisture());
             case "new_level" -> new ElementTag(newFarmland.getMoisture());
             default -> super.getContext(name);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
@@ -27,7 +27,8 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     //
     // @Context
     // <context.location> returns the LocationTag of the farmland.
-    // <context.material> returns the MaterialTag of the new farmland.
+    // <context.old_material> returns the MaterialTag the old farmland block, before the level changed.
+    // <context.new_material> returns the MaterialTag the farmland block is changing to.
     // <context.old_level> returns the ElementTag(Number) of the previous moisture level.
     // <context.new_level> returns the ElementTag(Number) of the new moisture level.
     //
@@ -46,7 +47,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     }
 
     public MoistureChangeEvent event;
-    public MaterialTag material;
+    public MaterialTag old_material;
     public LocationTag location;
     public Farmland oldFarmland;
     public Farmland newFarmland;
@@ -56,7 +57,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
         if (!runInCheck(path, location)) {
             return false;
         }
-        if (!path.tryArgObject(0, material)) {
+        if (!path.tryArgObject(0, old_material)) {
             return false;
         }
         if (!path.checkSwitch("from", String.valueOf(oldFarmland.getMoisture()))) {
@@ -72,7 +73,8 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "location" -> location;
-            case "material" -> material;
+            case "old_material" -> old_material;
+            case "new_material" -> new MaterialTag(event.getBlock().getBlockData());
             case "old_level" -> new ElementTag(oldFarmland.getMoisture());
             case "new_level" -> new ElementTag(newFarmland.getMoisture());
             default -> super.getContext(name);
@@ -84,7 +86,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
         location = new LocationTag(event.getBlock().getLocation());
         oldFarmland = (Farmland) event.getBlock().getBlockData();
         newFarmland = (Farmland) event.getNewState().getBlockData();
-        material = new MaterialTag(newFarmland);
+        old_material = new MaterialTag(newFarmland);
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
@@ -26,9 +26,8 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     // @Switch to:<level> to only process the event when the new moisture level matches the input.
     //
     // @Context
-    // <context.location> returns the LocationTag of the farmland.
-    // <context.old_material> returns the MaterialTag the old farmland block, before the level changed.
-    // <context.new_material> returns the MaterialTag the farmland block is changing to.
+    // <context.location> returns the LocationTag of the farmland block.
+    // <context.material> returns the MaterialTag of the farmland block that changed the moisture level.
     // <context.old_level> returns the ElementTag(Number) of the previous moisture level.
     // <context.new_level> returns the ElementTag(Number) of the new moisture level.
     //
@@ -47,7 +46,6 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     }
 
     public MoistureChangeEvent event;
-    public MaterialTag newMaterial;
     public LocationTag location;
     public Farmland oldFarmland;
     public Farmland newFarmland;
@@ -70,8 +68,7 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
     public ObjectTag getContext(String name) {
         return switch (name) {
             case "location" -> location;
-            case "old_material" -> new MaterialTag(event.getBlock().getBlockData());
-            case "new_material" -> newMaterial;
+            case "material" -> new MaterialTag(event.getBlock().getBlockData());
             case "old_level" -> new ElementTag(oldFarmland.getMoisture());
             case "new_level" -> new ElementTag(newFarmland.getMoisture());
             default -> super.getContext(name);
@@ -83,7 +80,6 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
         location = new LocationTag(event.getBlock().getLocation());
         oldFarmland = (Farmland) event.getBlock().getBlockData();
         newFarmland = (Farmland) event.getNewState().getBlockData();
-        newMaterial = new MaterialTag(newFarmland);
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/MoistureChangeScriptEvent.java
@@ -57,9 +57,6 @@ public class MoistureChangeScriptEvent extends BukkitScriptEvent implements List
         if (!runInCheck(path, location)) {
             return false;
         }
-        if (!path.tryArgObject(0, newMaterial)) {
-            return false;
-        }
         if (!path.checkSwitch("from", String.valueOf(oldFarmland.getMoisture()))) {
             return false;
         }


### PR DESCRIPTION
This PR adds the `MoistureChangeEvent` as `farmland moisture level changes` Denizen event with following contexts and switches:

### Context
`<context.location>` returns the LocationTag of the farmland.
`<context.material>` returns the MaterialTag of the farmland.
`<context.old_level>` returns the ElementTag of the previous moisture level.
`<context.new_level>` returns the ElementTag of the new moisture level.

### Switches
`from:<level>` to only process the event when the previous moisture level matches the input.
`to:<level>` to only process the event when the new moisture level matches the input.