### PR TITLE
Legacy renames: enable by default

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -498,6 +498,9 @@ public class Denizen extends JavaPlugin {
         if (!CoreConfiguration.defaultDebugMode) {
             getLogger().warning("Debug is disabled in the Denizen config. This is almost always a mistake, and should not be done in the majority of cases.");
         }
+        if (Settings.cache_legacySpigotNamesSupport) {
+            getLogger().warning("LEGACY SPIGOT NAMES SUPPORT ENABLED! This should only be used if you have scripts with legacy Spigot names, and should otherwise be disabled; see config.yml for more information.");
+        }
     }
 
     private FileConfiguration scoreboardsConfig = null;

--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -499,7 +499,7 @@ public class Denizen extends JavaPlugin {
             getLogger().warning("Debug is disabled in the Denizen config. This is almost always a mistake, and should not be done in the majority of cases.");
         }
         if (Settings.cache_legacySpigotNamesSupport) {
-            getLogger().warning("LEGACY SPIGOT NAMES SUPPORT ENABLED! This should only be used if you have scripts with legacy Spigot names, and should otherwise be disabled; see config.yml for more information.");
+            Debug.log("LEGACY SPIGOT NAMES SUPPORT ENABLED! This should only be used if you have scripts with legacy Spigot names, and should otherwise be disabled; see config.yml for more information.");
         }
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Settings.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Settings.java
@@ -129,7 +129,7 @@ public class Settings {
         cache_packetInterception = config.getBoolean("Packets.Interception", true);
         cache_packetInterceptAutoInit = config.getBoolean("Packets.Auto init", false);
         cache_commandScriptAutoInit = config.getBoolean("Scripts.Command.Auto init", false);
-        cache_legacySpigotNamesSupport = config.getBoolean("Scripts.Legacy Spigot names support", false);
+        cache_legacySpigotNamesSupport = config.getBoolean("Scripts.Legacy Spigot names support", true);
         PlayerFlagHandler.cacheTimeoutSeconds = config.getLong("Saves.Offline player cache timeout", 300);
         PlayerFlagHandler.asyncPreload = config.getBoolean("Saves.Load async on login", true);
         PlayerFlagHandler.saveOnlyWhenWorldSaveOn = config.getBoolean("Saves.Only save if world save is on", false);

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -587,18 +587,14 @@ public class Utilities {
     }
 
     public static <T> T elementToEnumlike(ElementTag element, Class<T> type, boolean showWarning) {
-        T value = (T) element.asEnum((Class) type);
-        if (value != null) {
-            return value;
-        }
         if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20)) {
-            return null;
+            return element.asEnum(type);
         }
         Registry<?> registry = Bukkit.getRegistry((Class<? extends Keyed>) type);
         if (registry == null) {
-            return null;
+            return element.asEnum(type);
         }
-        value = (T) registry.get(parseNamespacedKey(element.asString()));
+        T value = (T) registry.get(parseNamespacedKey(element.asString()));
         if (value != null || !Settings.cache_legacySpigotNamesSupport) {
             return value;
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -598,6 +598,13 @@ public class Utilities {
         if (value != null || !Settings.cache_legacySpigotNamesSupport) {
             return value;
         }
+        T enumValue = element.asEnum(type);
+        if (enumValue != null) {
+            if (showWarning) {
+                BukkitImplDeprecations.oldSpigotNames.warn();
+            }
+            return enumValue;
+        }
         String updatedName = NMSHandler.instance.updateLegacyName(type, element.asString());
         if (CoreUtilities.equalsIgnoreCase(element.asString(), updatedName)) {
             return null;

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -52,7 +52,7 @@ Debug:
 Scripts:
     # Whether backwards compatibility for older Spigot names should be enabled (e.g. 'GENERIC_MAX_HEALTH' as an attribute instead of 'max_health').
     # This should generally be disabled, and should only be used while updating older scripts to Minecraft versions 1.21 and above.
-    Legacy Spigot names support: false
+    Legacy Spigot names support: true
     World:
         Events:
             On player chats:

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
@@ -434,10 +434,6 @@ public class Handler extends NMSHandler {
 
     @Override
     public String updateLegacyName(Class<?> type, String legacyName) {
-        if (type == Sound.class) {
-            Sound sound = ReflectionHelper.getFieldValue(Sound.class, CoreUtilities.toUpperCase(legacyName), null);
-            return sound != null ? sound.getKey().toString() : null;
-        }
         return FieldRename.rename(ApiVersion.FIELD_NAME_PARITY, type.getName().replace('.', '/'), legacyName);
     }
 }


### PR DESCRIPTION
Following [Discord](https://discord.com/channels/315163488085475337/1011496047811506227/1319273737262075994) discussion.
## Changes

- `Denizen#reloadConfig` now prints a warning if legacy renaming is enabled.
- `Scripts.Legacy Spigot names support` now defaults to `true`.
- `Utilities#elementToEnumlike` now only tries using `#asEnum` when on outdated versions/there's no registry (similar to before, but now the renaming is on by default so all scripts should work out of the box).