### PR TITLE
Fix item hovers on 1.20+

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -371,6 +371,7 @@ public class Denizen extends JavaPlugin {
         ExSustainedCommandHandler exsCommand = new ExSustainedCommandHandler();
         exsCommand.enableFor(getCommand("exs"));
         FullBlockData.init();
+        HoverFormatHelper.tryInitializeItemHoverFix();
         // Load script files without processing.
         DenizenCore.preloadScripts(false, null);
         // Load the saves.yml into memory

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
@@ -5,7 +5,6 @@ import com.denizenscript.denizen.nms.interfaces.*;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
-import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -130,8 +129,6 @@ public abstract class NMSHandler {
     public void setInventoryTitle(InventoryView view, String title) {
         throw new UnsupportedOperationException();
     }
-
-    public abstract String stringForHover(HoverEvent hover);
 
     public abstract ArrayList<String> containerListFlags(PersistentDataContainer container, String prefix);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
 import com.denizenscript.denizencore.objects.core.MapTag;
+import com.google.gson.JsonObject;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -42,7 +43,17 @@ public abstract class ItemHelper {
 
     public abstract String getJsonString(ItemStack itemStack);
 
-    public abstract String getRawHoverText(ItemStack itemStack);
+    public String getLegacyHoverNbt(ItemTag item) { // TODO: once 1.20 is the minimum supported version, remove this
+        return item.getItemMeta().getAsString();
+    }
+
+    public JsonObject getRawHoverComponentsJson(ItemStack item) {
+        throw new UnsupportedOperationException();
+    }
+
+    public ItemStack applyRawHoverComponentsJson(ItemStack item, JsonObject components) {
+        throw new UnsupportedOperationException();
+    }
 
     public abstract PlayerProfile getSkullSkin(ItemStack itemStack);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -164,7 +164,7 @@ public class FormattedTextHelper {
         boolean hasHover = component.getHoverEvent() != null;
         if (hasHover) {
             HoverEvent hover = component.getHoverEvent();
-            builder.append(ChatColor.COLOR_CHAR).append("[hover=").append(hover.getAction().name()).append(";").append(escape(NMSHandler.instance.stringForHover(hover))).append("]");
+            builder.append(ChatColor.COLOR_CHAR).append("[hover=").append(hover.getAction().name()).append(";").append(escape(HoverFormatHelper.stringForHover(hover))).append("]");
         }
         boolean hasClick = component.getClickEvent() != null;
         if (hasClick) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
@@ -32,7 +32,7 @@ public class HoverFormatHelper {
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
                 content = new FixedItemHover(item.getBukkitMaterial().getKey().toString(), item.getAmount(), NMSHandler.itemHelper.getRawHoverComponentsJson(item.getItemStack()));
             }
-            else  {
+            else {
                 content = new Item(item.getBukkitMaterial().getKey().toString(), item.getAmount(), net.md_5.bungee.api.chat.ItemTag.ofNbt(NMSHandler.itemHelper.getLegacyHoverNbt(item)));
             }
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
@@ -122,14 +122,6 @@ public class HoverFormatHelper {
         public JsonObject getComponents() {
             return components;
         }
-
-        @Override
-        public net.md_5.bungee.api.chat.ItemTag getTag() {
-            if (components != null && super.getTag() == null) {
-                super.setTag(net.md_5.bungee.api.chat.ItemTag.ofNbt(FormattedTextHelper.vanillaStyleSpigotComponentGSON.toJson(components)));
-            }
-            return super.getTag();
-        }
     }
 
     public static class FixedItemHoverSerializer extends ItemSerializer {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
@@ -1,17 +1,24 @@
 package com.denizenscript.denizen.utilities;
 
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.ReflectionHelper;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.google.gson.*;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.api.chat.hover.content.Content;
-import net.md_5.bungee.api.chat.hover.content.Entity;
-import net.md_5.bungee.api.chat.hover.content.Item;
-import net.md_5.bungee.api.chat.hover.content.Text;
+import net.md_5.bungee.api.chat.hover.content.*;
+import net.md_5.bungee.chat.ComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Registry;
+import org.bukkit.inventory.ItemStack;
+
+import java.lang.reflect.Type;
 
 public class HoverFormatHelper {
 
@@ -22,9 +29,12 @@ public class HoverFormatHelper {
             if (item == null) {
                 return true;
             }
-            // TODO: Why is there not a direct conversion method for Spigot ItemStack -> BungeeChat Item?
-            String itemNbt = NMSHandler.itemHelper.getRawHoverText(item.getItemStack());
-            content = new Item(item.getBukkitMaterial().getKey().toString(), item.getAmount(), net.md_5.bungee.api.chat.ItemTag.ofNbt(itemNbt));
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                content = new FixedItemHover(item.getBukkitMaterial().getKey().toString(), item.getAmount(), NMSHandler.itemHelper.getRawHoverComponentsJson(item.getItemStack()));
+            }
+            else  {
+                content = new Item(item.getBukkitMaterial().getKey().toString(), item.getAmount(), net.md_5.bungee.api.chat.ItemTag.ofNbt(NMSHandler.itemHelper.getLegacyHoverNbt(item)));
+            }
         }
         else if (action == HoverEvent.Action.SHOW_ENTITY) {
             EntityTag entity = EntityTag.valueOf(FormattedTextHelper.unescape(input), CoreUtilities.basicContext);
@@ -45,5 +55,108 @@ public class HoverFormatHelper {
         }
         hoverableText.setHoverEvent(new HoverEvent(action, content));
         return false;
+    }
+
+    public static String stringForHover(HoverEvent hover) {
+        if (hover.getContents().isEmpty()) {
+            return "";
+        }
+        Content contentObject = hover.getContents().get(0);
+        if (contentObject instanceof Text textHover) {
+            Object value = textHover.getValue();
+            if (value instanceof BaseComponent[] componentsValue) {
+                return FormattedTextHelper.stringify(componentsValue);
+            }
+            else {
+                return value.toString();
+            }
+        }
+        else if (contentObject instanceof Item itemHover) {
+            ItemStack item = new ItemStack(Registry.MATERIAL.get(Utilities.parseNamespacedKey(itemHover.getId())), itemHover.getCount() == -1 ? 1 : itemHover.getCount());
+            if (itemHover instanceof FixedItemHover fixedItemHover && fixedItemHover.getComponents() != null) {
+                item = NMSHandler.itemHelper.applyRawHoverComponentsJson(item, fixedItemHover.getComponents());
+            }
+            else if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19) && itemHover.getTag() != null && itemHover.getTag().getNbt() != null) {
+                item = Bukkit.getUnsafe().modifyItemStack(item, itemHover.getTag().getNbt());
+            }
+            return new ItemTag(item).identify();
+        }
+        else if (contentObject instanceof net.md_5.bungee.api.chat.hover.content.Entity entityHover) {
+            // TODO: Maybe a stabler way of doing this?
+            return "e@" + entityHover.getId();
+        }
+        else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static void tryInitializeItemHoverFix() {
+        if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            return;
+        }
+        Gson bungeeGson = ReflectionHelper.getFieldValue(ComponentSerializer.class, "gson", null);
+        if (bungeeGson == null) {
+            return;
+        }
+        Gson fixedGson = bungeeGson.newBuilder()
+                .registerTypeAdapter(FixedItemHover.class, new FixedItemHoverSerializer())
+                .registerTypeAdapter(Item.class, new FixedItemHoverSerializer())
+                .create();
+        try {
+            ReflectionHelper.getFinalSetter(ComponentSerializer.class, "gson").invoke(fixedGson);
+        }
+        catch (Throwable e) {
+            Debug.echoError(e);
+        }
+    }
+
+    public static class FixedItemHover extends Item {
+
+        private final JsonObject components;
+
+        public FixedItemHover(String id, int count, JsonObject components) {
+            super(id, count, null);
+            this.components = components;
+        }
+
+        public JsonObject getComponents() {
+            return components;
+        }
+
+        @Override
+        public net.md_5.bungee.api.chat.ItemTag getTag() {
+            if (components != null && super.getTag() == null) {
+                super.setTag(net.md_5.bungee.api.chat.ItemTag.ofNbt(FormattedTextHelper.vanillaStyleSpigotComponentGSON.toJson(components)));
+            }
+            return super.getTag();
+        }
+    }
+
+    public static class FixedItemHoverSerializer extends ItemSerializer {
+
+        @Override
+        public Item deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException {
+            Item deserialized = super.deserialize(element, type, context);
+            if (deserialized.getTag() != null) {
+                return deserialized;
+            }
+            JsonObject componentsObject = element.getAsJsonObject().getAsJsonObject("components");
+            if (componentsObject == null) {
+                return deserialized;
+            }
+            return new FixedItemHover(deserialized.getId(), deserialized.getCount(), componentsObject);
+        }
+
+        @Override
+        public JsonElement serialize(Item content, Type type, JsonSerializationContext context) {
+            JsonElement serialized = super.serialize(content, type, context);
+            if (!(content instanceof FixedItemHover fixedItemHover) || fixedItemHover.getComponents() == null) {
+                return serialized;
+            }
+            JsonObject serializedObject = serialized.getAsJsonObject();
+            serializedObject.remove("tag");
+            serializedObject.add("components", fixedItemHover.getComponents());
+            return serializedObject;
+        }
     }
 }

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
@@ -14,8 +14,6 @@ import com.denizenscript.denizen.nms.v1_17.impl.ProfileEditorImpl;
 import com.denizenscript.denizen.nms.v1_17.impl.SidebarImpl;
 import com.denizenscript.denizen.nms.v1_17.impl.blocks.BlockLightImpl;
 import com.denizenscript.denizen.nms.v1_17.impl.jnbt.CompoundTagImpl;
-import com.denizenscript.denizen.objects.ItemTag;
-import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
@@ -24,15 +22,10 @@ import com.google.common.collect.Iterables;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.HoverEvent;
-import net.md_5.bungee.api.chat.hover.content.Content;
-import net.md_5.bungee.api.chat.hover.content.Item;
-import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.StringTag;
-import net.minecraft.nbt.TagParser;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
@@ -42,7 +35,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Container;
 import net.minecraft.world.Nameable;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -54,7 +46,6 @@ import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftInventory;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftInventoryCustom;
-import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_17_R1.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
@@ -257,48 +248,6 @@ public class Handler extends NMSHandler {
         Biome biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getKey(biome);
         return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
-    }
-
-    @Override
-    public String stringForHover(HoverEvent hover) {
-        if (hover.getContents().isEmpty()) {
-            return "";
-        }
-        Content contentObject = hover.getContents().get(0);
-        if (contentObject instanceof Text) {
-            Object value = ((Text) contentObject).getValue();
-            if (value instanceof BaseComponent[]) {
-                return FormattedTextHelper.stringify((BaseComponent[]) value);
-            }
-            else {
-                return value.toString();
-            }
-        }
-        else if (contentObject instanceof Item) {
-            Item item = (Item) contentObject;
-            try {
-                net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-                tag.putString("id", item.getId());
-                tag.putByte("Count", (byte) item.getCount());
-                if (item.getTag() != null && item.getTag().getNbt() != null) {
-                    tag.put("tag", TagParser.parseTag(item.getTag().getNbt()));
-                }
-                ItemStack itemStack = ItemStack.of(tag);
-                return new ItemTag(CraftItemStack.asBukkitCopy(itemStack)).identify();
-            }
-            catch (Throwable ex) {
-                Debug.echoError(ex);
-                return null;
-            }
-        }
-        else if (contentObject instanceof net.md_5.bungee.api.chat.hover.content.Entity) {
-            net.md_5.bungee.api.chat.hover.content.Entity entity = (net.md_5.bungee.api.chat.hover.content.Entity) contentObject;
-            // TODO: Maybe a stabler way of doing this?
-            return "e@" + entity.getId();
-        }
-        else {
-            throw new UnsupportedOperationException();
-        }
     }
 
     @Override

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/ItemHelperImpl.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/helpers/ItemHelperImpl.java
@@ -165,8 +165,8 @@ public class ItemHelperImpl extends ItemHelper {
     }
 
     @Override
-    public String getRawHoverText(ItemStack itemStack) {
-        net.minecraft.nbt.CompoundTag tag = CraftItemStack.asNMSCopy(itemStack).getTag();
+    public String getLegacyHoverNbt(ItemTag item) {
+        net.minecraft.nbt.CompoundTag tag = CraftItemStack.asNMSCopy(item.getItemStack()).getTag();
         if (tag == null) {
             return null;
         }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
@@ -15,7 +15,6 @@ import com.denizenscript.denizen.nms.v1_18.impl.ProfileEditorImpl;
 import com.denizenscript.denizen.nms.v1_18.impl.SidebarImpl;
 import com.denizenscript.denizen.nms.v1_18.impl.blocks.BlockLightImpl;
 import com.denizenscript.denizen.nms.v1_18.impl.jnbt.CompoundTagImpl;
-import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
@@ -27,16 +26,11 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.HoverEvent;
-import net.md_5.bungee.api.chat.hover.content.Content;
-import net.md_5.bungee.api.chat.hover.content.Item;
-import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.StringTag;
-import net.minecraft.nbt.TagParser;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
@@ -47,7 +41,6 @@ import net.minecraft.world.Container;
 import net.minecraft.world.Nameable;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -60,7 +53,6 @@ import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventory;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryCustom;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryView;
-import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
@@ -280,48 +272,6 @@ public class Handler extends NMSHandler {
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getKey(biome.value());
         return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
-    }
-
-    @Override
-    public String stringForHover(HoverEvent hover) {
-        if (hover.getContents().isEmpty()) {
-            return "";
-        }
-        Content contentObject = hover.getContents().get(0);
-        if (contentObject instanceof Text) {
-            Object value = ((Text) contentObject).getValue();
-            if (value instanceof BaseComponent[]) {
-                return FormattedTextHelper.stringify((BaseComponent[]) value);
-            }
-            else {
-                return value.toString();
-            }
-        }
-        else if (contentObject instanceof Item) {
-            Item item = (Item) contentObject;
-            try {
-                net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-                tag.putString("id", item.getId());
-                tag.putByte("Count", item.getCount() == -1 ? 1 : (byte) item.getCount());
-                if (item.getTag() != null && item.getTag().getNbt() != null) {
-                    tag.put("tag", TagParser.parseTag(item.getTag().getNbt()));
-                }
-                ItemStack itemStack = ItemStack.of(tag);
-                return new ItemTag(CraftItemStack.asBukkitCopy(itemStack)).identify();
-            }
-            catch (Throwable ex) {
-                Debug.echoError(ex);
-                return null;
-            }
-        }
-        else if (contentObject instanceof net.md_5.bungee.api.chat.hover.content.Entity) {
-            net.md_5.bungee.api.chat.hover.content.Entity entity = (net.md_5.bungee.api.chat.hover.content.Entity) contentObject;
-            // TODO: Maybe a stabler way of doing this?
-            return "e@" + entity.getId();
-        }
-        else {
-            throw new UnsupportedOperationException();
-        }
     }
 
     @Override

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/ItemHelperImpl.java
@@ -171,15 +171,6 @@ public class ItemHelperImpl extends ItemHelper {
     }
 
     @Override
-    public String getRawHoverText(ItemStack itemStack) {
-        net.minecraft.nbt.CompoundTag tag = CraftItemStack.asNMSCopy(itemStack).getTag();
-        if (tag == null) {
-            return null;
-        }
-        return tag.toString();
-    }
-
-    @Override
     public PlayerProfile getSkullSkin(ItemStack is) {
         net.minecraft.world.item.ItemStack itemStack = CraftItemStack.asNMSCopy(is);
         if (itemStack.hasTag()) {

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
@@ -15,7 +15,6 @@ import com.denizenscript.denizen.nms.v1_19.impl.ProfileEditorImpl;
 import com.denizenscript.denizen.nms.v1_19.impl.SidebarImpl;
 import com.denizenscript.denizen.nms.v1_19.impl.blocks.BlockLightImpl;
 import com.denizenscript.denizen.nms.v1_19.impl.jnbt.CompoundTagImpl;
-import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
@@ -27,16 +26,11 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.HoverEvent;
-import net.md_5.bungee.api.chat.hover.content.Content;
-import net.md_5.bungee.api.chat.hover.content.Item;
-import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.StringTag;
-import net.minecraft.nbt.TagParser;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
@@ -48,7 +42,6 @@ import net.minecraft.world.Container;
 import net.minecraft.world.Nameable;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -63,7 +56,6 @@ import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftInventory;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftInventoryCustom;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftInventoryView;
-import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R3.persistence.CraftPersistentDataContainer;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftChatMessage;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
@@ -284,48 +276,6 @@ public class Handler extends NMSHandler {
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome.value());
         return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
-    }
-
-    @Override
-    public String stringForHover(HoverEvent hover) {
-        if (hover.getContents().isEmpty()) {
-            return "";
-        }
-        Content contentObject = hover.getContents().get(0);
-        if (contentObject instanceof Text) {
-            Object value = ((Text) contentObject).getValue();
-            if (value instanceof BaseComponent[]) {
-                return FormattedTextHelper.stringify((BaseComponent[]) value);
-            }
-            else {
-                return value.toString();
-            }
-        }
-        else if (contentObject instanceof Item) {
-            Item item = (Item) contentObject;
-            try {
-                net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-                tag.putString("id", item.getId());
-                tag.putByte("Count", item.getCount() == -1 ? 1 : (byte) item.getCount());
-                if (item.getTag() != null && item.getTag().getNbt() != null) {
-                    tag.put("tag", TagParser.parseTag(item.getTag().getNbt()));
-                }
-                ItemStack itemStack = ItemStack.of(tag);
-                return new ItemTag(CraftItemStack.asBukkitCopy(itemStack)).identify();
-            }
-            catch (Throwable ex) {
-                Debug.echoError(ex);
-                return null;
-            }
-        }
-        else if (contentObject instanceof net.md_5.bungee.api.chat.hover.content.Entity) {
-            net.md_5.bungee.api.chat.hover.content.Entity entity = (net.md_5.bungee.api.chat.hover.content.Entity) contentObject;
-            // TODO: Maybe a stabler way of doing this?
-            return "e@" + entity.getId();
-        }
-        else {
-            throw new UnsupportedOperationException();
-        }
     }
 
     @Override

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/ItemHelperImpl.java
@@ -175,15 +175,6 @@ public class ItemHelperImpl extends ItemHelper {
     }
 
     @Override
-    public String getRawHoverText(ItemStack itemStack) {
-        net.minecraft.nbt.CompoundTag tag = CraftItemStack.asNMSCopy(itemStack).getTag();
-        if (tag == null) {
-            return null;
-        }
-        return tag.toString();
-    }
-
-    @Override
     public PlayerProfile getSkullSkin(ItemStack is) {
         net.minecraft.world.item.ItemStack itemStack = CraftItemStack.asNMSCopy(is);
         if (itemStack.hasTag()) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
@@ -37,10 +37,6 @@ import com.mojang.authlib.yggdrasil.ProfileResult;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.HoverEvent;
-import net.md_5.bungee.api.chat.hover.content.Content;
-import net.md_5.bungee.api.chat.hover.content.Item;
-import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -68,7 +64,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.boss.BossBar;
-import org.bukkit.craftbukkit.v1_20_R4.CraftRegistry;
 import org.bukkit.craftbukkit.v1_20_R4.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R4.block.data.CraftBlockData;
@@ -333,49 +328,6 @@ public class Handler extends NMSHandler {
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome.value());
         return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
-    }
-
-    @Override
-    public String stringForHover(HoverEvent hover) {
-        if (hover.getContents().isEmpty()) {
-            return "";
-        }
-        Content contentObject = hover.getContents().get(0);
-        if (contentObject instanceof Text) {
-            Object value = ((Text) contentObject).getValue();
-            if (value instanceof BaseComponent[]) {
-                return FormattedTextHelper.stringify((BaseComponent[]) value);
-            }
-            else {
-                return value.toString();
-            }
-        }
-        else if (contentObject instanceof Item) {
-            Item item = (Item) contentObject;
-            try {
-                net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-                tag.putString("id", item.getId());
-                tag.putByte("Count", item.getCount() == -1 ? 1 : (byte) item.getCount());
-                if (item.getTag() != null && item.getTag().getNbt() != null) {
-                    tag.put("tag", TagParser.parseTag(item.getTag().getNbt()));
-                }
-                // TODO: 1.20.6: use components and fallback to creating item from tag when custom NBT is specified
-                ItemStack nmsStack = ItemStack.parseOptional(CraftRegistry.getMinecraftRegistry(), tag);
-                return new ItemTag(CraftItemStack.asBukkitCopy(nmsStack)).identify();
-            }
-            catch (Throwable ex) {
-                Debug.echoError(ex);
-                return null;
-            }
-        }
-        else if (contentObject instanceof net.md_5.bungee.api.chat.hover.content.Entity) {
-            net.md_5.bungee.api.chat.hover.content.Entity entity = (net.md_5.bungee.api.chat.hover.content.Entity) contentObject;
-            // TODO: Maybe a stabler way of doing this?
-            return "e@" + entity.getId();
-        }
-        else {
-            throw new UnsupportedOperationException();
-        }
     }
 
     @Override

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
@@ -38,10 +38,6 @@ import com.mojang.authlib.yggdrasil.ProfileResult;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.api.chat.HoverEvent;
-import net.md_5.bungee.api.chat.hover.content.Content;
-import net.md_5.bungee.api.chat.hover.content.Item;
-import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -62,10 +58,12 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.boss.BossBar;
-import org.bukkit.craftbukkit.v1_21_R3.CraftRegistry;
 import org.bukkit.craftbukkit.v1_21_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_21_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R3.block.data.CraftBlockData;
@@ -328,49 +326,6 @@ public class Handler extends NMSHandler {
         Holder<Biome> biome = level.getNoiseBiome(block.getX() >> 2, block.getY() >> 2, block.getZ() >> 2);
         ResourceLocation key = level.registryAccess().lookupOrThrow(Registries.BIOME).getKey(biome.value());
         return new BiomeNMSImpl(level, CraftNamespacedKey.fromMinecraft(key));
-    }
-
-    @Override
-    public String stringForHover(HoverEvent hover) {
-        if (hover.getContents().isEmpty()) {
-            return "";
-        }
-        Content contentObject = hover.getContents().get(0);
-        if (contentObject instanceof Text) {
-            Object value = ((Text) contentObject).getValue();
-            if (value instanceof BaseComponent[]) {
-                return FormattedTextHelper.stringify((BaseComponent[]) value);
-            }
-            else {
-                return value.toString();
-            }
-        }
-        else if (contentObject instanceof Item) {
-            Item item = (Item) contentObject;
-            try {
-                net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
-                tag.putString("id", item.getId());
-                tag.putByte("Count", item.getCount() == -1 ? 1 : (byte) item.getCount());
-                if (item.getTag() != null && item.getTag().getNbt() != null) {
-                    tag.put("tag", TagParser.parseTag(item.getTag().getNbt()));
-                }
-                // TODO: 1.20.6: use components and fallback to creating item from tag when custom NBT is specified
-                ItemStack nmsStack = ItemStack.parseOptional(CraftRegistry.getMinecraftRegistry(), tag);
-                return new ItemTag(CraftItemStack.asBukkitCopy(nmsStack)).identify();
-            }
-            catch (Throwable ex) {
-                Debug.echoError(ex);
-                return null;
-            }
-        }
-        else if (contentObject instanceof net.md_5.bungee.api.chat.hover.content.Entity) {
-            net.md_5.bungee.api.chat.hover.content.Entity entity = (net.md_5.bungee.api.chat.hover.content.Entity) contentObject;
-            // TODO: Maybe a stabler way of doing this?
-            return "e@" + entity.getId();
-        }
-        else {
-            throw new UnsupportedOperationException();
-        }
     }
 
     @Override


### PR DESCRIPTION
## Changes

- `HoverFormatHelper#tryInitializeItemHoverFix` is now called in `Denizen#onEnable` (can't just be in the static initializer, since the serialization needs to be correct before any script is run).
- `NMSHandler#stringForHover` has been moved to `HoverFormatHelper`, as it only had one minor part that needed NMS (which is handled via new `ItemHelper` methods now).
  It also now:
  - Creates the item normally and then applies components/nbt instead of desrializing it all from NBT. 
  - Uses `Registry.MATERIAL` to get the material from an id.
  - Checks for `FixedItemHover` and does the components patch application.
  - Uses `Unsafe#modifyItemStack` to apply NBT on older versions.
  - Uses modern `instanceof` pattern matching.
  - I forgot to put it in separate commits but here's a diff: https://www.diffchecker.com/AeqIq5Bo/
- `HoverFormatHelper#processHoverInput` now creates a `FixedItemHover` with the proper components json on 1.20+.

## Additions

- `ItemHelper#getLegacyHoverNbt` (replacing `getRawHoverText`) - for getting an SNBT string for item hovers on versions below 1.20.
- `ItemHelper#getRawHoverComponentsJson` - for getting an item's components patch as a `JsonObject`.
- `ItemHelper#applyRawHoverComponentsJson` - for applying a `JsonObject` components patch to an item.
- `HoverFormatHelper#tryInitializeItemHoverFix` - modifies Bungee chat's `Gson` serializer to accept `FixedItemHover` and properly deserialize normal ones where possible with reflection.
- `HoverFormatHelper$FixedItemHover` - extends Bungee chat's `Item` hover, and adds a `JsonObject components` field for proper hover handling.
- `HoverFormatHelper$FixedItemHoverSerializer` - extends Bungee chat's `ItemSerializer`, and:
  - When deserializing, if a `components` field is present, returns a `FixedItemHover` with it - normal `Item` otherwise.
  - When serializing, if the object is a `FixedItemHover` with components, removes the `tag` key and adds in a `components` key with it's components JSON.

> [!NOTE]
> ### `FixedItemHover` compatibility
> Currently it overrides `getTag` to return a best-effort version that's just the raw components patch json.
> This is somewhat compatible as it's just a string internally? but technically speaking it isn't SNBT, so not sure what's the best course of action there:
> 1. Just return `null` and match the normal impl's bug.
> 2. Return the components JSON like right now, which works for any sorta debug messages, null checks, or similar basic compact (especially as it's just a `String` in practice)
>3. Add full-on components JSON to SNBT `ItemHelper` methods to provide the full experience™️(more work, but full compact in theory).

> [!NOTE]
> Not sure how much invalid input handling should the deserializer have? like, should it account for a different value type under a `components` key and stuff like that?