### PR TITLE
Opentrades meta update

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/TradeTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/TradeTag.java
@@ -41,9 +41,9 @@ public class TradeTag implements ObjectTag, Adjustable {
     // For example, the following command opens a virtual merchant inventory with two merchant trades.
     // The first trade offers a sponge for two emeralds, can be used up to 10 times,
     // and offers XP upon a successful transaction.
-    // The second trade has zero maximum uses and displays a barrier.
+    // The second trade has zero maximum uses and displays a barrier in the input and output slots.
     // <code>
-    // - opentrades trade[max_uses=10;inputs=emerald[quantity=2];result=sponge]|trade[result=barrier]
+    // - opentrades trade[max_uses=10;inputs=emerald[quantity=2];result=sponge]|trade[inputs=barrier;result=barrier]
     // </code>
     //
     // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/OpenTradesCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/OpenTradesCommand.java
@@ -55,7 +55,7 @@ public class OpenTradesCommand extends AbstractCommand {
     //
     // @Usage
     // Use to open a list of trades with an optional title.
-    // - opentrades trade[result=stone;inputs=stone;max_uses=9999]|trade[result=barrier] "title:Useless Trades"
+    // - opentrades trade[result=stone;inputs=stone;max_uses=9999]|trade[inputs=barrier;result=barrier] "title:Useless Trades"
     //
     // @Usage
     // Use to force a player to trade with a villager.


### PR DESCRIPTION
Discovered in https://discord.com/channels/315163488085475337/1343781197297356920, the use of just the `results` property results in an error without an input(s).