### PR TITLE
Add PlayerTag.view_distance tag & mech

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
@@ -86,7 +86,7 @@ public class PaperPlayerExtensions {
         // @group paper
         // @Plugin Paper
         // @description
-        // Returns this player's view distance.
+        // Returns this player's view distance, or the view distance of the world they're in if unset.
         // -->
         PlayerTag.registerOnlineOnlyTag(ElementTag.class, "view_distance", (attribute, object) -> {
             return new ElementTag(object.getPlayerEntity().getViewDistance());
@@ -157,12 +157,15 @@ public class PaperPlayerExtensions {
         // @group paper
         // @description
         // Sets this player's view distance. Input must be a number between 2 and 32.
-        // This will be reset when a player rejoins.
+        // This will be reset when a player rejoins. Provide empty input to unset.
         // @tags
         // <PlayerTag.view_distance>
         // -->
         PlayerTag.registerOnlineOnlyMechanism("view_distance", ElementTag.class, (object, mechanism, input) -> {
-            if (mechanism.requireInteger()) {
+            if (!mechanism.hasValue()) {
+                object.getPlayerEntity().setViewDistance(-1);
+            }
+            else if (mechanism.requireInteger()) {
                 int distance = input.asInt();
                 if (distance < 2 || distance > 32) {
                     mechanism.echoError("Invalid view distance '" + input + "': must be between 2 and 32.");

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
@@ -79,6 +79,19 @@ public class PaperPlayerExtensions {
             return map;
         });
 
+        // <--[tag]
+        // @attribute <PlayerTag.view_distance>
+        // @returns ElementTag(Number)
+        // @mechanism PlayerTag.view_distance
+        // @group paper
+        // @Plugin Paper
+        // @description
+        // Returns this player's view distance.
+        // -->
+        PlayerTag.registerOnlineOnlyTag(ElementTag.class, "view_distance", (attribute, object) -> {
+            return new ElementTag(object.getPlayerEntity().getViewDistance());
+        });
+
         // <--[mechanism]
         // @object PlayerTag
         // @name affects_monster_spawning
@@ -133,6 +146,29 @@ public class PaperPlayerExtensions {
         PlayerTag.registerOnlineOnlyMechanism("fake_op_level", ElementTag.class, (object, mechanism, input) -> {
             if (mechanism.requireInteger()) {
                 object.getPlayerEntity().sendOpLevel((byte) input.asInt());
+            }
+        });
+
+        // <--[mechanism]
+        // @object PlayerTag
+        // @name view_distance
+        // @input ElementTag(Number)
+        // @Plugin Paper
+        // @group paper
+        // @description
+        // Sets this player's view distance. Input must be a number between 2 and 32.
+        // This will be reset when a player rejoins.
+        // @tags
+        // <PlayerTag.view_distance>
+        // -->
+        PlayerTag.registerOnlineOnlyMechanism("view_distance", ElementTag.class, (object, mechanism, input) -> {
+            if (mechanism.requireInteger()) {
+                int distance = input.asInt();
+                if (distance < 2 || distance > 32) {
+                    mechanism.echoError("Invalid view distance '" + input + "': must be between 2 and 32.");
+                    return;
+                }
+                object.getPlayerEntity().setViewDistance(distance);
             }
         });
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/PaperPlayerExtensions.java
@@ -157,18 +157,18 @@ public class PaperPlayerExtensions {
         // @group paper
         // @description
         // Sets this player's view distance. Input must be a number between 2 and 32.
-        // This will be reset when a player rejoins. Provide empty input to unset.
+        // This will be reset when a player rejoins. Provide no input to unset.
         // @tags
         // <PlayerTag.view_distance>
         // -->
-        PlayerTag.registerOnlineOnlyMechanism("view_distance", ElementTag.class, (object, mechanism, input) -> {
+        PlayerTag.registerOnlineOnlyMechanism("view_distance", (object, mechanism) -> {
             if (!mechanism.hasValue()) {
                 object.getPlayerEntity().setViewDistance(-1);
             }
             else if (mechanism.requireInteger()) {
-                int distance = input.asInt();
+                int distance = mechanism.getValue().asInt();
                 if (distance < 2 || distance > 32) {
-                    mechanism.echoError("Invalid view distance '" + input + "': must be between 2 and 32.");
+                    mechanism.echoError("Invalid view distance '" + distance + "': must be between 2 and 32.");
                     return;
                 }
                 object.getPlayerEntity().setViewDistance(distance);


### PR DESCRIPTION
### Additions
- tag `player.view_distance` - returns player's view distance
- mechanism `player.view_distance` - adjust player's view distance

Requested on discord https://discord.com/channels/315163488085475337/1320439849425305811

> [!NOTE]
> `Player#setViewDistance` also supports `-1` as an input (this resets player's viewdistance to match world's view distance) should I add this option as well?