### PR TITLE
`PlayerTag.stop_sound`: input consistency

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 
 public abstract class PlayerHelper {
 
-    public abstract void stopSound(Player player, String sound, SoundCategory category); // TODO: remove the category param once 1.19 is the minimum version
+    public abstract void stopSound(Player player, NamespacedKey sound, SoundCategory category); // TODO: remove the category param once 1.19 is the minimum version
 
     public abstract FakeEntity sendEntitySpawn(List<PlayerTag> players, DenizenEntityType entityType, LocationTag location, ArrayList<Mechanism> mechanisms, int customId, UUID customUUID, boolean autoTrack);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -3944,7 +3944,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // -->
         if (mechanism.matches("stop_sound")) {
             SoundCategory category = null;
-            String key = null;
+            NamespacedKey key = null;
             if (mechanism.hasValue()) {
                 if (mechanism.getValue().matchesEnum(SoundCategory.class)) {
                     category = mechanism.getValue().asEnum(SoundCategory.class);
@@ -3954,7 +3954,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
                     }
                 }
                 else {
-                    key = mechanism.getValue().asString();
+                    key = Utilities.parseNamespacedKey(mechanism.getValue().asString());
                 }
             }
             NMSHandler.playerHelper.stopSound(getPlayerEntity(), key, category);

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/PlayerHelperImpl.java
@@ -47,6 +47,7 @@ import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.boss.CraftBossBar;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_17_R1.util.CraftNamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -78,8 +79,8 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public void stopSound(Player player, String sound, SoundCategory category) {
-        ResourceLocation soundKey = sound == null ? null : new ResourceLocation(sound);
+    public void stopSound(Player player, NamespacedKey sound, SoundCategory category) {
+        ResourceLocation soundKey = sound == null ? null : CraftNamespacedKey.toMinecraft(sound);
         net.minecraft.sounds.SoundSource nmsCategory = category == null ? null : net.minecraft.sounds.SoundSource.valueOf(category.name());
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(soundKey, nmsCategory));
     }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/PlayerHelperImpl.java
@@ -56,6 +56,7 @@ import org.bukkit.craftbukkit.v1_18_R2.boss.CraftBossBar;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_18_R2.util.CraftNamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -87,8 +88,8 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public void stopSound(Player player, String sound, SoundCategory category) {
-        ResourceLocation soundKey = sound == null ? null : new ResourceLocation(sound);
+    public void stopSound(Player player, NamespacedKey sound, SoundCategory category) {
+        ResourceLocation soundKey = sound == null ? null : CraftNamespacedKey.toMinecraft(sound);
         net.minecraft.sounds.SoundSource nmsCategory = category == null ? null : net.minecraft.sounds.SoundSource.valueOf(category.name());
         ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(soundKey, nmsCategory));
     }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/PlayerHelperImpl.java
@@ -63,6 +63,7 @@ import org.bukkit.craftbukkit.v1_19_R3.boss.CraftBossBar;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_19_R3.util.CraftNamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -94,8 +95,8 @@ public class PlayerHelperImpl extends PlayerHelper {
     }
 
     @Override
-    public void stopSound(Player player, String sound, SoundCategory category) {
-        ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(sound == null ? null : new ResourceLocation(sound), null));
+    public void stopSound(Player player, NamespacedKey sound, SoundCategory category) {
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(sound == null ? null : CraftNamespacedKey.toMinecraft(sound), null));
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/PlayerHelperImpl.java
@@ -64,6 +64,7 @@ import org.bukkit.craftbukkit.v1_20_R4.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_20_R4.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_20_R4.util.CraftNamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -85,8 +86,8 @@ public class PlayerHelperImpl extends PlayerHelper {
     public static final EntityDataAccessor<Byte> PLAYER_DATA_ACCESSOR_SKINLAYERS = ReflectionHelper.getFieldValue(net.minecraft.world.entity.player.Player.class, ReflectionMappingsInfo.Player_DATA_PLAYER_MODE_CUSTOMISATION, null);
 
     @Override
-    public void stopSound(Player player, String sound, SoundCategory category) {
-        ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(sound == null ? null : new ResourceLocation(sound), null));
+    public void stopSound(Player player, NamespacedKey sound, SoundCategory category) {
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(sound == null ? null : CraftNamespacedKey.toMinecraft(sound), null));
     }
 
     @Override

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PlayerHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PlayerHelperImpl.java
@@ -64,6 +64,7 @@ import org.bukkit.craftbukkit.v1_21_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_21_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_21_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_21_R1.util.CraftNamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -85,8 +86,8 @@ public class PlayerHelperImpl extends PlayerHelper {
     public static final EntityDataAccessor<Byte> PLAYER_DATA_ACCESSOR_SKINLAYERS = ReflectionHelper.getFieldValue(net.minecraft.world.entity.player.Player.class, ReflectionMappingsInfo.Player_DATA_PLAYER_MODE_CUSTOMISATION, null);
 
     @Override
-    public void stopSound(Player player, String sound, SoundCategory category) {
-        ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(sound == null ? null : ResourceLocation.withDefaultNamespace(sound), null));
+    public void stopSound(Player player, NamespacedKey sound, SoundCategory category) {
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundStopSoundPacket(sound == null ? null : CraftNamespacedKey.toMinecraft(sound), null));
     }
 
     @Override


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1276389069470957571).

## Changes

- `PlayerHelper#stopSound` now takes in a `NamespacedKey` instead of a `String` for the sound key.
- `PlayerTag.stop_sound` now properly uses `Utilities#parseNamespacedKey`, to have consistent input with other features.