### PR TITLE
Biomes: proper key handling with `NamespacedKey`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/BukkitScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/BukkitScriptEvent.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.scripts.containers.core.InventoryScriptHelper;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
 import com.denizenscript.denizen.tags.BukkitTagContext;
 import com.denizenscript.denizen.utilities.NotedAreaTracker;
+import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
@@ -725,7 +726,7 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
             }
             else if (lower.startsWith("biome:")) {
                 String biome = inputText.substring("biome:".length());
-                return runGenericCheck(biome, new LocationTag(location).getBiome().name);
+                return runGenericCheck(biome, Utilities.namespacedKeyToString(new LocationTag(location).getBiome().getKey()));
             }
         }
         if (lower.equals("cuboid")) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/BiomeEnterExitScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/BiomeEnterExitScriptEvent.java
@@ -78,10 +78,11 @@ public class BiomeEnterExitScriptEvent extends BukkitScriptEvent implements List
         if (biome == null) {
             return false;
         }
-        if (!biome_test.equals("biome") && !biome_test.equals(CoreUtilities.toLowerCase(biome.getBiome().getName()))) {
+        String biomeKey = Utilities.namespacedKeyToString(biome.getBiome().getKey());
+        if (!biome_test.equals("biome") && !biome_test.equals(biomeKey)) {
             return false;
         }
-        if (!runGenericSwitchCheck(path, "biome", biome.getBiome().getName())) {
+        if (!runGenericSwitchCheck(path, "biome", biomeKey)) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.boss.BossBar;
@@ -110,10 +111,10 @@ public abstract class NMSHandler {
         throw new UnsupportedOperationException();
     }
 
-    public abstract BiomeNMS getBiomeNMS(World world, String name);
+    public abstract BiomeNMS getBiomeNMS(World world, NamespacedKey key);
 
     public BiomeNMS getBiomeAt(Block block) {
-        return NMSHandler.instance.getBiomeNMS(block.getWorld(), block.getBiome().name());
+        return NMSHandler.instance.getBiomeNMS(block.getWorld(), block.getBiome().getKey());
     }
 
     public abstract double[] getRecentTps();

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
@@ -1,7 +1,6 @@
 package com.denizenscript.denizen.nms.abstracts;
 
 import com.denizenscript.denizencore.objects.core.ColorTag;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/BiomeNMS.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.nms.abstracts;
 import com.denizenscript.denizencore.objects.core.ColorTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
@@ -12,17 +13,17 @@ import java.util.List;
 
 public abstract class BiomeNMS {
 
-    public String name;
+    public NamespacedKey key;
 
     public World world;
 
-    public BiomeNMS(World world, String name) {
+    public BiomeNMS(World world, NamespacedKey key) {
         this.world = world;
-        this.name = CoreUtilities.toLowerCase(name);
+        this.key = key;
     }
 
-    public String getName() {
-        return name;
+    public NamespacedKey getKey() {
+        return key;
     }
 
     public DownfallType getDownfallType() {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/BiomeTag.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.nms.abstracts.BiomeNMS;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
@@ -78,7 +79,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
             }
             world = worldTag.getWorld();
         }
-        BiomeNMS biome = NMSHandler.instance.getBiomeNMS(world, biomeName);
+        BiomeNMS biome = NMSHandler.instance.getBiomeNMS(world, Utilities.parseNamespacedKey(biomeName));
         if (biome == null) {
             return null;
         }
@@ -97,14 +98,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
     /////////////
 
     public BiomeTag(Biome biome) {
-        String key;
-        if (biome.getKey().getNamespace().equals("minecraft")) {
-            key = biome.getKey().getKey();
-        }
-        else {
-            key = biome.getKey().toString();
-        }
-        this.biome = NMSHandler.instance.getBiomeNMS(Bukkit.getWorlds().get(0), key);
+        this.biome = NMSHandler.instance.getBiomeNMS(Bukkit.getWorlds().get(0), biome.getKey());
     }
 
     public BiomeTag(BiomeNMS biome) {
@@ -135,7 +129,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
 
     @Override
     public String identify() {
-        return "b@" + biome.world.getName() + "," + biome.getName();
+        return "b@" + biome.world.getName() + "," + Utilities.namespacedKeyToString(biome.getKey());
     }
 
     @Override
@@ -158,7 +152,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
 
     @Override
     public AbstractFlagTracker getFlagTracker() {
-        return new RedirectionFlagTracker(DenizenCore.serverFlagMap, "__biomes." + biome.getName().replace(".", "&dot"));
+        return new RedirectionFlagTracker(DenizenCore.serverFlagMap, "__biomes." + Utilities.namespacedKeyToString(biome.getKey()).replace(".", "&dot"));
     }
 
     @Override
@@ -200,7 +194,7 @@ public class BiomeTag implements ObjectTag, Adjustable, FlaggableObject {
         // - narrate "You are currently in a <biome[plains].name> biome!"
         // -->
         tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
-            return new ElementTag(CoreUtilities.toLowerCase(object.biome.getName()));
+            return new ElementTag(Utilities.namespacedKeyToString(object.biome.getKey()), true);
         });
 
         // <--[tag]

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
@@ -46,6 +46,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
@@ -57,6 +58,7 @@ import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_17_R1.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_17_R1.util.CraftNamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -234,14 +236,14 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) world).getHandle();
         ArrayList<BiomeNMS> output = new ArrayList<>();
         for (Map.Entry<ResourceKey<Biome>, Biome> pair : level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).entrySet()) {
-            output.add(new BiomeNMSImpl(level, pair.getKey().location().toString()));
+            output.add(new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(pair.getKey().location())));
         }
         return output;
     }
 
     @Override
