### PR TITLE
Cross-version `InventoryView` compatibility

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperEventHelpers.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperEventHelpers.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.paper;
 
 import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.scripts.containers.core.InventoryScriptContainer;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizencore.objects.core.ScriptTag;
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent;
 import org.bukkit.event.EventHandler;
@@ -11,7 +12,7 @@ public class PaperEventHelpers implements Listener {
 
     @EventHandler
     public void onRecipeBookClick(PlayerRecipeBookClickEvent event) {
-        InventoryTag inventory = InventoryTag.mirrorBukkitInventory(event.getPlayer().getOpenInventory().getTopInventory());
+        InventoryTag inventory = InventoryTag.mirrorBukkitInventory(InventoryViewUtil.getTopInventory(event.getPlayer().getOpenInventory()));
         if (inventory.getIdHolder() instanceof ScriptTag) {
             if (((InventoryScriptContainer) ((ScriptTag) inventory.getIdHolder()).getContainer()).gui) {
                 event.setCancelled(true);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/AnvilBlockDamagedScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/AnvilBlockDamagedScriptEvent.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.paper.events;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
@@ -91,7 +92,7 @@ public class AnvilBlockDamagedScriptEvent extends BukkitScriptEvent implements L
 
     @Override
     public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(event.getView().getPlayer());
+        return new BukkitScriptEntryData(InventoryViewUtil.getPlayer(event.getView()));
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/item/ItemRecipeFormedScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/item/ItemRecipeFormedScriptEvent.java
@@ -1,13 +1,14 @@
 package com.denizenscript.denizen.events.item;
 
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
@@ -68,7 +69,7 @@ public class ItemRecipeFormedScriptEvent extends BukkitScriptEvent implements Li
 
     @Override
     public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(EntityTag.getPlayerFrom(event.getView().getPlayer()), null);
+        return new BukkitScriptEntryData(EntityTag.getPlayerFrom(InventoryViewUtil.getPlayer(event.getView())), null);
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerDragsInInvScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerDragsInInvScriptEvent.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
@@ -112,8 +113,7 @@ public class PlayerDragsInInvScriptEvent extends BukkitScriptEvent implements Li
             case "item":
                 return item;
             case "clicked_inventory":
-                return InventoryTag.mirrorBukkitInventory(event.getView()
-                        .getInventory(event.getRawSlots().stream().findFirst().orElse(0)));
+                return InventoryTag.mirrorBukkitInventory(InventoryViewUtil.getInventory(event.getView(), event.getRawSlots().stream().findFirst().orElse(0)));
             case "drag_type":
                 return new ElementTag(event.getType());
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerSmithsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerSmithsItemScriptEvent.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import org.bukkit.entity.HumanEntity;
@@ -94,7 +95,7 @@ public class PlayerSmithsItemScriptEvent extends BukkitScriptEvent implements Li
 
     @EventHandler
     public void onCraftItem(SmithItemEvent event) {
-        HumanEntity humanEntity = event.getView().getPlayer();
+        HumanEntity humanEntity = InventoryViewUtil.getPlayer(event.getView());
         if (EntityTag.isNPC(humanEntity)) {
             return;
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/InventoryTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/InventoryTag.java
@@ -1,13 +1,17 @@
 package com.denizenscript.denizen.objects;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
 import com.denizenscript.denizen.scripts.containers.core.InventoryScriptContainer;
 import com.denizenscript.denizen.scripts.containers.core.InventoryScriptHelper;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
+import com.denizenscript.denizen.tags.BukkitTagContext;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.PaperAPITools;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizen.utilities.inventory.InventoryTrackerSystem;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizen.utilities.inventory.RecipeHelper;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
@@ -16,9 +20,6 @@ import com.denizenscript.denizencore.flags.AbstractFlagTracker;
 import com.denizenscript.denizencore.flags.FlaggableObject;
 import com.denizenscript.denizencore.flags.SavableMapFlagTracker;
 import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.abstracts.ImprovedOfflinePlayer;
-import com.denizenscript.denizen.tags.BukkitTagContext;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.MapTag;
@@ -32,8 +33,8 @@ import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.utilities.YamlConfiguration;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.citizensnpcs.api.CitizensAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
@@ -48,7 +49,10 @@ import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
 public class InventoryTag implements ObjectTag, Notable, Adjustable, FlaggableObject {
 
@@ -306,7 +310,7 @@ public class InventoryTag implements ObjectTag, Notable, Adjustable, FlaggableOb
                         case "workbench":
                             return player.getWorkbench();
                         case "crafting":
-                            Inventory opened = player.getPlayerEntity().getOpenInventory().getTopInventory();
+                            Inventory opened = InventoryViewUtil.getTopInventory(player.getPlayerEntity().getOpenInventory());
                             if (opened instanceof CraftingInventory) {
                                 return new InventoryTag(opened, player.getPlayerEntity());
                             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -19,6 +19,7 @@ import com.denizenscript.denizen.utilities.entity.BossBarHelper;
 import com.denizenscript.denizen.utilities.entity.FakeEntity;
 import com.denizenscript.denizen.utilities.entity.HideEntitiesHelper;
 import com.denizenscript.denizen.utilities.flags.PlayerFlagHandler;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizen.utilities.packets.DenizenPacketHandler;
 import com.denizenscript.denizen.utilities.packets.HideParticles;
 import com.denizenscript.denizen.utilities.packets.ItemChangeMessage;
@@ -358,9 +359,9 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
 
     public CraftingInventory getBukkitWorkbench() {
         if (isOnline()) {
-            if (getPlayerEntity().getOpenInventory().getType() == InventoryType.WORKBENCH
-                    || getPlayerEntity().getOpenInventory().getType() == InventoryType.CRAFTING) {
-                return (CraftingInventory) getPlayerEntity().getOpenInventory().getTopInventory();
+            if (InventoryViewUtil.getType(getPlayerEntity().getOpenInventory()) == InventoryType.WORKBENCH
+                    || InventoryViewUtil.getType(getPlayerEntity().getOpenInventory()) == InventoryType.CRAFTING) {
+                return (CraftingInventory) InventoryViewUtil.getTopInventory(getPlayerEntity().getOpenInventory());
             }
         }
         return null;
@@ -1538,7 +1539,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // inventory, this returns the player's inventory.
         // -->
         registerOnlineOnlyTag(InventoryTag.class, "open_inventory", (attribute, object) -> {
-            return InventoryTag.mirrorBukkitInventory(object.getPlayerEntity().getOpenInventory().getTopInventory());
+            return InventoryTag.mirrorBukkitInventory(InventoryViewUtil.getTopInventory(object.getPlayerEntity().getOpenInventory()));
         });
 
         // <--[tag]
@@ -1562,8 +1563,8 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Returns the index of the trade the player is currently viewing, if any.
         // -->
         registerOnlineOnlyTag(ElementTag.class, "selected_trade_index", (attribute, object) -> {
-            if (object.getPlayerEntity().getOpenInventory().getTopInventory() instanceof MerchantInventory) {
-                return new ElementTag(((MerchantInventory) object.getPlayerEntity().getOpenInventory().getTopInventory())
+            if (InventoryViewUtil.getTopInventory(object.getPlayerEntity().getOpenInventory()) instanceof MerchantInventory) {
+                return new ElementTag(((MerchantInventory) InventoryViewUtil.getTopInventory(object.getPlayerEntity().getOpenInventory()))
                         .getSelectedRecipeIndex() + 1);
             }
             return null;
@@ -1577,7 +1578,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // This is almost completely broke and only works if the player has placed items in the trade slots.
         //
         registerOnlineOnlyTag(TradeTag.class, "selected_trade", (attribute, object) -> {
-            Inventory playerInventory = object.getPlayerEntity().getOpenInventory().getTopInventory();
+            Inventory playerInventory = InventoryViewUtil.getTopInventory(object.getPlayerEntity().getOpenInventory());
             if (playerInventory instanceof MerchantInventory && ((MerchantInventory) playerInventory).getSelectedRecipe() != null) {
                 return new TradeTag(((MerchantInventory) playerInventory).getSelectedRecipe()).duplicate();
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/FakeItemCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/FakeItemCommand.java
@@ -1,20 +1,21 @@
 package com.denizenscript.denizen.scripts.commands.item;
 
-import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizen.utilities.command.TabCompleteHelper;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.command.TabCompleteHelper;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
+import com.denizenscript.denizen.utilities.inventory.SlotHelper;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.*;
+import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.scheduling.OneTimeSchedulable;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.CraftingInventory;
@@ -138,15 +139,15 @@ public class FakeItemCommand extends AbstractCommand {
                 final Player ent = player.getPlayerEntity();
                 final int translated = raw ? slot : translateSlot(ent, slot);
                 final InventoryView view = ent.getOpenInventory();
-                final Inventory top = view.getTopInventory();
+                final Inventory top = InventoryViewUtil.getTopInventory(view);
                 NMSHandler.packetHelper.setSlot(ent, translated, item.getItemStack(), false);
                 if (duration.getSeconds() > 0) {
                     DenizenCore.schedule(new OneTimeSchedulable(() -> {
                         if (!ent.isOnline()) {
                             return;
                         }
-                        if (top == view.getTopInventory()) {
-                            ItemStack original = view.getItem(translated);
+                        if (top == InventoryViewUtil.getTopInventory(view)) {
+                            ItemStack original = InventoryViewUtil.getItem(view, translated);
                             NMSHandler.packetHelper.setSlot(ent, translated, original, false);
                         }
                         else if (slotSnapshot < 36) {
@@ -162,8 +163,8 @@ public class FakeItemCommand extends AbstractCommand {
     static int translateSlot(Player player, int slot) {
         // This translates Spigot slot standards to vanilla slots.
         // The slot order is different when a player is viewing an inventory vs not doing so, leading to this chaos.
-        int topSize = player.getOpenInventory().getTopInventory().getSize();
-        if (player.getOpenInventory().getTopInventory() instanceof CraftingInventory) {
+        int topSize = InventoryViewUtil.getTopInventory(player.getOpenInventory()).getSize();
+        if (InventoryViewUtil.getTopInventory(player.getOpenInventory()) instanceof CraftingInventory) {
             topSize = 9;
             if (slot > 35) {
                 if (slot < 40) { // Armor equipment

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/InventoryCommand.java
@@ -3,22 +3,29 @@ package com.denizenscript.denizen.scripts.commands.item;
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
-import com.denizenscript.denizen.objects.*;
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.InventoryTag;
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.scripts.containers.core.InventoryScriptHelper;
-import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Conversion;
+import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
-import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizen.utilities.inventory.InventoryTrackerSystem;
+import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizen.utilities.inventory.SlotHelper;
-import com.denizenscript.denizencore.objects.*;
-import com.denizenscript.denizencore.objects.core.*;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.core.TimeTag;
 import com.denizenscript.denizencore.objects.notable.NoteManager;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.core.FlagCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizencore.utilities.data.DataAction;
 import com.denizenscript.denizencore.utilities.data.DataActionHelper;
 import org.bukkit.Bukkit;
@@ -30,7 +37,9 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.inventory.*;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.AbstractMap;
 import java.util.HashSet;
@@ -233,7 +242,7 @@ public class InventoryCommand extends AbstractCommand implements Listener {
             else {
                 return;
             }
-            Inventory newInv = view.getTopInventory();
+            Inventory newInv = InventoryViewUtil.getTopInventory(view);
             newInv.setContents(destination.getContents());
         }
         finally {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/InventoryViewUtil.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/inventory/InventoryViewUtil.java
@@ -1,0 +1,64 @@
+package com.denizenscript.denizen.utilities.inventory;
+
+import com.denizenscript.denizencore.utilities.ReflectionHelper;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+
+import java.lang.invoke.MethodHandle;
+
+public class InventoryViewUtil {
+
+    private static <T> T get(MethodHandle methodHandle, InventoryView view) {
+        try {
+            return (T) methodHandle.invoke(view);
+        }
+        catch (Throwable e) {
+            Debug.echoError(e);
+            return null;
+        }
+    }
+
+    private static <T> T get(MethodHandle methodHandle, InventoryView view, int num) {
+        try {
+            return (T) methodHandle.invoke(view, num);
+        }
+        catch (Throwable e) {
+            Debug.echoError(e);
+            return null;
+        }
+    }
+
+    private static final MethodHandle GET_TOP_INVENTORY = ReflectionHelper.getMethodHandle(InventoryView.class, "getTopInventory");
+
+    public static Inventory getTopInventory(InventoryView view) {
+        return get(GET_TOP_INVENTORY, view);
+    }
+
+    private static final MethodHandle GET_PLAYER = ReflectionHelper.getMethodHandle(InventoryView.class, "getPlayer");
+
+    public static HumanEntity getPlayer(InventoryView view) {
+        return get(GET_PLAYER, view);
+    }
+
+    private static final MethodHandle GET_TYPE = ReflectionHelper.getMethodHandle(InventoryView.class, "getType");
+
+    public static InventoryType getType(InventoryView view) {
+        return get(GET_TYPE, view);
+    }
+
+    private static final MethodHandle GET_ITEM = ReflectionHelper.getMethodHandle(InventoryView.class, "getItem", int.class);
+
+    public static ItemStack getItem(InventoryView view, int slot) {
+        return get(GET_ITEM, view, slot);
+    }
+
+    private static final MethodHandle GET_INVENTORY = ReflectionHelper.getMethodHandle(InventoryView.class, "getInventory", int.class);
+
+    public static Inventory getInventory(InventoryView view, int slot) {
+        return get(GET_INVENTORY, view, slot);
+    }
+}


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1270826564908486828).
Ended up going with reflection instead of modulizing it, since it'd be one util class instead of methods in every version module, and performance wise it should be basically the same due to `static final MethodHandle`s (I think?).

## Additions

- `InventoryViewUtil` - util for calling relevant `InventoryView` methods with reflection.

## Changes

- `InventoryView` method usages now use `InventoryViewUtil`.

> [!NOTE]
> `InventoryViewUtil` has some static util methods for invoking the `MethodHandle`s, not sure how does that affect (performance) things? might have to call them directly?