### PR TITLE
Fix `VanillaTagHelper` on 1.20+

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
@@ -89,9 +89,6 @@ public class VanillaTagHelper {
             addMaterialTag(tag);
         }
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) { // Note: existed on prior versions, but was bugged
-            for (Tag<Material> tag : Bukkit.getTags("fluids", Material.class)) {
-                addMaterialTag(tag);
-            }
             for (Tag<EntityType> tag : Bukkit.getTags("entity_types", EntityType.class)) {
                 addEntityTag(tag);
             }


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1327711248116351016).

As far as I can see `Bukkit.getTags("fluids", Material.class)` was never really valid due to fluids and materials being a separate thing, and just only now broke because Spigot fixed the class check there?
Can keep it on older versions if you want to, but from some quick testing it doesn't look like it ever worked, `<server.vanilla_tagged_materials[water]>` errors on 1.17.