### PR TITLE
`ItemTag.is_waxed` property

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -245,6 +245,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(ItemRepairCost.class, ItemTag.class);
         PropertyParser.registerProperty(ItemScript.class, ItemTag.class);
         PropertyParser.registerProperty(ItemSignContents.class, ItemTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            PropertyParser.registerProperty(ItemSignIsWaxed.class, ItemTag.class);
+        }
         PropertyParser.registerProperty(ItemSkullskin.class, ItemTag.class);
         PropertyParser.registerProperty(ItemSpawnerCount.class, ItemTag.class);
         PropertyParser.registerProperty(ItemSpawnerDelay.class, ItemTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSignIsWaxed.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSignIsWaxed.java
@@ -1,0 +1,55 @@
+package com.denizenscript.denizen.objects.properties.item;
+
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.Tag;
+import org.bukkit.block.Sign;
+import org.bukkit.inventory.meta.BlockStateMeta;
+
+public class ItemSignIsWaxed extends ItemProperty<ElementTag> {
+
+    // <--[property]
+    // @object ItemTag
+    // @name is_waxed
+    // @input ElementTag(Boolean)
+    // @description
+    // Controls whether a sign item is waxed.
+    // @tag
+    // Will return null if the item doesn't have a waxed state set.
+    // -->
+
+    public static boolean describes(ItemTag item) {
+        return Tag.ALL_SIGNS.isTagged(item.getBukkitMaterial());
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        BlockStateMeta stateMeta = as(BlockStateMeta.class);
+        if (!stateMeta.hasBlockState()) {
+            return null;
+        }
+        return new ElementTag(((Sign) stateMeta.getBlockState()).isWaxed());
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (!mechanism.requireBoolean()) {
+            return;
+        }
+        editMeta(BlockStateMeta.class, stateMeta -> {
+            Sign sign = (Sign) stateMeta.getBlockState();
+            sign.setWaxed(value.asBoolean());
+            stateMeta.setBlockState(sign);
+        });
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "is_waxed";
+    }
+
+    public static void register() {
+        autoRegister("is_waxed", ItemSignIsWaxed.class, ElementTag.class, false);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSignIsWaxed.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSignIsWaxed.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.objects.properties.item;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.tags.Attribute;
 import org.bukkit.Tag;
 import org.bukkit.block.Sign;
 import org.bukkit.inventory.meta.BlockStateMeta;
@@ -15,8 +16,6 @@ public class ItemSignIsWaxed extends ItemProperty<ElementTag> {
     // @input ElementTag(Boolean)
     // @description
     // Controls whether a sign item is waxed (cannot be edited once placed).
-    // @tag
-    // Will return null if the item doesn't have a waxed state set.
     // -->
 
     public static boolean describes(ItemTag item) {
@@ -30,6 +29,12 @@ public class ItemSignIsWaxed extends ItemProperty<ElementTag> {
             return null;
         }
         return new ElementTag(((Sign) stateMeta.getBlockState()).isWaxed());
+    }
+
+    @Override
+    public ElementTag getTagValue(Attribute attribute) {
+        ElementTag value = getPropertyValue();
+        return value == null ? new ElementTag(false) : value;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSignIsWaxed.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemSignIsWaxed.java
@@ -14,7 +14,7 @@ public class ItemSignIsWaxed extends ItemProperty<ElementTag> {
     // @name is_waxed
     // @input ElementTag(Boolean)
     // @description
-    // Controls whether a sign item is waxed.
+    // Controls whether a sign item is waxed (cannot be edited once placed).
     // @tag
     // Will return null if the item doesn't have a waxed state set.
     // -->


### PR DESCRIPTION
## Additions

- `ItemTag.is_waxed` property - controls whether a sign item is waxed.

> [!NOTE]
> Not sure if the tag returning `null` when there isn't a `BlockState` is the best way to handle this? another option is have the tag return `false` and only have the property value actually return `null`, but then something like `<[item].with[is_waxed=<[item].is_waxed>]>` (adjusting the item to it's current value) would produce a different item, which isn't great either.

> [!NOTE]
> Could name it `waxed` to be consistent with the `LocationTag` mechanism? although `is_waxed` fits better here imo - let me know wdyt.