### PR TITLE
Mechanisms & Tags > Properties

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAnger.java
@@ -12,6 +12,14 @@ import org.bukkit.entity.PigZombie;
 
 public class EntityAnger implements Property {
 
+    // <--[property]
+    // @object EntityTag
+    // @name anger
+    // @input DurationTag
+    // @description
+    // Controls the anger time of a PigZombie or Bee.
+    // -->
+
     public static boolean describes(ObjectTag entity) {
         if (!(entity instanceof EntityTag)) {
             return false;
@@ -46,6 +54,23 @@ public class EntityAnger implements Property {
     }
 
     @Override
+    public void setPropertyValue(DurationTag param, Mechanism mechanism) {
+        
+        if (mechanism.getValue().isInt()) { // Soft-deprecated - backwards compatibility, as this used to use a tick count
+            duration = new DurationTag(mechanism.getValue().asLong());
+        }
+        else {
+            duration = mechanism.valueAsType(DurationTag.class);
+        }
+        if (isPigZombie()) {
+            getPigZombie().setAnger(duration.getTicksAsInt());
+        }
+        else {
+            getBee().setAnger(duration.getTicksAsInt());
+        }
+    }
+
+    @Override
     public String getPropertyId() {
         return "anger";
     }
@@ -72,46 +97,6 @@ public class EntityAnger implements Property {
     }
 
     public static void register() {
-
-        // <--[tag]
-        // @attribute <EntityTag.anger>
-        // @returns DurationTag
-        // @mechanism EntityTag.anger
-        // @group properties
-        // @description
-        // Returns the remaining anger time of a PigZombie or Bee.
-        // -->
-        PropertyParser.registerTag(EntityAnger.class, DurationTag.class, "anger", (attribute, object) -> {
-            return new DurationTag((long) object.getAnger());
-        });
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name anger
-        // @input DurationTag
-        // @description
-        // Changes the remaining anger time of a PigZombie or Bee.
-        // @tags
-        // <EntityTag.anger>
-        // -->
-        if (mechanism.matches("anger") && mechanism.requireObject(DurationTag.class)) {
-            DurationTag duration;
-            if (mechanism.getValue().isInt()) { // Soft-deprecated - backwards compatibility, as this used to use a tick count
-                duration = new DurationTag(mechanism.getValue().asLong());
-            }
-            else {
-                duration = mechanism.valueAsType(DurationTag.class);
-            }
-            if (isPigZombie()) {
-                getPigZombie().setAnger(duration.getTicksAsInt());
-            }
-            else {
-                getBee().setAnger(duration.getTicksAsInt());
-            }
-        }
+        autoRegister("anger", EntityAnger.class, DurationTag.class, false);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAngry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAngry.java
@@ -15,6 +15,15 @@ import org.bukkit.entity.Wolf;
 
 public class EntityAngry implements Property {
 
+    // <--[property]
+    // @object EntityTag
+    // @name angry
+    // @input ElementTag(Boolean)
+    // @description
+    // If the entity is a Wolf or PigZombie, controls the entity's anger mode.
+    // If the entity is a Vindicator, controls it in "Johnny" mode.
+    // -->
+
     public static boolean describes(ObjectTag object) {
         if (!(object instanceof EntityTag)) {
             return false;
@@ -45,6 +54,19 @@ public class EntityAngry implements Property {
     EntityTag entity;
 
     @Override
+    public void setPropertyValue(ElementTag param, Mechanism mechanism) {
+        
+        if (isWolf()) {
+            getWolf().setAngry(mechanism.getValue().asBoolean());
+        }
+        else if (isPigZombie()) {
+            getPigZombie().setAngry(mechanism.getValue().asBoolean());
+        }
+        else if (isVindicator()) {
+            getVindicator().setJohnny(mechanism.getValue().asBoolean());
+        }
+    }
+    @Override
     public String getPropertyString() {
         if (isWolf()) {
             return getWolf().isAngry() ? "true" : null;
@@ -64,28 +86,7 @@ public class EntityAngry implements Property {
     }
 
     public static void register() {
-
-        // <--[tag]
-        // @attribute <EntityTag.angry>
-        // @returns ElementTag(Boolean)
-        // @mechanism EntityTag.angry
-        // @group properties
-        // @description
-        // If the entity is a wolf or PigZombie, returns whether the entity is angry.
-        // If the entity is a Vindicator, returns whether it is in "Johnny" mode.
-        // -->
-        PropertyParser.registerTag(EntityAngry.class, ElementTag.class, "angry", (attribute, entity) -> {
-            if (entity.isWolf()) {
-                return new ElementTag(entity.getWolf().isAngry());
-            }
-            else if (entity.isPigZombie()) {
-                return new ElementTag(entity.getPigZombie().isAngry());
-            }
-            else if (entity.isVindicator()) {
-                return new ElementTag(entity.getVindicator().isJohnny());
-            }
-            return null;
-        });
+        autoRegister("angry", EntityAngry.class, ElementTag.class, false);
     }
 
     public boolean isWolf() {
@@ -110,31 +111,5 @@ public class EntityAngry implements Property {
 
     public Vindicator getVindicator() {
         return (Vindicator) entity.getBukkitEntity();
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name angry
-        // @input ElementTag(Boolean)
-        // @description
-        // If the entity is wolf or PigZombie, sets whether the entity is angry.
-        // If the entity is a Vindicator, returns whether it is in "Johnny" mode.
-        // @tags
-        // <EntityTag.angry>
-        // -->
-        if (mechanism.matches("angry") && mechanism.requireBoolean()) {
-            if (isWolf()) {
-                getWolf().setAngry(mechanism.getValue().asBoolean());
-            }
-            else if (isPigZombie()) {
-                getPigZombie().setAngry(mechanism.getValue().asBoolean());
-            }
-            else if (isVindicator()) {
-                getVindicator().setJohnny(mechanism.getValue().asBoolean());
-            }
-        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -71,14 +71,20 @@ public class EntityAreaEffectCloud implements Property {
             return null;
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.base_potion>
-        // @returns ElementTag
-        // @mechanism EntityTag.base_potion
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name base_potion
+        // @input ElementTag
         // @description
         // Returns the Area Effect Cloud's base potion data.
         // In the format Type,Upgraded,Extended
+        // NOTE: Potion cannot be both upgraded and extended
+        // @tags
+        // <EntityTag.base_potion>
+        // <EntityTag.base_potion.type>
+        // <EntityTag.base_potion.is_upgraded>
+        // <EntityTag.base_potion.is_extended>
+        // <server.potion_types>
         // -->
         if (attribute.startsWith("base_potion")) {
             attribute = attribute.fulfill(1);
@@ -122,13 +128,12 @@ public class EntityAreaEffectCloud implements Property {
                     .getObjectAttribute(attribute);
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.particle>
-        // @returns ElementTag
-        // @mechanism EntityTag.particle
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name particle
+        // @input ElementTag
         // @description
-        // Returns the Area Effect Cloud's particle.
+        // Controls the Area Effect Cloud's particle.
         // -->
         if (attribute.startsWith("particle")) {
             attribute = attribute.fulfill(1);
@@ -148,13 +153,12 @@ public class EntityAreaEffectCloud implements Property {
                     .getObjectAttribute(attribute);
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.duration>
-        // @returns DurationTag
-        // @mechanism EntityTag.duration
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name duration
+        // @input DurationTag
         // @description
-        // Returns the Area Effect Cloud's duration.
+        // Controls the Area Effect Cloud's duration.
         // -->
         if (attribute.startsWith("duration")) {
             attribute = attribute.fulfill(1);
@@ -175,13 +179,12 @@ public class EntityAreaEffectCloud implements Property {
                     .getObjectAttribute(attribute);
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.radius>
-        // @returns ElementTag(Decimal)
-        // @mechanism EntityTag.radius
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name radius
+        // @input ElementTag(Decimal)
         // @description
-        // Returns the Area Effect Cloud's radius.
+        // Controls the Area Effect Cloud's radius.
         // -->
         if (attribute.startsWith("radius")) {
             attribute = attribute.fulfill(1);
@@ -215,13 +218,12 @@ public class EntityAreaEffectCloud implements Property {
                     .getObjectAttribute(attribute);
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.reapplication_delay>
-        // @returns DurationTag
-        // @mechanism EntityTag.reapplication_delay
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name reapplication_delay
+        // @input DurationTag
         // @description
-        // Returns the duration an entity will be immune
+        // Controls the duration an entity will be immune
         // from the Area Effect Cloud's subsequent exposure.
         // -->
         if (attribute.startsWith("reapplication_delay")) {
@@ -229,13 +231,12 @@ public class EntityAreaEffectCloud implements Property {
                     .getObjectAttribute(attribute.fulfill(1));
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.wait_time>
-        // @returns DurationTag
-        // @mechanism EntityTag.wait_time
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name wait_time
+        // @input DurationTag
         // @description
-        // Returns the duration before the Area Effect Cloud starts applying potion effects.
+        // Controls the duration before the Area Effect Cloud starts applying potion effects.
         // -->
         if (attribute.startsWith("wait_time")) {
             return new DurationTag(getHelper().getWaitTime())
@@ -265,13 +266,12 @@ public class EntityAreaEffectCloud implements Property {
                     .getObjectAttribute(attribute.fulfill(1));
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.source>
-        // @returns EntityTag
-        // @mechanism EntityTag.source
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name source
+        // @input EntityTag
         // @description
-        // Returns the source of the Area Effect Cloud.
+        // Controls the source of the Area Effect Cloud.
         // -->
         if (attribute.startsWith("source")) {
             ProjectileSource shooter = getHelper().getSource();
@@ -281,14 +281,13 @@ public class EntityAreaEffectCloud implements Property {
             }
         }
 
-        // <--[tag]
-        // @attribute <EntityTag.custom_effects>
-        // @returns ListTag
-        // @mechanism EntityTag.custom_effects
-        // @group properties
+        // <--[property]
+        // @object EntityTag
+        // @name custom_effects
+        // @input ListTag
         // @description
-        // Returns a ListTag of the Area Effect Cloud's custom effects
-        // In the form Type,Amplifier,Duration,Ambient,Particles|...
+        // Controls the Area Effect Cloud's custom effects.
+        // Listed in the form Type,Amplifier,Duration,Ambient,Particles|...
         // -->
         if (attribute.startsWith("custom_effects")) {
             List<PotionEffect> effects = getHelper().getCustomEffects();
@@ -416,16 +415,6 @@ public class EntityAreaEffectCloud implements Property {
             }
         }
 
-        // <--[mechanism]
-        // @object EntityTag
-        // @name custom_effects
-        // @input ListTag
-        // @description
-        // Adds a list of custom potion effects to the Area Effect Cloud
-        // In the form Type,Amplifier,Duration(,Ambient,Particles)|...
-        // @tags
-        // <EntityTag.custom_effects>
-        // -->
         if (mechanism.matches("custom_effects")) {
             ListTag list = mechanism.valueAsType(ListTag.class);
             getHelper().clearEffects();
@@ -466,22 +455,7 @@ public class EntityAreaEffectCloud implements Property {
         if (mechanism.matches("particle_color") && mechanism.requireObject(ColorTag.class)) {
             getHelper().setColor(BukkitColorExtensions.getColor(mechanism.valueAsType(ColorTag.class)));
         }
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name base_potion
-        // @input ElementTag
-        // @description
-        // Sets the Area Effect Cloud's base potion.
-        // In the form: Type,Upgraded,Extended
-        // NOTE: Potion cannot be both upgraded and extended
-        // @tags
-        // <EntityTag.base_potion>
-        // <EntityTag.base_potion.type>
-        // <EntityTag.base_potion.is_upgraded>
-        // <EntityTag.base_potion.is_extended>
-        // <server.potion_types>
-        // -->
+        
         if (mechanism.matches("base_potion")) {
             List<String> data = CoreUtilities.split(mechanism.getValue().asString().toUpperCase(), ',');
             if (data.size() != 3) {
@@ -505,15 +479,6 @@ public class EntityAreaEffectCloud implements Property {
             }
         }
 
-        // <--[mechanism]
-        // @object EntityTag
-        // @name duration
-        // @input DurationTag
-        // @description
-        // Sets the Area Effect Cloud's duration.
-        // @tags
-        // <EntityTag.duration>
-        // -->
         if (mechanism.matches("duration") && mechanism.requireObject(DurationTag.class)) {
             getHelper().setDuration(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
         }
@@ -532,28 +497,10 @@ public class EntityAreaEffectCloud implements Property {
             getHelper().setDurationOnUse(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
         }
 
-        // <--[mechanism]
-        // @object EntityTag
-        // @name particle
-        // @input ElementTag
-        // @description
-        // Sets the particle of the Area Effect Cloud
-        // @tags
-        // <EntityTag.particle>
-        // -->
         if (mechanism.matches("particle") && mechanism.hasValue()) {
             getHelper().setParticle(mechanism.getValue().asString().toUpperCase());
         }
 
-        // <--[mechanism]
-        // @object EntityTag
-        // @name radius
-        // @input ElementTag(Decimal)
-        // @description
-        // Sets the radius of the Area Effect Cloud
-        // @tags
-        // <EntityTag.radius>
-        // -->
         if (mechanism.matches("radius") && mechanism.requireFloat()) {
             getHelper().setRadius(mechanism.getValue().asFloat());
         }
@@ -586,42 +533,14 @@ public class EntityAreaEffectCloud implements Property {
             getHelper().setRadiusPerTick(mechanism.getValue().asFloat());
         }
 
-        // <--[mechanism]
-        // @object EntityTag
-        // @name reapplication_delay
-        // @input DurationTag
-        // @description
-        // Sets the duration an entity will be immune
-        // from the Area Effect Cloud's subsequent exposure.
-        // @tags
-        // <EntityTag.reapplication_delay>
-        // -->
         if (mechanism.matches("reapplication_delay") && mechanism.requireObject(DurationTag.class)) {
             getHelper().setReappDelay(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
         }
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name source
-        // @input EntityTag
-        // @description
-        // Sets the source of the Area Effect Cloud
-        // @tags
-        // <EntityTag.source>
-        // -->
+        
         if (mechanism.matches("source") && mechanism.requireObject(EntityTag.class)) {
             getHelper().setSource((ProjectileSource) mechanism.valueAsType(EntityTag.class).getBukkitEntity());
         }
 
-        // <--[mechanism]
-        // @object EntityTag
-        // @name wait_time
-        // @input DurationTag
-        // @description
-        // Sets the duration before the Area Effect Cloud starts applying potion effects.
-        // @tags
-        // <EntityTag.wait_time>
-        // -->
         if (mechanism.matches("wait_time") && mechanism.requireObject(DurationTag.class)) {
             getHelper().setWaitTime(mechanism.valueAsType(DurationTag.class).getTicksAsInt());
         }


### PR DESCRIPTION
- EntityTag.anger: Property & autoRegister
- EntityTag.angry: Property & autoRegister
- EntityTag.base_potion: Property
- EntityTag.particle: Property
- EntityTag.duration: Property
- EntityTag.radius: Property
- EntityTag.reapplication_delay: Property
- EntityTag.wait_time: Property
- EntityTag.particle: Property
- EntityTag.source: Property
- EntityTag.custom_effects: Property
- EntityTag.particle: Property
(Intention to soon deprecate mechanisms and tags in EntityAreaEffectCloud to either "radius.on_use" or "radius_on_use" format)