### PR TITLE
Fix: Paper deprecation warning on BellRingEvent

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -30,7 +30,9 @@ public class PaperModule {
         // Events
         ScriptEvent.registerScriptEvent(AnvilBlockDamagedScriptEvent.class);
         ScriptEvent.registerScriptEvent(AreaEnterExitScriptEventPaperImpl.class);
-        ScriptEvent.registerScriptEvent(BellRingScriptEvent.class);
+        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_18)) {
+            ScriptEvent.registerScriptEvent(BellRingScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(BlockPreDispenseScriptEvent.class);
         ScriptEvent.registerScriptEvent(CreeperIgnitesScriptEvent.class);
         ScriptEvent.registerScriptEvent(EntityAddToWorldScriptEvent.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BellRingScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BellRingScriptEvent.java
@@ -12,27 +12,6 @@ import org.bukkit.event.Listener;
 
 public class BellRingScriptEvent extends BukkitScriptEvent implements Listener {
 
-    // <--[event]
-    // @Events
-    // bell rings
-    //
-    // @Location true
-    //
-    // @Plugin Paper
-    //
-    // @Group Paper
-    //
-    // @Cancellable true
-    //
-    // @Triggers when a bell block rings.
-    //
-    // @Context
-    // <context.entity> returns the entity that rung the bell, if any.
-    // <context.location> returns the location of the bell being rung.
-    //
-    // @Player when the ringing entity is a player.
-    //
-    // -->
 
     public BellRingScriptEvent() {
         registerCouldMatcher("bell rings");

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/BellRingScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/BellRingScriptEvent.java
@@ -37,7 +37,7 @@ public class BellRingScriptEvent extends BukkitScriptEvent implements Listener {
     public ObjectTag getContext(String name) {
         switch (name) {
             case "entity":
-                return event.getEntity() == null ? null : new EntityTag(event.getEntity());
+                return event.getEntity() == null ? null : new EntityTag(event.getEntity()).getDenizenObject();
             case "location": return location;
         }
         return super.getContext(name);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/ScriptEventRegistry.java
@@ -61,6 +61,9 @@ public class ScriptEventRegistry {
         ScriptEvent.notNameParts.add(0, "SpigotImpl");
 
         // Block events
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            ScriptEvent.registerScriptEvent(BellRingScriptEvent.class);
+        }
         ScriptEvent.registerScriptEvent(BlockBuiltScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockBurnsScriptEvent.class);
         ScriptEvent.registerScriptEvent(BlockCooksSmeltsItemScriptEvent.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BellRingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BellRingScriptEvent.java
@@ -28,7 +28,7 @@ public class BellRingScriptEvent extends BukkitScriptEvent implements Listener {
     // @Context
     // <context.entity> returns the EntityTag that rung the bell, if any.
     // <context.location> returns the LocationTag of the bell being rung.
-    // <context.direction> returns the ElementTag of the direction the bell was rung. Available only on MC 1.19+.
+    // <context.direction> returns the ElementTag of the direction the bell was rung in. Can be "north", "west", "south", "east". Available only on MC 1.19+.
     //
     // @Player when the ringing entity is a player.
     //

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BellRingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BellRingScriptEvent.java
@@ -57,7 +57,7 @@ public class BellRingScriptEvent extends BukkitScriptEvent implements Listener {
     @Override
     public ObjectTag getContext(String name) {
         return switch (name) {
-            case "entity" -> event.getEntity() == null ? null : new EntityTag(event.getEntity());
+            case "entity" -> event.getEntity() == null ? null : new EntityTag(event.getEntity()).getDenizenObject();
             case "location" -> location;
             case "direction" -> new ElementTag(event.getDirection());
             default -> super.getContext(name);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BellRingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BellRingScriptEvent.java
@@ -1,0 +1,73 @@
+package com.denizenscript.denizen.events.block;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BellRingEvent;
+
+public class BellRingScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // bell rings
+    //
+    // @Location true
+    //
+    // @Group Block
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a bell block rings. (Requires Paper on versions lower than 1.19)
+    //
+    // @Context
+    // <context.entity> returns the EntityTag that rung the bell, if any.
+    // <context.location> returns the LocationTag of the bell being rung.
+    // <context.direction> returns the ElementTag of the direction the bell was rung. Available only on MC 1.19+.
+    //
+    // @Player when the ringing entity is a player.
+    //
+    // -->
+
+    public BellRingScriptEvent() {
+        registerCouldMatcher("bell rings");
+    }
+
+    public BellRingEvent event;
+    public LocationTag location;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, location)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getEntity());
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        return switch (name) {
+            case "entity" -> event.getEntity() == null ? null : new EntityTag(event.getEntity());
+            case "location" -> location;
+            case "direction" -> new ElementTag(event.getDirection());
+            default -> super.getContext(name);
+        };
+    }
+
+    @EventHandler
+    public void bellRingEvent(BellRingEvent event) {
+        this.event = event;
+        location = new LocationTag(event.getBlock().getLocation());
+        fire(event);
+    }
+}


### PR DESCRIPTION
This PR fixes the paper deprecation warning by registering the Spigot event on versions 1.19+ and still using the Paper event on versions lower than 1.19, since the event was added by Spigot on 1.19.

It also adds the `<context.direction>` tag that returns the ElementTag of the direction the bell was rung. Available only on MC 1.19+.

Reported by Maxime on Discord. 
discord://discord.com/channels/315163488085475337/1261389727576227840/1261389727576227840