### PR TITLE
1.20 Networking cleanups

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/packets/PacketOutChat.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/packets/PacketOutChat.java
@@ -12,5 +12,6 @@ public abstract class PacketOutChat {
 
     public abstract String getRawJson();
 
+    // TODO: once 1.20 is the minimum supported version, remove this
     public static Function<Object, String> convertComponentToJsonString;
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -49,14 +49,12 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class DenizenNetworkManagerImpl extends Connection {
-    // TODO: 1.20.6: there are some new methods that should potentially be overriden
 
-    // TODO: 1.20.6: this can be cleaned up by decoding with the codec and returning the new packet
-    public static <T extends Packet<?>, B extends FriendlyByteBuf> RegistryFriendlyByteBuf copyPacket(T original, StreamCodec<B, T> packetCodec) {
+    public static <T extends Packet<?>> T copyPacket(T original, StreamCodec<? super RegistryFriendlyByteBuf, T> packetCodec) {
         try {
             RegistryFriendlyByteBuf copier = new RegistryFriendlyByteBuf(Unpooled.buffer(), CraftRegistry.getMinecraftRegistry());
-            packetCodec.encode((B) copier, original);
-            return copier;
+            packetCodec.encode(copier, original);
+            return packetCodec.decode(copier);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/FakeBlockHelper.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/FakeBlockHelper.java
@@ -90,7 +90,7 @@ public class FakeBlockHelper {
 
     public static ClientboundLevelChunkWithLightPacket handleMapChunkPacket(World world, ClientboundLevelChunkWithLightPacket originalPacket, int chunkX, int chunkZ, List<FakeBlock> blocks) {
         try {
-            ClientboundLevelChunkWithLightPacket duplicateCorePacket = ClientboundLevelChunkWithLightPacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket(originalPacket, ClientboundLevelChunkWithLightPacket.STREAM_CODEC));
+            ClientboundLevelChunkWithLightPacket duplicateCorePacket = DenizenNetworkManagerImpl.copyPacket(originalPacket, ClientboundLevelChunkWithLightPacket.STREAM_CODEC);
             copyPacketPaperPatch(duplicateCorePacket, originalPacket);
             RegistryFriendlyByteBuf copier = new RegistryFriendlyByteBuf(Unpooled.buffer(), CraftRegistry.getMinecraftRegistry());
             originalPacket.getChunkData().write(copier);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/AttachPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/AttachPacketHandlers.java
@@ -181,7 +181,7 @@ public class AttachPacketHandlers {
             for (EntityAttachmentHelper.PlayerAttachMap attMap : attList.attachedToMap.values()) {
                 EntityAttachmentHelper.AttachmentData att = attMap.getAttachment(networkManager.player.getUUID());
                 if (attMap.attached.isValid() && att != null) {
-                    ClientboundSetEntityMotionPacket pNew = ClientboundSetEntityMotionPacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket(packet, ClientboundSetEntityMotionPacket.STREAM_CODEC));
+                    ClientboundSetEntityMotionPacket pNew = DenizenNetworkManagerImpl.copyPacket(packet, ClientboundSetEntityMotionPacket.STREAM_CODEC);
                     ENTITY_ID_PACKVELENT.setInt(pNew, att.attached.getBukkitEntity().getEntityId());
                     if (NMSHandler.debugPackets) {
                         DenizenNetworkManagerImpl.doPacketOutput("Attach Velocity Packet: " + pNew.getClass().getCanonicalName() + " for " + att.attached.getUUID() + " sent to " + networkManager.player.getScoreboardName());
@@ -203,7 +203,7 @@ public class AttachPacketHandlers {
             for (EntityAttachmentHelper.PlayerAttachMap attMap : attList.attachedToMap.values()) {
                 EntityAttachmentHelper.AttachmentData att = attMap.getAttachment(networkManager.player.getUUID());
                 if (attMap.attached.isValid() && att != null) {
-                    ClientboundTeleportEntityPacket pNew = ClientboundTeleportEntityPacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket(packet, ClientboundTeleportEntityPacket.STREAM_CODEC));
+                    ClientboundTeleportEntityPacket pNew = DenizenNetworkManagerImpl.copyPacket(packet, ClientboundTeleportEntityPacket.STREAM_CODEC);
                     ENTITY_ID_PACKTELENT.setInt(pNew, att.attached.getBukkitEntity().getEntityId());
                     Vector resultPos = new Vector(POS_X_PACKTELENT.getDouble(pNew), POS_Y_PACKTELENT.getDouble(pNew), POS_Z_PACKTELENT.getDouble(pNew)).add(relative);
                     if (att.positionalOffset != null) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/DisguisePacketHandlers.java
@@ -114,7 +114,7 @@ public class DisguisePacketHandlers {
 
     public static ClientboundTeleportEntityPacket processTeleportPacket(DenizenNetworkManagerImpl networkManager, ClientboundTeleportEntityPacket teleportEntityPacket, DisguiseCommand.TrackedDisguise disguise) throws IllegalAccessException {
         if (disguise.as.getBukkitEntityType() == EntityType.ENDER_DRAGON) {
-            ClientboundTeleportEntityPacket pNew = ClientboundTeleportEntityPacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket(teleportEntityPacket, ClientboundTeleportEntityPacket.STREAM_CODEC));
+            ClientboundTeleportEntityPacket pNew = DenizenNetworkManagerImpl.copyPacket(teleportEntityPacket, ClientboundTeleportEntityPacket.STREAM_CODEC);
             TELEPORT_PACKET_YAW.setByte(pNew, EntityAttachmentHelper.adaptedCompressedAngle(teleportEntityPacket.getyRot(), 180));
             return pNew;
         }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakeBlocksPacketHandlers.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/handlers/packet/FakeBlocksPacketHandlers.java
@@ -50,17 +50,17 @@ public class FakeBlocksPacketHandlers {
                 ClientboundLevelChunkWithLightPacket newPacket = FakeBlockHelper.handleMapChunkPacket(networkManager.player.getBukkitEntity().getWorld(), (ClientboundLevelChunkWithLightPacket) packet, chunkX, chunkZ, blocks);
                 return newPacket;
             }
-            else if (packet instanceof ClientboundSectionBlocksUpdatePacket) {
+            else if (packet instanceof ClientboundSectionBlocksUpdatePacket sectionBlocksUpdatePacket) {
                 FakeBlock.FakeBlockMap map = FakeBlock.blocks.get(networkManager.player.getUUID());
                 if (map == null) {
-                    return packet;
+                    return sectionBlocksUpdatePacket;
                 }
-                SectionPos coord = (SectionPos) SECTIONPOS_MULTIBLOCKCHANGE.get(packet);
+                SectionPos coord = (SectionPos) SECTIONPOS_MULTIBLOCKCHANGE.get(sectionBlocksUpdatePacket);
                 ChunkCoordinate coordinateDenizen = new ChunkCoordinate(coord.getX(), coord.getZ(), networkManager.player.level().getWorld().getName());
                 if (!map.byChunk.containsKey(coordinateDenizen)) {
-                    return packet;
+                    return sectionBlocksUpdatePacket;
                 }
-                ClientboundSectionBlocksUpdatePacket newPacket = ClientboundSectionBlocksUpdatePacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket((ClientboundSectionBlocksUpdatePacket) packet, ClientboundSectionBlocksUpdatePacket.STREAM_CODEC));
+                ClientboundSectionBlocksUpdatePacket newPacket = DenizenNetworkManagerImpl.copyPacket(sectionBlocksUpdatePacket, ClientboundSectionBlocksUpdatePacket.STREAM_CODEC);
                 LocationTag location = new LocationTag(networkManager.player.level().getWorld(), 0, 0, 0);
                 short[] originalOffsetArray = (short[])OFFSETARRAY_MULTIBLOCKCHANGE.get(newPacket);
                 BlockState[] originalDataArray = (BlockState[])BLOCKARRAY_MULTIBLOCKCHANGE.get(newPacket);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/packets/PacketOutChatImpl.java
@@ -2,14 +2,10 @@ package com.denizenscript.denizen.nms.v1_20.impl.network.packets;
 
 import com.denizenscript.denizen.nms.interfaces.packets.PacketOutChat;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
-import com.denizenscript.denizencore.utilities.ReflectionHelper;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
 import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftChatMessage;
-
-import java.lang.reflect.Field;
 
 public class PacketOutChatImpl extends PacketOutChat {
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/network/packets/PacketOutChatImpl.java
@@ -19,24 +19,9 @@ public class PacketOutChatImpl extends PacketOutChat {
     public String rawJson;
     public boolean isOverlayActionbar;
 
-    public static Field paperTextField;
-
     public PacketOutChatImpl(ClientboundSystemChatPacket internal) {
         systemPacket = internal;
         rawJson = CraftChatMessage.toJSON(internal.content());
-        if (rawJson == null && convertComponentToJsonString != null) {
-            try {
-                if (paperTextField == null) {
-                    paperTextField = ReflectionHelper.getFields(ClientboundSystemChatPacket.class).get("adventure$content");
-                }
-                if (paperTextField != null) {
-                    rawJson = convertComponentToJsonString.apply(paperTextField.get(internal));
-                }
-            }
-            catch (Throwable ex) {
-                Debug.echoError(ex);
-            }
-        }
         message = FormattedTextHelper.stringify(ComponentSerializer.parse(rawJson));
         isOverlayActionbar = internal.overlay();
     }

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/DenizenNetworkManagerImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/DenizenNetworkManagerImpl.java
@@ -51,12 +51,11 @@ import java.util.stream.Collectors;
 
 public class DenizenNetworkManagerImpl extends Connection {
 
-    // TODO: 1.20.6: this can be cleaned up by decoding with the codec and returning the new packet
-    public static <T extends Packet<?>, B extends FriendlyByteBuf> RegistryFriendlyByteBuf copyPacket(T original, StreamCodec<B, T> packetCodec) {
+    public static <T extends Packet<?>> T copyPacket(T original, StreamCodec<? super RegistryFriendlyByteBuf, T> packetCodec) {
         try {
             RegistryFriendlyByteBuf copier = new RegistryFriendlyByteBuf(Unpooled.buffer(), CraftRegistry.getMinecraftRegistry());
-            packetCodec.encode((B) copier, original);
-            return copier;
+            packetCodec.encode(copier, original);
+            return packetCodec.decode(copier);
         }
         catch (Throwable ex) {
             Debug.echoError(ex);

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/FakeBlockHelper.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/FakeBlockHelper.java
@@ -90,7 +90,7 @@ public class FakeBlockHelper {
 
     public static ClientboundLevelChunkWithLightPacket handleMapChunkPacket(World world, ClientboundLevelChunkWithLightPacket originalPacket, int chunkX, int chunkZ, List<FakeBlock> blocks) {
         try {
-            ClientboundLevelChunkWithLightPacket duplicateCorePacket = ClientboundLevelChunkWithLightPacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket(originalPacket, ClientboundLevelChunkWithLightPacket.STREAM_CODEC));
+            ClientboundLevelChunkWithLightPacket duplicateCorePacket = DenizenNetworkManagerImpl.copyPacket(originalPacket, ClientboundLevelChunkWithLightPacket.STREAM_CODEC);
             copyPacketPaperPatch(duplicateCorePacket, originalPacket);
             RegistryFriendlyByteBuf copier = new RegistryFriendlyByteBuf(Unpooled.buffer(), CraftRegistry.getMinecraftRegistry());
             originalPacket.getChunkData().write(copier);

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/packet/AttachPacketHandlers.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/packet/AttachPacketHandlers.java
@@ -177,7 +177,7 @@ public class AttachPacketHandlers {
             for (EntityAttachmentHelper.PlayerAttachMap attMap : attList.attachedToMap.values()) {
                 EntityAttachmentHelper.AttachmentData att = attMap.getAttachment(networkManager.player.getUUID());
                 if (attMap.attached.isValid() && att != null) {
-                    ClientboundSetEntityMotionPacket pNew = ClientboundSetEntityMotionPacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket(packet, ClientboundSetEntityMotionPacket.STREAM_CODEC));
+                    ClientboundSetEntityMotionPacket pNew = DenizenNetworkManagerImpl.copyPacket(packet, ClientboundSetEntityMotionPacket.STREAM_CODEC);
                     ENTITY_ID_PACKVELENT.setInt(pNew, att.attached.getBukkitEntity().getEntityId());
                     if (NMSHandler.debugPackets) {
                         DenizenNetworkManagerImpl.doPacketOutput("Attach Velocity Packet: " + pNew.getClass().getCanonicalName() + " for " + att.attached.getUUID() + " sent to " + networkManager.player.getScoreboardName());

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/packet/FakeBlocksPacketHandlers.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/packet/FakeBlocksPacketHandlers.java
@@ -50,17 +50,17 @@ public class FakeBlocksPacketHandlers {
                 ClientboundLevelChunkWithLightPacket newPacket = FakeBlockHelper.handleMapChunkPacket(networkManager.player.getBukkitEntity().getWorld(), (ClientboundLevelChunkWithLightPacket) packet, chunkX, chunkZ, blocks);
                 return newPacket;
             }
-            else if (packet instanceof ClientboundSectionBlocksUpdatePacket) {
+            else if (packet instanceof ClientboundSectionBlocksUpdatePacket sectionBlocksUpdatePacket) {
                 FakeBlock.FakeBlockMap map = FakeBlock.blocks.get(networkManager.player.getUUID());
                 if (map == null) {
-                    return packet;
+                    return sectionBlocksUpdatePacket;
                 }
-                SectionPos coord = (SectionPos) SECTIONPOS_MULTIBLOCKCHANGE.get(packet);
+                SectionPos coord = (SectionPos) SECTIONPOS_MULTIBLOCKCHANGE.get(sectionBlocksUpdatePacket);
                 ChunkCoordinate coordinateDenizen = new ChunkCoordinate(coord.getX(), coord.getZ(), networkManager.player.level().getWorld().getName());
                 if (!map.byChunk.containsKey(coordinateDenizen)) {
-                    return packet;
+                    return sectionBlocksUpdatePacket;
                 }
-                ClientboundSectionBlocksUpdatePacket newPacket = ClientboundSectionBlocksUpdatePacket.STREAM_CODEC.decode(DenizenNetworkManagerImpl.copyPacket((ClientboundSectionBlocksUpdatePacket) packet, ClientboundSectionBlocksUpdatePacket.STREAM_CODEC));
+                ClientboundSectionBlocksUpdatePacket newPacket = DenizenNetworkManagerImpl.copyPacket(sectionBlocksUpdatePacket, ClientboundSectionBlocksUpdatePacket.STREAM_CODEC);
                 LocationTag location = new LocationTag(networkManager.player.level().getWorld(), 0, 0, 0);
                 short[] originalOffsetArray = (short[])OFFSETARRAY_MULTIBLOCKCHANGE.get(newPacket);
                 BlockState[] originalDataArray = (BlockState[])BLOCKARRAY_MULTIBLOCKCHANGE.get(newPacket);

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/packets/PacketOutChatImpl.java
@@ -2,14 +2,10 @@ package com.denizenscript.denizen.nms.v1_21.impl.network.packets;
 
 import com.denizenscript.denizen.nms.interfaces.packets.PacketOutChat;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
-import com.denizenscript.denizencore.utilities.ReflectionHelper;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
 import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
 import org.bukkit.craftbukkit.v1_21_R3.util.CraftChatMessage;
-
-import java.lang.reflect.Field;
 
 public class PacketOutChatImpl extends PacketOutChat {
 

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/packets/PacketOutChatImpl.java
@@ -19,24 +19,9 @@ public class PacketOutChatImpl extends PacketOutChat {
     public String rawJson;
     public boolean isOverlayActionbar;
 
-    public static Field paperTextField;
-
     public PacketOutChatImpl(ClientboundSystemChatPacket internal) {
         systemPacket = internal;
         rawJson = CraftChatMessage.toJSON(internal.content());
-        if (rawJson == null && convertComponentToJsonString != null) {
-            try {
-                if (paperTextField == null) {
-                    paperTextField = ReflectionHelper.getFields(ClientboundSystemChatPacket.class).get("adventure$content");
-                }
-                if (paperTextField != null) {
-                    rawJson = convertComponentToJsonString.apply(paperTextField.get(internal));
-                }
-            }
-            catch (Throwable ex) {
-                Debug.echoError(ex);
-            }
-        }
         message = FormattedTextHelper.stringify(ComponentSerializer.parse(rawJson));
         isOverlayActionbar = internal.overlay();
     }


### PR DESCRIPTION
## Changes

- `DenizenNetworkManagerImpl#copyPacket` now fully copies the packet (by encoding & decoding it) instead of just returning the encoded `ByteBuf` & did some small generics fixups.
- Removed `adventure$content` reflection from `PacketOutChatImpl`, as Paper doesn't do that anymore (on 1.20+, still on 1.19).
- Some more `instanceof` pattern matching.