### PR TITLE
Entity potion handling 1.20 fixes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -140,6 +140,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityPlayingDead.class, EntityTag.class);
         PropertyParser.registerProperty(EntityPotion.class, EntityTag.class);
         PropertyParser.registerProperty(EntityPotionEffects.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            PropertyParser.registerProperty(EntityPotionType.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityPowered.class, EntityTag.class);
         PropertyParser.registerProperty(EntityProfession.class, EntityTag.class);
         PropertyParser.registerProperty(EntityRiptide.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotion.java
@@ -14,70 +14,50 @@ import org.bukkit.entity.ThrownPotion;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 
-public class EntityPotion implements Property {
+public class EntityPotion extends EntityProperty<ItemTag> {
 
-    public static boolean describes(ObjectTag entity) {
-        if (!(entity instanceof EntityTag)) {
-            return false;
-        }
-        return ((EntityTag) entity).getBukkitEntity() instanceof ThrownPotion
-                || ((EntityTag) entity).getBukkitEntity() instanceof Arrow;
+    // <--[property]
+    // @object EntityTag
+    // @name potion
+    // @input ItemTag
+    // @description
+    // Controls a tipped arrow/splash potion's potion data.
+    // For a Tipped Arrow, this is an ItemTag of a potion with the base potion data of the arrow.
+    // For a Splash Potion, this is an ItemTag of the splash potion's full potion data.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof ThrownPotion || entity.getBukkitEntity() instanceof Arrow;
     }
 
-    public static EntityPotion getFrom(ObjectTag entity) {
-        if (!describes(entity)) {
-            return null;
-        }
-        else {
-            return new EntityPotion((EntityTag) entity);
-        }
-    }
-
-    public static final String[] handledTags = new String[] {
-            "potion"
-    };
-
-    public static final String[] handledMechs = new String[] {
-            "potion"
-    };
-
-    EntityTag entity;
-
-    public EntityPotion(EntityTag entity) {
-        this.entity = entity;
-    }
-
-    public ItemStack getPotion() {
-        if (entity.getBukkitEntity() instanceof ThrownPotion) {
-            return ((ThrownPotion) entity.getBukkitEntity()).getItem();
+    @Override
+    public ItemTag getPropertyValue() {
+        if (getEntity() instanceof ThrownPotion thrownPotion) {
+            return new ItemTag(thrownPotion.getItem());
         }
         else { // Tipped arrow
             ItemStack refItem = new ItemStack(Material.POTION);
             PotionMeta meta = (PotionMeta) refItem.getItemMeta();
             // TODO: 1.20.6: PotionData API
             if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
-                meta.setBasePotionData(((Arrow) entity.getBukkitEntity()).getBasePotionData());
+                meta.setBasePotionData(as(Arrow.class).getBasePotionData());
             }
             refItem.setItemMeta(meta);
-            return refItem;
-        }
-    }
-
-    public void setPotion(ItemStack item) {
-        if (entity.getBukkitEntity() instanceof ThrownPotion) {
-            ((ThrownPotion) entity.getBukkitEntity()).setItem(item);
-        }
-        else { // Tipped arrow
-            // TODO: 1.20.6: PotionData API
-            if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
-                ((Arrow) entity.getBukkitEntity()).setBasePotionData(((PotionMeta) item.getItemMeta()).getBasePotionData());
-            }
+            return new ItemTag(refItem);
         }
     }
 
     @Override
-    public String getPropertyString() {
-        return new ItemTag(getPotion()).identify();
+    public void setPropertyValue(ItemTag value, Mechanism mechanism) {
+        if (getEntity() instanceof ThrownPotion thrownPotion) {
+            thrownPotion.setItem(value.getItemStack());
+        }
+        else { // Tipped arrow
+            // TODO: 1.20.6: PotionData API
+            if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
+                as(Arrow.class).setBasePotionData(((PotionMeta) value.getItemMeta()).getBasePotionData());
+            }
+        }
     }
 
     @Override
@@ -85,45 +65,7 @@ public class EntityPotion implements Property {
         return "potion";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-        if (attribute == null) {
-            return null;
-        }
-
-        // <--[tag]
-        // @attribute <EntityTag.potion>
-        // @returns ItemTag
-        // @mechanism EntityTag.potion
-        // @group properties
-        // @description
-        // If the entity is a Tipped Arrow, returns an ItemTag of a potion with the base potion data of the arrow.
-        // If the entity is a Splash Potion, returns an ItemTag of the splash potion's full potion data.
-        // -->
-        if (attribute.startsWith("potion")) {
-            return new ItemTag(getPotion()).getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name potion
-        // @input ItemTag
-        // @description
-        // Input must be a potion item!
-        // If the entity is a Tipped Arrow, sets the arrow's base potion data based on the item input.
-        // If the entity is a splash Potion, sets the splash potion's full potion data from the item input.
-        // @tags
-        // <EntityTag.potion>
-        // -->
-        if (mechanism.matches("potion") && mechanism.requireObject(ItemTag.class)) {
-            setPotion(mechanism.valueAsType(ItemTag.class).getItemStack());
-        }
-
+    public static void register() {
+        autoRegister("potion", EntityPotion.class, ItemTag.class, false);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotion.java
@@ -38,8 +38,10 @@ public class EntityPotion extends EntityProperty<ItemTag> {
         else { // Tipped arrow
             ItemStack refItem = new ItemStack(Material.POTION);
             PotionMeta meta = (PotionMeta) refItem.getItemMeta();
-            // TODO: 1.20.6: PotionData API
-            if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                meta.setBasePotionType(as(Arrow.class).getBasePotionType());
+            }
+            else {
                 meta.setBasePotionData(as(Arrow.class).getBasePotionData());
             }
             refItem.setItemMeta(meta);
@@ -53,8 +55,10 @@ public class EntityPotion extends EntityProperty<ItemTag> {
             thrownPotion.setItem(value.getItemStack());
         }
         else { // Tipped arrow
-            // TODO: 1.20.6: PotionData API
-            if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                as(Arrow.class).setBasePotionType(((PotionMeta) value.getItemMeta()).getBasePotionType());
+            }
+            else {
                 as(Arrow.class).setBasePotionData(((PotionMeta) value.getItemMeta()).getBasePotionData());
             }
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotion.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotion.java
@@ -4,9 +4,8 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.tags.Attribute;
 import org.bukkit.Material;
 import org.bukkit.entity.Arrow;
@@ -14,16 +13,16 @@ import org.bukkit.entity.ThrownPotion;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 
+@Deprecated
 public class EntityPotion extends EntityProperty<ItemTag> {
 
     // <--[property]
     // @object EntityTag
     // @name potion
     // @input ItemTag
+    // @deprecated use 'EntityTag.potion_type' for arrows, and 'EntityTag.item' for splash potions.
     // @description
-    // Controls a tipped arrow/splash potion's potion data.
-    // For a Tipped Arrow, this is an ItemTag of a potion with the base potion data of the arrow.
-    // For a Splash Potion, this is an ItemTag of the splash potion's full potion data.
+    // Deprecated in favor of <@link property EntityTag.potion_type> for arrows, and <@link property EntityTag.item> for splash potions.
     // -->
 
     public static boolean describes(EntityTag entity) {
@@ -50,12 +49,30 @@ public class EntityPotion extends EntityProperty<ItemTag> {
     }
 
     @Override
+    public ItemTag getTagValue(Attribute attribute) {
+        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
+            return super.getTagValue(attribute);
+        }
+        if (getEntity() instanceof ThrownPotion) {
+            BukkitImplDeprecations.splashPotionItem.warn(attribute.context);
+        }
+        else {
+            BukkitImplDeprecations.arrowBasePotionType.warn(attribute.context);
+        }
+        return super.getTagValue(attribute);
+    }
+
+    @Override
     public void setPropertyValue(ItemTag value, Mechanism mechanism) {
         if (getEntity() instanceof ThrownPotion thrownPotion) {
             thrownPotion.setItem(value.getItemStack());
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                BukkitImplDeprecations.splashPotionItem.warn(mechanism.context);
+            }
         }
         else { // Tipped arrow
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                BukkitImplDeprecations.arrowBasePotionType.warn(mechanism.context);
                 as(Arrow.class).setBasePotionType(((PotionMeta) value.getItemMeta()).getBasePotionType());
             }
             else {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionType.java
@@ -17,6 +17,8 @@ public class EntityPotionType extends EntityProperty<ElementTag> {
     // Controls an Arrow's base potion type, if any.
     // See <@link url https://minecraft.wiki/w/Potion#Item_data> for a list of potion types.
     // See <@link property EntityTag.potion_effects> to control the potion effects an arrow applies.
+    // @mechanism
+    // Specify no input to remove the base potion type.
     // -->
 
     public static boolean describes(EntityTag entity) {
@@ -31,7 +33,7 @@ public class EntityPotionType extends EntityProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (!mechanism.hasValue()) {
+        if (value == null) {
             as(Arrow.class).setBasePotionType(null);
             return;
         }
@@ -46,6 +48,6 @@ public class EntityPotionType extends EntityProperty<ElementTag> {
     }
 
     public static void register() {
-        autoRegister("potion_type", EntityPotionType.class, ElementTag.class, false);
+        autoRegisterNullable("potion_type", EntityPotionType.class, ElementTag.class, false);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionType.java
@@ -1,0 +1,51 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.entity.Arrow;
+import org.bukkit.potion.PotionType;
+
+public class EntityPotionType extends EntityProperty<ElementTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name potion_type
+    // @input ElementTag
+    // @description
+    // Controls an Arrow's base potion type, if any.
+    // See <@link url https://minecraft.wiki/w/Potion#Item_data> for a list of potion types.
+    // See <@link property EntityTag.potion_effects> to control the potion effects an arrow applies.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof Arrow;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        PotionType type = as(Arrow.class).getBasePotionType();
+        return type != null ? new ElementTag(Utilities.namespacedKeyToString(type.getKey()), true) : null;
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (!mechanism.hasValue()) {
+            as(Arrow.class).setBasePotionType(null);
+            return;
+        }
+        if (Utilities.requireEnumlike(mechanism, PotionType.class)) {
+            as(Arrow.class).setBasePotionType(Utilities.elementToEnumlike(value, PotionType.class));
+        }
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "potion_type";
+    }
+
+    public static void register() {
+        autoRegister("potion_type", EntityPotionType.class, ElementTag.class, false);
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -350,6 +350,12 @@ public class BukkitImplDeprecations {
     // Added 2024/12/27
     public static Warning entityIsSheared = new FutureWarning("entityIsSheared", "'EntityTag.is_sheared' and 'EntityTag.has_pumpkin_head' properties are deprecated in favor of 'EntityTag.sheared'.");
 
+    // Added 2025/1/12
+    public static Warning splashPotionItem = new FutureWarning("splashPotionItem", "Using 'EntityTag.potion' to get a splash potion's item is deprecated in favor of 'EntityTag.item'.");
+
+    // Added 2025/1/12
+    public static Warning arrowBasePotionType = new FutureWarning("arrowBasePotionType", "Using 'EntityTag.potion' to get an arrow's base potion type is deprecated in favor of 'EntityTag.potion_type'.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2023/10/29 without warning.


### PR DESCRIPTION
## Changes

- `EntityTag.potion` has been updated to modern property format.
- `EntityTag.potion` is now deprecated in favor of `EntityTag.item` for thrown potions & `EntityTag.base_type` for arrows on 1.20+.

## Additions

- `EntityTag.potion_type` - for controlling an arrow's base potion type (1.20+).
- `splashPotionItem` and `arrowBasePotionType` deprecation warnings.

> [!NOTE]
> Not sure if `potion_type` is the best name there? lmk if you have any other suggestions.

> [!NOTE]
> Made 2 separate warnings because it directs to 2 different properties, not sure if these should be merged.
> Also `EntityTag.item` technically works for splash potions from 1.19, but made it 1.20 for simpler handling and because that's probably going to be the minimum supported version in the near future anyway.