### PR TITLE
Properly deprecate `EntityTag.step_height`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -11,6 +11,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.data.BlockData;
@@ -445,11 +446,13 @@ public abstract class EntityHelper {
     }
 
     public float getStepHeight(Entity entity) {
-        throw new UnsupportedOperationException();
+        return entity instanceof LivingEntity livingEntity ? (float) livingEntity.getAttribute(Attribute.GENERIC_STEP_HEIGHT).getBaseValue() : 0;
     }
 
     public void setStepHeight(Entity entity, float stepHeight) {
-        throw new UnsupportedOperationException();
+        if (entity instanceof LivingEntity livingEntity) {
+            livingEntity.getAttribute(Attribute.GENERIC_STEP_HEIGHT).setBaseValue(stepHeight);
+        }
     }
 
     public List<Object> convertInternalEntityDataValues(Entity entity, MapTag internalData) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStepHeight.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStepHeight.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.tags.Attribute;
 
+@Deprecated(forRemoval = true)
 public class EntityStepHeight extends EntityProperty<ElementTag> {
 
     // <--[property]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStepHeight.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStepHeight.java
@@ -1,23 +1,22 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.tags.Attribute;
 
 public class EntityStepHeight extends EntityProperty<ElementTag> {
 
-    // TODO: 1.20.6: this can be controlled by an attribute now, can deprecate in favor of that & backsupport
     // <--[property]
     // @object EntityTag
     // @name step_height
     // @input ElementTag(Decimal)
+    // @deprecated Use the step height attribute on MC 1.20+.
     // @description
-    // Controls the entity's step height, which controls how many blocks can it walk over.
-    // As this is based on an internal value, it has some edge-cases, for example:
-    // - most (but not all) living entities can still step over 1 block tall things as usual, even if this is set to 0.
-    // - this doesn't apply to vehicles when the player is controlling them.
-    // Note that this also applies to things like getting pushed.
+    // Deprecated in favor of the step height attribute on MC 1.20+, see <@link language Attribute Modifiers>.
     // -->
 
     public static boolean describes(EntityTag entity) {
@@ -30,7 +29,18 @@ public class EntityStepHeight extends EntityProperty<ElementTag> {
     }
 
     @Override
+    public ElementTag getTagValue(Attribute attribute) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            BukkitImplDeprecations.entityStepHeight.warn(attribute.context);
+        }
+        return super.getTagValue(attribute);
+    }
+
+    @Override
     public void setPropertyValue(ElementTag param, Mechanism mechanism) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            BukkitImplDeprecations.entityStepHeight.warn(mechanism.context);
+        }
         if (mechanism.requireFloat()) {
             NMSHandler.entityHelper.setStepHeight(getEntity(), param.asFloat());
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -337,6 +337,10 @@ public class BukkitImplDeprecations {
     // Added 2024/02/19, deprecate officially by 2027.
     public static Warning lecternPage = new FutureWarning("lecternPage", "'LocationTag.lectern_page' is deprecated in favor of 'LocationTag.page'.");
 
+    // Added 2024/10/12
+    // Good candidate for bumping, as this is a niche feature only on 1.19+ that already had some issues
+    public static Warning entityStepHeight = new FutureWarning("entityStepHeight", "'EntityTag.step_height' is deprecated in favor of the step height attribute.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2023/10/29 without warning.


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1261031106489356298).

## Changes

- `EntityHelper#get/setStepHeight` now redirect to the step height attribute by default.
- `EntityTag.step_height` is now deprecated in favor of using the attribute.

## Additions

- `entityStepHeight` `FutureWarning`, for the `EntityTag.step_height` property being replaced by the attribute.