### PR TITLE
ProjectileLaunchedScriptEvent updates

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
@@ -17,8 +17,6 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
     // projectile launched
     // <entity> launched
     //
-    // @Regex ^on [^\s]+ launched$
-    //
     // @Group Entity
     //
     // @Switch by:<entity> to only process the event if the projectile shooter matches the specified entity matcher.
@@ -67,7 +65,7 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
                 yield projectile;
             }
             case "projectile" -> projectile;
-            case "shooter" -> shooter;
+            case "shooter" -> shooter.getDenizenObject();
             default -> super.getContext(name);
         };
     }
@@ -81,6 +79,6 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
         location = projectile.getLocation();
         shooter = projectile.getShooter();
         fire(event);
-        EntityTag.forgetEntity(event.getEntity());
+        EntityTag.forgetEntity(entity);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
@@ -1,10 +1,11 @@
 package com.denizenscript.denizen.events.entity;
 
 import com.denizenscript.denizen.objects.EntityTag;
-import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
@@ -20,6 +21,8 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
     //
     // @Group Entity
     //
+    // @Switch by:<entity> to only process the event if the projectile shooter matches the specified entity matcher.
+    //
     // @Location true
     //
     // @Cancellable true
@@ -33,6 +36,8 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
     // -->
 
     public ProjectileLaunchedScriptEvent() {
+        registerCouldMatcher("<entity> launched");
+        registerCouldMatcher("projectile launched");
         registerSwitches("by");
     }
 
@@ -42,26 +47,14 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
     public EntityTag shooter;
 
     @Override
-    public boolean couldMatch(ScriptPath path) {
-        if (!path.eventArgLowerAt(1).equals("launched")) {
-            return false;
-        }
-        if (!couldMatchEntity(path.eventArgLowerAt(0))) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryObjectSwitch("by", shooter)) {
-            return false;
-        }
-        String projTest = path.eventArgLowerAt(0);
-        if (!projTest.equals("projectile") && !projectile.tryAdvancedMatcher(projTest, path.context)) {
-            return false;
-        }
         if (!runInCheck(path, location)) {
+            return false;
+        }
+        if (!path.tryArgObject(0, projectile)) {
+            return false;
+        }
+        if (!path.tryObjectSwitch("by", shooter)) {
             return false;
         }
         return super.matches(path);
@@ -82,10 +75,13 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
 
     @EventHandler
     public void onProjectileLaunched(ProjectileLaunchEvent event) {
+        Entity entity = event.getEntity();
+        EntityTag.rememberEntity(entity);
         this.event = event;
-        projectile = new EntityTag(event.getEntity());
+        projectile = new EntityTag(entity);
         location = projectile.getLocation();
         shooter = projectile.getShooter();
         fire(event);
+        EntityTag.forgetEntity(event.getEntity());
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
@@ -3,8 +3,8 @@ package com.denizenscript.denizen.events.entity;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
@@ -27,16 +27,19 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
     // @Triggers when a projectile is launched.
     //
     // @Context
-    // <context.entity> returns the projectile.
+    // <context.projectile> returns an EntityTag of the projectile.
+    // <context.shooter> returns an EntityTag of the entity that shot the projectile, if any.
     //
     // -->
 
     public ProjectileLaunchedScriptEvent() {
+        registerSwitches("by");
     }
 
     public EntityTag projectile;
     private LocationTag location;
     public ProjectileLaunchEvent event;
+    public EntityTag shooter;
 
     @Override
     public boolean couldMatch(ScriptPath path) {
@@ -51,6 +54,9 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
 
     @Override
     public boolean matches(ScriptPath path) {
+        if (!path.tryObjectSwitch("by", shooter)) {
+            return false;
+        }
         String projTest = path.eventArgLowerAt(0);
         if (!projTest.equals("projectile") && !projectile.tryAdvancedMatcher(projTest, path.context)) {
             return false;
@@ -63,20 +69,23 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("entity")) {
-            return projectile.getDenizenObject();
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "entity" -> {
+                BukkitImplDeprecations.projectileLaunchedEntityContext.warn();
+                yield projectile;
+            }
+            case "projectile" -> projectile;
+            case "shooter" -> shooter;
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler
     public void onProjectileLaunched(ProjectileLaunchEvent event) {
-        Entity projectile = event.getEntity();
-        EntityTag.rememberEntity(projectile);
-        this.projectile = new EntityTag(projectile);
-        location = new LocationTag(event.getEntity().getLocation());
         this.event = event;
+        projectile = new EntityTag(event.getEntity());
+        location = projectile.getLocation();
+        shooter = projectile.getShooter();
         fire(event);
-        EntityTag.forgetEntity(projectile);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/ProjectileLaunchedScriptEvent.java
@@ -37,7 +37,6 @@ public class ProjectileLaunchedScriptEvent extends BukkitScriptEvent implements 
 
     public ProjectileLaunchedScriptEvent() {
         registerCouldMatcher("<entity> launched");
-        registerCouldMatcher("projectile launched");
         registerSwitches("by");
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -450,7 +450,7 @@ public class BukkitImplDeprecations {
     public static Warning playEffectSpecialDataListInput = new FutureWarning("playEffectSpecialDataListInput", "List input for the special_data argument in playeffect command is now deprecated. Please use a MapTag instead.");
 
     // Added 2025/01/23
-    public static Warning projectileLaunchedEntityContext = new FutureWarning("projectileLaunchedEntityContext", "'context.entity' in the '<projectile>/<entity> launched' event is deprecated in favor of 'context.projectile'.");
+    public static Warning projectileLaunchedEntityContext = new FutureWarning("projectileLaunchedEntityContext", "'context.entity' in the 'projectile launched' event is deprecated in favor of 'context.projectile'.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -449,6 +449,9 @@ public class BukkitImplDeprecations {
     // Added 2025/01/04
     public static Warning playEffectSpecialDataListInput = new FutureWarning("playEffectSpecialDataListInput", "List input for the special_data argument in playeffect command is now deprecated. Please use a MapTag instead.");
 
+    // Added 2025/01/23
+    public static Warning projectileLaunchedEntityContext = new FutureWarning("projectileLaunchedEntityContext", "'context.entity' in the '<projectile>/<entity> launched' event is deprecated in favor of 'context.projectile'.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2023/10/29 without warning.


### PR DESCRIPTION
- <context.shooter> added to "ProjectileLaunchedScriptEvent"
- <context.entity> deprecated and replaced with <context.projectile> since there are technically multiple entities.