-    public BiomeNMS getBiomeNMS(World world, String name) {
-        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), name);
+    public BiomeNMS getBiomeNMS(World world, NamespacedKey key) {
+        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), key);
         if (impl.biomeBase == null) {
             return null;
         }
@@ -254,8 +256,7 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) block.getWorld()).getHandle();
         Biome biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getKey(biome);
-        String keyText = key.getNamespace().equals("minecraft") ? key.getPath() : key.toString();
-        return new BiomeNMSImpl(level, keyText);
+        return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
     }
 
     @Override

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/BiomeNMSImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/impl/BiomeNMSImpl.java
@@ -7,7 +7,6 @@ import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.MobCategory;
@@ -15,8 +14,10 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_17_R1.util.CraftNamespacedKey;
 import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
@@ -30,10 +31,10 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     public ServerLevel world;
 
-    public BiomeNMSImpl(ServerLevel world, String name) {
-        super(world.getWorld(), name);
+    public BiomeNMSImpl(ServerLevel world, NamespacedKey key) {
+        super(world.getWorld(), key);
         this.world = world;
-        biomeBase = world.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).get(new ResourceLocation(name));
+        biomeBase = world.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).get(CraftNamespacedKey.toMinecraft(key));
     }
 
     @Override
@@ -170,7 +171,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     @Override
     public void setTo(Block block) {
         if (((CraftWorld) block.getWorld()).getHandle() != this.world) {
-            NMSHandler.instance.getBiomeNMS(block.getWorld(), getName()).setTo(block);
+            NMSHandler.instance.getBiomeNMS(block.getWorld(), getKey()).setTo(block);
             return;
         }
         // Based on CraftWorld source

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
@@ -2,7 +2,10 @@ package com.denizenscript.denizen.nms.v1_18;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.abstracts.*;
+import com.denizenscript.denizen.nms.abstracts.BiomeNMS;
+import com.denizenscript.denizen.nms.abstracts.BlockLight;
+import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
+import com.denizenscript.denizen.nms.abstracts.Sidebar;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
@@ -48,6 +51,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
@@ -60,6 +64,7 @@ import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_18_R2.util.CraftNamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
@@ -254,14 +259,14 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) world).getHandle();
         ArrayList<BiomeNMS> output = new ArrayList<>();
         for (Map.Entry<ResourceKey<Biome>, Biome> pair : level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).entrySet()) {
-            output.add(new BiomeNMSImpl(level, pair.getKey().location().toString()));
+            output.add(new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(pair.getKey().location())));
         }
         return output;
     }
 
     @Override
-    public BiomeNMS getBiomeNMS(World world, String name) {
-        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), name);
+    public BiomeNMS getBiomeNMS(World world, NamespacedKey key) {
+        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), key);
         if (impl.biomeBase == null) {
             return null;
         }
@@ -274,8 +279,7 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) block.getWorld()).getHandle();
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getKey(biome.value());
-        String keyText = key.getNamespace().equals("minecraft") ? key.getPath() : key.toString();
-        return new BiomeNMSImpl(level, keyText);
+        return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/BiomeNMSImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/impl/BiomeNMSImpl.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.MobCategory;
@@ -17,8 +16,10 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_18_R2.util.CraftNamespacedKey;
 import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
@@ -32,10 +33,10 @@ public class BiomeNMSImpl extends BiomeNMS {
 
     public ServerLevel world;
 
-    public BiomeNMSImpl(ServerLevel world, String name) {
-        super(world.getWorld(), name);
+    public BiomeNMSImpl(ServerLevel world, NamespacedKey key) {
+        super(world.getWorld(), key);
         this.world = world;
-        biomeBase = world.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getHolder(ResourceKey.create(Registry.BIOME_REGISTRY, new ResourceLocation(name))).orElse(null);
+        biomeBase = world.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getHolder(ResourceKey.create(Registry.BIOME_REGISTRY, CraftNamespacedKey.toMinecraft(key))).orElse(null);
     }
 
     @Override
@@ -160,7 +161,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     @Override
     public void setTo(Block block) {
         if (((CraftWorld) block.getWorld()).getHandle() != this.world) {
-            NMSHandler.instance.getBiomeNMS(block.getWorld(), getName()).setTo(block);
+            NMSHandler.instance.getBiomeNMS(block.getWorld(), getKey()).setTo(block);
             return;
         }
         // Based on CraftWorld source

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
@@ -2,7 +2,10 @@ package com.denizenscript.denizen.nms.v1_19;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.abstracts.*;
+import com.denizenscript.denizen.nms.abstracts.BiomeNMS;
+import com.denizenscript.denizen.nms.abstracts.BlockLight;
+import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
+import com.denizenscript.denizen.nms.abstracts.Sidebar;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
@@ -49,6 +52,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.boss.BossBar;
@@ -63,6 +67,7 @@ import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R3.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_19_R3.util.CraftNamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
@@ -258,14 +263,14 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) world).getHandle();
         ArrayList<BiomeNMS> output = new ArrayList<>();
         for (Map.Entry<ResourceKey<Biome>, Biome> pair : level.registryAccess().registryOrThrow(Registries.BIOME).entrySet()) {
-            output.add(new BiomeNMSImpl(level, pair.getKey().location().toString()));
+            output.add(new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(pair.getKey().location())));
         }
         return output;
     }
 
     @Override
-    public BiomeNMS getBiomeNMS(World world, String name) {
-        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), name);
+    public BiomeNMS getBiomeNMS(World world, NamespacedKey key) {
+        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), key);
         if (impl.biomeHolder == null) {
             return null;
         }
@@ -278,8 +283,7 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) block.getWorld()).getHandle();
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome.value());
-        String keyText = key.getNamespace().equals("minecraft") ? key.getPath() : key.toString();
-        return new BiomeNMSImpl(level, keyText);
+        return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/BiomeNMSImpl.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.MobCategory;
@@ -18,9 +17,11 @@ import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftLocation;
+import org.bukkit.craftbukkit.v1_19_R3.util.CraftNamespacedKey;
 import org.bukkit.entity.EntityType;
 
 import java.lang.invoke.MethodHandle;
@@ -36,10 +37,10 @@ public class BiomeNMSImpl extends BiomeNMS {
     public Holder<Biome> biomeHolder;
     public ServerLevel world;
 
-    public BiomeNMSImpl(ServerLevel world, String name) {
-        super(world.getWorld(), name);
+    public BiomeNMSImpl(ServerLevel world, NamespacedKey key) {
+        super(world.getWorld(), key);
         this.world = world;
-        biomeHolder = world.registryAccess().registryOrThrow(Registries.BIOME).getHolder(ResourceKey.create(Registries.BIOME, new ResourceLocation(name))).orElse(null);
+        biomeHolder = world.registryAccess().registryOrThrow(Registries.BIOME).getHolder(ResourceKey.create(Registries.BIOME, CraftNamespacedKey.toMinecraft(key))).orElse(null);
     }
 
     @Override
@@ -185,7 +186,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     @Override
     public void setTo(Block block) {
         if (((CraftWorld) block.getWorld()).getHandle() != this.world) {
-            NMSHandler.instance.getBiomeNMS(block.getWorld(), getName()).setTo(block);
+            NMSHandler.instance.getBiomeNMS(block.getWorld(), getKey()).setTo(block);
             return;
         }
         // Based on CraftWorld source

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
@@ -2,7 +2,10 @@ package com.denizenscript.denizen.nms.v1_20;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.abstracts.*;
+import com.denizenscript.denizen.nms.abstracts.BiomeNMS;
+import com.denizenscript.denizen.nms.abstracts.BlockLight;
+import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
+import com.denizenscript.denizen.nms.abstracts.Sidebar;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
@@ -47,7 +50,6 @@ import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.TagParser;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
@@ -62,6 +64,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.boss.BossBar;
@@ -79,6 +82,7 @@ import org.bukkit.craftbukkit.v1_20_R4.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftLocation;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_20_R4.util.CraftNamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
@@ -308,14 +312,14 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) world).getHandle();
         ArrayList<BiomeNMS> output = new ArrayList<>();
         for (Map.Entry<ResourceKey<Biome>, Biome> pair : level.registryAccess().registryOrThrow(Registries.BIOME).entrySet()) {
-            output.add(new BiomeNMSImpl(level, pair.getKey().location().toString()));
+            output.add(new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(pair.getKey().location())));
         }
         return output;
     }
 
     @Override
-    public BiomeNMS getBiomeNMS(World world, String name) {
-        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), name);
+    public BiomeNMS getBiomeNMS(World world, NamespacedKey key) {
+        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), key);
         if (impl.biomeHolder == null) {
             return null;
         }
@@ -328,8 +332,7 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) block.getWorld()).getHandle();
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome.value());
-        String keyText = key.getNamespace().equals("minecraft") ? key.getPath() : key.toString();
-        return new BiomeNMSImpl(level, keyText);
+        return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
     }
 
     @Override

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/BiomeNMSImpl.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.MobCategory;
@@ -18,10 +17,12 @@ import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R4.entity.CraftEntityType;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftLocation;
+import org.bukkit.craftbukkit.v1_20_R4.util.CraftNamespacedKey;
 import org.bukkit.entity.EntityType;
 
 import java.lang.invoke.MethodHandle;
@@ -36,10 +37,10 @@ public class BiomeNMSImpl extends BiomeNMS {
     public Holder<Biome> biomeHolder;
     public ServerLevel world;
 
-    public BiomeNMSImpl(ServerLevel world, String name) {
-        super(world.getWorld(), name);
+    public BiomeNMSImpl(ServerLevel world, NamespacedKey key) {
+        super(world.getWorld(), key);
         this.world = world;
-        biomeHolder = world.registryAccess().registryOrThrow(Registries.BIOME).getHolder(ResourceKey.create(Registries.BIOME, new ResourceLocation(name))).orElse(null);
+        biomeHolder = world.registryAccess().registryOrThrow(Registries.BIOME).getHolder(ResourceKey.create(Registries.BIOME, CraftNamespacedKey.toMinecraft(key))).orElse(null);
     }
 
     @Override
@@ -175,7 +176,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     @Override
     public void setTo(Block block) {
         if (((CraftWorld) block.getWorld()).getHandle() != this.world) {
-            NMSHandler.instance.getBiomeNMS(block.getWorld(), getName()).setTo(block);
+            NMSHandler.instance.getBiomeNMS(block.getWorld(), getKey()).setTo(block);
             return;
         }
         // Based on CraftWorld source

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
@@ -2,7 +2,10 @@ package com.denizenscript.denizen.nms.v1_21;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.abstracts.*;
+import com.denizenscript.denizen.nms.abstracts.BiomeNMS;
+import com.denizenscript.denizen.nms.abstracts.BlockLight;
+import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
+import com.denizenscript.denizen.nms.abstracts.Sidebar;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
@@ -47,7 +50,6 @@ import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.TagParser;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -61,6 +63,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.boss.BossBar;
@@ -78,6 +81,7 @@ import org.bukkit.craftbukkit.v1_21_R1.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftLocation;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_21_R1.util.CraftNamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
@@ -306,15 +310,15 @@ public class Handler extends NMSHandler {
     public List<BiomeNMS> getBiomes(World world) {
         ServerLevel level = ((CraftWorld) world).getHandle();
         ArrayList<BiomeNMS> output = new ArrayList<>();
-        for (Map.Entry<ResourceKey<Biome>, Biome> pair : level.registryAccess().registryOrThrow(Registries.BIOME).entrySet()) {
-            output.add(new BiomeNMSImpl(level, pair.getKey().location().toString()));
+        for (ResourceLocation key : level.registryAccess().registryOrThrow(Registries.BIOME).keySet()) {
+            output.add(new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key)));
         }
         return output;
     }
 
     @Override
-    public BiomeNMS getBiomeNMS(World world, String name) {
-        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), name);
+    public BiomeNMS getBiomeNMS(World world, NamespacedKey key) {
+        BiomeNMSImpl impl = new BiomeNMSImpl(((CraftWorld) world).getHandle(), key);
         if (impl.biomeHolder == null) {
             return null;
         }
@@ -327,8 +331,7 @@ public class Handler extends NMSHandler {
         ServerLevel level = ((CraftWorld) block.getWorld()).getHandle();
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome.value());
-        String keyText = key.getNamespace().equals("minecraft") ? key.getPath() : key.toString();
-        return new BiomeNMSImpl(level, keyText);
+        return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
     }
 
     @Override

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/BiomeNMSImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/BiomeNMSImpl.java
@@ -18,10 +18,12 @@ import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_21_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R1.entity.CraftEntityType;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftLocation;
+import org.bukkit.craftbukkit.v1_21_R1.util.CraftNamespacedKey;
 import org.bukkit.entity.EntityType;
 
 import java.lang.invoke.MethodHandle;
@@ -36,10 +38,10 @@ public class BiomeNMSImpl extends BiomeNMS {
     public Holder<Biome> biomeHolder;
     public ServerLevel world;
 
-    public BiomeNMSImpl(ServerLevel world, String name) {
-        super(world.getWorld(), name);
+    public BiomeNMSImpl(ServerLevel world, NamespacedKey key) {
+        super(world.getWorld(), key);
         this.world = world;
-        biomeHolder = world.registryAccess().registryOrThrow(Registries.BIOME).getHolder(ResourceKey.create(Registries.BIOME, ResourceLocation.withDefaultNamespace(name))).orElse(null);
+        biomeHolder = world.registryAccess().registryOrThrow(Registries.BIOME).getHolder(ResourceKey.create(Registries.BIOME, CraftNamespacedKey.toMinecraft(key))).orElse(null);
     }
 
     @Override
@@ -175,7 +177,7 @@ public class BiomeNMSImpl extends BiomeNMS {
     @Override
     public void setTo(Block block) {
         if (((CraftWorld) block.getWorld()).getHandle() != this.world) {
-            NMSHandler.instance.getBiomeNMS(block.getWorld(), getName()).setTo(block);
+            NMSHandler.instance.getBiomeNMS(block.getWorld(), getKey()).setTo(block);
             return;
         }
         // Based on CraftWorld source

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/BiomeNMSImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/BiomeNMSImpl.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.MobCategory;


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1273670987623305316).

## Changes

- `BiomeNMS` now stores a `NamespacedKey key` instead of a `String name`, for proper biome key handling/parsing.
- `BiomeNMS#getName` has been replaced by `getKey`.
- All relevant places changed to take/use `NamespacedKey`s instead of `String`s, with `Utilities#namespacedKeyToString` to stringify where needed & `CraftNamespacedKey` for NMS conversions.

> [!NOTE]
> Might be a good idea to have a cache of `Utilities#namespacedKeyToString` on `BiomeNMS`, just because it's used a bunch to get the "display name"? it's not a particularly heavy operation or anything though, so lmk what do you think.