### PR TITLE
`MaterialTag.vanilla_tags` 1.21 fixes

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperEventHelpers.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperEventHelpers.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizencore.objects.core.ScriptTag;
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent;
 import io.papermc.paper.event.server.ServerResourcesReloadedEvent;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 public class PaperEventHelpers implements Listener {
@@ -22,7 +23,7 @@ public class PaperEventHelpers implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onServerResourcesReloaded(ServerResourcesReloadedEvent event) {
         VanillaTagHelper.loadTagsCache();
     }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperEventHelpers.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperEventHelpers.java
@@ -2,9 +2,11 @@ package com.denizenscript.denizen.paper;
 
 import com.denizenscript.denizen.objects.InventoryTag;
 import com.denizenscript.denizen.scripts.containers.core.InventoryScriptContainer;
+import com.denizenscript.denizen.utilities.VanillaTagHelper;
 import com.denizenscript.denizen.utilities.inventory.InventoryViewUtil;
 import com.denizenscript.denizencore.objects.core.ScriptTag;
 import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent;
+import io.papermc.paper.event.server.ServerResourcesReloadedEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -18,5 +20,10 @@ public class PaperEventHelpers implements Listener {
                 event.setCancelled(true);
             }
         }
+    }
+
+    @EventHandler
+    public void onServerResourcesReloaded(ServerResourcesReloadedEvent event) {
+        VanillaTagHelper.loadTagsCache();
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
@@ -41,12 +41,6 @@ public class BlockTagsSetter {
 
     Map<TypedKey<BlockType>, Set<TagKey<BlockType>>> modifiedTags = new HashMap<>();
 
-    public void setTags(Material material, Set<NamespacedKey> tags) {
-        TypedKey<BlockType> blockKey = TypedKey.create(RegistryKey.BLOCK, material.getKey());
-        modifiedTags.put(blockKey, tags.stream().map(tag -> TagKey.create(RegistryKey.BLOCK, tag)).collect(Collectors.toSet()));
-        Bukkit.reloadData();
-    }
-
     public BlockTagsSetter(JavaPlugin plugin) {
         try {
             File pluginSourceFile = (File) JAVA_PLUGIN_GET_FILE.invoke(plugin);
@@ -74,5 +68,11 @@ public class BlockTagsSetter {
         catch (Throwable e) {
             Debug.echoError(e);
         }
+    }
+
+    public void setTags(Material material, Set<NamespacedKey> tags) {
+        TypedKey<BlockType> blockKey = TypedKey.create(RegistryKey.BLOCK, material.getKey());
+        modifiedTags.put(blockKey, tags.stream().map(tag -> TagKey.create(RegistryKey.BLOCK, tag)).collect(Collectors.toSet()));
+        Bukkit.reloadData();
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
@@ -19,9 +19,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.block.BlockType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.File;
 import java.lang.invoke.MethodHandle;
 import java.nio.file.Path;
 import java.util.*;
@@ -29,7 +27,6 @@ import java.util.stream.Collectors;
 
 public class BlockTagsSetter implements Listener {
 
-    public static final MethodHandle JAVA_PLUGIN_GET_FILE = ReflectionHelper.getMethodHandle(JavaPlugin.class, "getFile");
     public static final MethodHandle BOOTSTRAP_CONTEXT_CONSTRUCTOR;
 
     static {
@@ -47,11 +44,10 @@ public class BlockTagsSetter implements Listener {
     public Map<TypedKey<BlockType>, Set<TagKey<BlockType>>> modifiedTags = new HashMap<>();
     public boolean batchReloadNeeded;
 
-    public BlockTagsSetter(JavaPlugin plugin) {
+    public BlockTagsSetter(Denizen plugin) {
         Bukkit.getPluginManager().registerEvents(this, plugin);
         try {
-            File pluginSourceFile = (File) JAVA_PLUGIN_GET_FILE.invoke(plugin);
-            BootstrapContext fakeContext = (BootstrapContext) BOOTSTRAP_CONTEXT_CONSTRUCTOR.invoke(plugin.getPluginMeta(), plugin.getDataPath(), plugin.getComponentLogger(), pluginSourceFile.toPath());
+            BootstrapContext fakeContext = (BootstrapContext) BOOTSTRAP_CONTEXT_CONSTRUCTOR.invoke(plugin.getPluginMeta(), plugin.getDataPath(), plugin.getComponentLogger(), plugin.getFile().toPath());
             fakeContext.getLifecycleManager().registerEventHandler(LifecycleEvents.TAGS.postFlatten(RegistryKey.BLOCK), event -> {
                 Map<TagKey<BlockType>, Collection<TypedKey<BlockType>>> allTags = event.registrar().getAllTags();
                 for (Map.Entry<TypedKey<BlockType>, Set<TagKey<BlockType>>> entry : modifiedTags.entrySet()) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
@@ -1,0 +1,78 @@
+package com.denizenscript.denizen.paper.utilities;
+
+import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizencore.utilities.ReflectionHelper;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import io.papermc.paper.plugin.bootstrap.BootstrapContext;
+import io.papermc.paper.plugin.configuration.PluginMeta;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.tag.TagKey;
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.BlockType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.lang.invoke.MethodHandle;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class BlockTagsSetter {
+
+    public static final MethodHandle JAVA_PLUGIN_GET_FILE = ReflectionHelper.getMethodHandle(JavaPlugin.class, "getFile");
+    public static final MethodHandle BOOTSTRAP_CONTEXT_CONSTRUCTOR;
+
+    static {
+        try {
+            Class<?> bootstrapContextImplClass = Class.forName("io.papermc.paper.plugin.bootstrap.PluginBootstrapContextImpl");
+            BOOTSTRAP_CONTEXT_CONSTRUCTOR = ReflectionHelper.getConstructor(bootstrapContextImplClass, PluginMeta.class, Path.class, ComponentLogger.class, Path.class);
+        }
+        catch (Throwable e) {
+            throw new RuntimeException("Failed to initialize BlockTagsSetter", e);
+        }
+    }
+
+    public static final BlockTagsSetter INSTANCE = new BlockTagsSetter(Denizen.getInstance());
+
+    Map<TypedKey<BlockType>, Set<TagKey<BlockType>>> modifiedTags = new HashMap<>();
+
+    public void setTags(Material material, Set<NamespacedKey> tags) {
+        TypedKey<BlockType> blockKey = TypedKey.create(RegistryKey.BLOCK, material.getKey());
+        modifiedTags.put(blockKey, tags.stream().map(tag -> TagKey.create(RegistryKey.BLOCK, tag)).collect(Collectors.toSet()));
+        Bukkit.reloadData();
+    }
+
+    public BlockTagsSetter(JavaPlugin plugin) {
+        try {
+            File pluginSourceFile = (File) JAVA_PLUGIN_GET_FILE.invoke(plugin);
+            BootstrapContext fakeContext = (BootstrapContext) BOOTSTRAP_CONTEXT_CONSTRUCTOR.invoke(plugin.getPluginMeta(), plugin.getDataPath(), plugin.getComponentLogger(), pluginSourceFile.toPath());
+            fakeContext.getLifecycleManager().registerEventHandler(LifecycleEvents.TAGS.postFlatten(RegistryKey.BLOCK), event -> {
+                Map<TagKey<BlockType>, Collection<TypedKey<BlockType>>> allTags = event.registrar().getAllTags();
+                for (Map.Entry<TypedKey<BlockType>, Set<TagKey<BlockType>>> entry : modifiedTags.entrySet()) {
+                    TypedKey<BlockType> blockType = entry.getKey();
+                    Set<TagKey<BlockType>> tags = entry.getValue();
+                    for (Map.Entry<TagKey<BlockType>, Collection<TypedKey<BlockType>>> tagEntry : allTags.entrySet()) {
+                        TagKey<BlockType> tagKey = tagEntry.getKey();
+                        Collection<TypedKey<BlockType>> values = tagEntry.getValue();
+                        if (values.contains(blockType) && !tags.contains(tagKey)) {
+                            List<TypedKey<BlockType>> modifiedValues = new ArrayList<>(values);
+                            modifiedValues.remove(blockType);
+                            event.registrar().setTag(tagKey, modifiedValues);
+                        }
+                    }
+                    for (TagKey<BlockType> tag : tags) {
+                        event.registrar().addToTag(tag, List.of(blockType));
+                    }
+                }
+            });
+        }
+        catch (Throwable e) {
+            Debug.echoError(e);
+        }
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/BlockTagsSetter.java
@@ -1,8 +1,11 @@
 package com.denizenscript.denizen.paper.utilities;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.VanillaTagHelper;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.destroystokyo.paper.event.server.ServerTickEndEvent;
 import io.papermc.paper.plugin.bootstrap.BootstrapContext;
 import io.papermc.paper.plugin.configuration.PluginMeta;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
@@ -14,6 +17,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.BlockType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -22,7 +27,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class BlockTagsSetter {
+public class BlockTagsSetter implements Listener {
 
     public static final MethodHandle JAVA_PLUGIN_GET_FILE = ReflectionHelper.getMethodHandle(JavaPlugin.class, "getFile");
     public static final MethodHandle BOOTSTRAP_CONTEXT_CONSTRUCTOR;
@@ -39,9 +44,11 @@ public class BlockTagsSetter {
 
     public static final BlockTagsSetter INSTANCE = new BlockTagsSetter(Denizen.getInstance());
 
-    Map<TypedKey<BlockType>, Set<TagKey<BlockType>>> modifiedTags = new HashMap<>();
+    public Map<TypedKey<BlockType>, Set<TagKey<BlockType>>> modifiedTags = new HashMap<>();
+    public boolean batchReloadNeeded;
 
     public BlockTagsSetter(JavaPlugin plugin) {
+        Bukkit.getPluginManager().registerEvents(this, plugin);
         try {
             File pluginSourceFile = (File) JAVA_PLUGIN_GET_FILE.invoke(plugin);
             BootstrapContext fakeContext = (BootstrapContext) BOOTSTRAP_CONTEXT_CONSTRUCTOR.invoke(plugin.getPluginMeta(), plugin.getDataPath(), plugin.getComponentLogger(), pluginSourceFile.toPath());
@@ -70,9 +77,22 @@ public class BlockTagsSetter {
         }
     }
 
+    @EventHandler
+    public void onServerTickEnd(ServerTickEndEvent event) {
+        if (batchReloadNeeded) {
+            batchReloadNeeded = false;
+            Bukkit.reloadData();
+        }
+    }
+
     public void setTags(Material material, Set<NamespacedKey> tags) {
         TypedKey<BlockType> blockKey = TypedKey.create(RegistryKey.BLOCK, material.getKey());
-        modifiedTags.put(blockKey, tags.stream().map(tag -> TagKey.create(RegistryKey.BLOCK, tag)).collect(Collectors.toSet()));
-        Bukkit.reloadData();
+        Set<TagKey<BlockType>> tagKeys = tags.stream().map(tag -> TagKey.create(RegistryKey.BLOCK, tag)).collect(Collectors.toCollection(HashSet::new));
+        Set<TagKey<BlockType>> oldTagKeys = modifiedTags.put(blockKey, tagKeys);
+        if (tagKeys.equals(oldTagKeys)) {
+            return;
+        }
+        VanillaTagHelper.tagsByMaterial.put(material, tags.stream().map(Utilities::namespacedKeyToString).collect(Collectors.toCollection(HashSet::new)));
+        batchReloadNeeded = true;
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -393,4 +393,13 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     public boolean hasCustomName(PotionMeta meta) {
         return meta.hasCustomPotionName();
     }
+
+    @Override
+    public void setMaterialTags(Material type, Set<NamespacedKey> tags) {
+        if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            super.setMaterialTags(type, tags);
+            return;
+        }
+        BlockTagsSetter.INSTANCE.setTags(type, tags);
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -618,4 +618,9 @@ public class Denizen extends JavaPlugin {
             default -> null;
         };
     }
+
+    @Override
+    public File getFile() {
+        return super.getFile();
+    }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -89,7 +89,7 @@ public interface BlockHelper {
         return block.getBlockData().getMapColor();
     }
 
-    default void setVanillaTags(Material material, Set<NamespacedKey> tags) {
+    default void setVanillaTags(Material material, Set<NamespacedKey> tags) { // TODO: once 1.21 is the minimum supported version, remove this
         throw new UnsupportedOperationException();
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -3,10 +3,7 @@ package com.denizenscript.denizen.nms.interfaces;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.objects.EntityTag;
-import org.bukkit.Color;
-import org.bukkit.Instrument;
-import org.bukkit.Location;
-import org.bukkit.Material;
+import org.bukkit.*;
 import org.bukkit.block.*;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.ItemStack;
@@ -92,7 +89,7 @@ public interface BlockHelper {
         return block.getBlockData().getMapColor();
     }
 
-    default void setVanillaTags(Material material, Set<String> tags) {
+    default void setVanillaTags(Material material, Set<NamespacedKey> tags) {
         throw new UnsupportedOperationException();
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -394,7 +394,7 @@ public abstract class EntityHelper {
 
     public abstract void setBoundingBox(Entity entity, BoundingBox box);
 
-    public List<Player> getPlayersThatSee(Entity entity) { // TODO: once the minimum supported version is 1.20, remove from NMS
+    public List<Player> getPlayersThatSee(Entity entity) { // TODO: once 1.20 is the minimum supported version, remove from NMS
         return List.copyOf(entity.getTrackedBy());
     }
 
@@ -406,7 +406,7 @@ public abstract class EntityHelper {
 
     public abstract void setHeadAngle(LivingEntity entity, float angle);
 
-    public void setGhastAttacking(Ghast ghast, boolean attacking) { // TODO: once minimum version is 1.19 or higher, remove from NMS
+    public void setGhastAttacking(Ghast ghast, boolean attacking) { // TODO: one 1.19 is the minimum supported version, remove from NMS
         ghast.setCharging(attacking);
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/EntityHelper.java
@@ -406,7 +406,7 @@ public abstract class EntityHelper {
 
     public abstract void setHeadAngle(LivingEntity entity, float angle);
 
-    public void setGhastAttacking(Ghast ghast, boolean attacking) { // TODO: one 1.19 is the minimum supported version, remove from NMS
+    public void setGhastAttacking(Ghast ghast, boolean attacking) { // TODO: once 1.19 is the minimum supported version, remove from NMS
         ghast.setCharging(attacking);
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -90,7 +90,7 @@ public interface PacketHelper {
         player.sendEquipmentChange(entity, equipmentSlot, itemStack);
     }
 
-    default void resetEquipment(Player player, LivingEntity entity) { // TODO: one 1.19 is the minimum supported version, remove from NMS
+    default void resetEquipment(Player player, LivingEntity entity) { // TODO: once 1.19 is the minimum supported version, remove from NMS
         EntityEquipment equipment = entity.getEquipment();
         Map<EquipmentSlot, ItemStack> equipmentMap = new EnumMap<>(EquipmentSlot.class);
         for (EquipmentSlot slot : EquipmentSlot.values()) {

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PacketHelper.java
@@ -90,7 +90,7 @@ public interface PacketHelper {
         player.sendEquipmentChange(entity, equipmentSlot, itemStack);
     }
 
-    default void resetEquipment(Player player, LivingEntity entity) { // TODO: once minimum version is 1.19 or higher, remove from NMS
+    default void resetEquipment(Player player, LivingEntity entity) { // TODO: one 1.19 is the minimum supported version, remove from NMS
         EntityEquipment equipment = entity.getEquipment();
         Map<EquipmentSlot, ItemStack> equipmentMap = new EnumMap<>(EquipmentSlot.class);
         for (EquipmentSlot slot : EquipmentSlot.values()) {

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -86,7 +86,7 @@ public abstract class PlayerHelper {
 
     public enum ProfileEditMode { ADD, UPDATE_DISPLAY, UPDATE_LATENCY, UPDATE_GAME_MODE, UPDATE_LISTED }
 
-    public void sendPlayerInfoAddPacket(Player player, EnumSet<ProfileEditMode> editModes, String name, String display, UUID id, String texture, String signature, int latency, GameMode gameMode, boolean listed) { // TODO: once minimum version is 1.19 or higher, rename to 'sendPlayerInfoUpdatePacket'
+    public void sendPlayerInfoAddPacket(Player player, EnumSet<ProfileEditMode> editModes, String name, String display, UUID id, String texture, String signature, int latency, GameMode gameMode, boolean listed) { // TODO: one 1.19 is the minimum supported version, rename to 'sendPlayerInfoUpdatePacket'
         throw new UnsupportedOperationException();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/PlayerHelper.java
@@ -86,7 +86,7 @@ public abstract class PlayerHelper {
 
     public enum ProfileEditMode { ADD, UPDATE_DISPLAY, UPDATE_LATENCY, UPDATE_GAME_MODE, UPDATE_LISTED }
 
-    public void sendPlayerInfoAddPacket(Player player, EnumSet<ProfileEditMode> editModes, String name, String display, UUID id, String texture, String signature, int latency, GameMode gameMode, boolean listed) { // TODO: one 1.19 is the minimum supported version, rename to 'sendPlayerInfoUpdatePacket'
+    public void sendPlayerInfoAddPacket(Player player, EnumSet<ProfileEditMode> editModes, String name, String display, UUID id, String texture, String signature, int latency, GameMode gameMode, boolean listed) { // TODO: once 1.19 is the minimum supported version, rename to 'sendPlayerInfoUpdatePacket'
         throw new UnsupportedOperationException();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -711,7 +711,7 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Sets a material's vanilla tags.
         // Any tag name will be accepted - meaning, any tag name input will be added to the material, regardless of whether it previously existed or not.
-        // Note that this gets reset once server resources are reloaded (see <@link event server resources reloaded>).
+        // This will work at any time, but applying your changes once during <@link event server prestart> is recommended, as usages require a server resources reload.
         // @tags
         // <MaterialTag.vanilla_tags>
         // @example

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.nms.interfaces.BlockHelper;
 import com.denizenscript.denizen.objects.properties.material.*;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.VanillaTagHelper;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.events.ScriptEvent;
@@ -734,7 +735,7 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
                 }
                 tags.add(tagKey);
             }
-            NMSHandler.blockHelper.setVanillaTags(material, tags);
+            PaperAPITools.instance.setMaterialTags(material, tags);
         }
 
         // TODO: 1.20.6: need an ItemTag variant providing the proper functionality, and then deprecate this

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -725,13 +725,14 @@ public class MaterialTag implements ObjectTag, Adjustable, FlaggableObject {
         // -->
         if (!mechanism.isProperty && mechanism.matches("vanilla_tags") && mechanism.requireObject(ListTag.class)) {
             ListTag input = mechanism.valueAsType(ListTag.class);
-            Set<String> tags = new HashSet<>();
+            Set<NamespacedKey> tags = new HashSet<>();
             for (String tag : input) {
-                if (!VanillaTagHelper.isValidTagName(tag)) {
+                NamespacedKey tagKey = NamespacedKey.fromString(tag);
+                if (tagKey == null) {
                     mechanism.echoError("Invalid tag name '" + tag + "' inputted.");
                     continue;
                 }
-                tags.add(tag);
+                tags.add(tagKey);
             }
             NMSHandler.blockHelper.setVanillaTags(material, tags);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -26,6 +26,7 @@ import org.bukkit.util.Consumer;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public class PaperAPITools {
@@ -222,5 +223,9 @@ public class PaperAPITools {
     // TODO workaround Paper issue - https://github.com/PaperMC/Paper/issues/11732
     public boolean hasCustomName(PotionMeta meta) {
         return meta.hasCustomName();
+    }
+
+    public void setMaterialTags(Material type, Set<NamespacedKey> tags) {
+        NMSHandler.blockHelper.setVanillaTags(type, tags);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
@@ -2,7 +2,10 @@ package com.denizenscript.denizen.utilities;
 
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Keyed;
+import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.entity.EntityType;
 
 import java.util.HashMap;
@@ -18,6 +21,10 @@ public class VanillaTagHelper {
     public static HashMap<EntityType, HashSet<String>> tagsByEntity = new HashMap<>();
 
     public static HashMap<String, HashSet<EntityType>> entityTagsByKey = new HashMap<>();
+
+    static {
+        loadTagsCache();
+    }
 
     public static void addOrUpdateMaterialTag(Tag<Material> tag) {
         if (materialTagsByKey.containsKey(tag.getKey().getKey())) {
@@ -84,7 +91,11 @@ public class VanillaTagHelper {
         add(tag, tagsByEntity, entityTagsByKey);
     }
 
-    static {
+    public static void loadTagsCache() {
+        tagsByMaterial.clear();
+        materialTagsByKey.clear();
+        tagsByEntity.clear();
+        entityTagsByKey.clear();
         for (Tag<Material> tag : Bukkit.getTags("blocks", Material.class)) {
             addMaterialTag(tag);
         }
@@ -96,9 +107,5 @@ public class VanillaTagHelper {
         for (Tag<Material> tag : Bukkit.getTags("items", Material.class)) {
             addMaterialTag(tag);
         }
-    }
-
-    public static boolean isValidTagName(String name) {
-        return name != null && !name.isEmpty() && NamespacedKey.fromString(name) != null;
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/VanillaTagHelper.java
@@ -44,6 +44,7 @@ public class VanillaTagHelper {
         }
     }
 
+    // TODO: once 1.21 is the minimum supported version, remove this and related methods
     static <T extends Keyed> void update(Tag<T> tag, HashMap<T, HashSet<String>> tagByObj, HashMap<String, HashSet<T>> objByTag) {
         String tagName = Utilities.namespacedKeyToString(tag.getKey());
         Set<T> objs = objByTag.get(tagName);

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/helpers/BlockHelperImpl.java
@@ -17,7 +17,6 @@ import com.mojang.authlib.properties.Property;
 import net.minecraft.core.Registry;
 import net.minecraft.core.*;
 import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.TagKey;
 import net.minecraft.tags.TagNetworkSerialization;
@@ -48,6 +47,7 @@ import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.tag.CraftBlockTag;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_18_R2.util.CraftNamespacedKey;
 import org.bukkit.entity.Player;
 
 import java.lang.invoke.MethodHandle;
@@ -337,7 +337,7 @@ public class BlockHelperImpl implements BlockHelper {
     public static MethodHandle Holder_Reference_bindTags = ReflectionHelper.getMethodHandle(Holder.Reference.class, ReflectionMappingsInfo.Holder_Reference_bindTags, Collection.class);
 
     @Override
-    public void setVanillaTags(Material material, Set<String> tags) {
+    public void setVanillaTags(Material material, Set<NamespacedKey> tags) {
         Holder<net.minecraft.world.level.block.Block> nmsHolder = getMaterialBlock(material).builtInRegistryHolder();
         nmsHolder.tags().forEach(nmsTag -> {
             HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getTag(nmsTag).orElse(null);
@@ -355,8 +355,8 @@ public class BlockHelperImpl implements BlockHelper {
             VanillaTagHelper.updateMaterialTag(new CraftBlockTag(Registry.BLOCK, nmsTag));
         });
         List<TagKey<net.minecraft.world.level.block.Block>> newNmsTags = new ArrayList<>();
-        for (String tag : tags) {
-            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(Registry.BLOCK_REGISTRY, new ResourceLocation(tag));
+        for (NamespacedKey tag : tags) {
+            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(Registry.BLOCK_REGISTRY, CraftNamespacedKey.toMinecraft(tag));
             HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = Registry.BLOCK.getOrCreateTag(newNmsTag);
             List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
             nmsHolders.add(nmsHolder);

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
@@ -19,7 +19,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.TagKey;
 import net.minecraft.tags.TagNetworkSerialization;
@@ -53,6 +52,7 @@ import org.bukkit.craftbukkit.v1_19_R3.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R3.tag.CraftBlockTag;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_19_R3.util.CraftNamespacedKey;
 import org.bukkit.entity.Player;
 
 import java.lang.invoke.MethodHandle;
@@ -316,7 +316,7 @@ public class BlockHelperImpl implements BlockHelper {
     public static MethodHandle Holder_Reference_bindTags = ReflectionHelper.getMethodHandle(Holder.Reference.class, ReflectionMappingsInfo.HolderReference_bindTags_method, Collection.class);
 
     @Override
-    public void setVanillaTags(Material material, Set<String> tags) {
+    public void setVanillaTags(Material material, Set<NamespacedKey> tags) {
         Holder<net.minecraft.world.level.block.Block> nmsHolder = getMaterialBlock(material).builtInRegistryHolder();
         nmsHolder.tags().forEach(nmsTag -> {
             HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = BuiltInRegistries.BLOCK.getTag(nmsTag).orElse(null);
@@ -334,8 +334,8 @@ public class BlockHelperImpl implements BlockHelper {
             VanillaTagHelper.updateMaterialTag(new CraftBlockTag(BuiltInRegistries.BLOCK, nmsTag));
         });
         List<TagKey<net.minecraft.world.level.block.Block>> newNmsTags = new ArrayList<>();
-        for (String tag : tags) {
-            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(BuiltInRegistries.BLOCK.key(), new ResourceLocation(tag));
+        for (NamespacedKey tag : tags) {
+            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(BuiltInRegistries.BLOCK.key(), CraftNamespacedKey.toMinecraft(tag));
             HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = BuiltInRegistries.BLOCK.getOrCreateTag(newNmsTag);
             List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
             nmsHolders.add(nmsHolder);

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
@@ -19,7 +19,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.protocol.common.ClientboundUpdateTagsPacket;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.TagKey;
 import net.minecraft.tags.TagNetworkSerialization;
@@ -36,10 +35,7 @@ import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.PushReaction;
-import org.bukkit.Bukkit;
-import org.bukkit.Instrument;
-import org.bukkit.Location;
-import org.bukkit.Material;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
@@ -57,6 +53,7 @@ import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R4.tag.CraftBlockTag;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftLocation;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_20_R4.util.CraftNamespacedKey;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
@@ -272,7 +269,7 @@ public class BlockHelperImpl implements BlockHelper {
     public static final MethodHandle HOLDER_REFERENCE_BINDTAGS = ReflectionHelper.getMethodHandle(Holder.Reference.class, ReflectionMappingsInfo.HolderReference_bindTags_method, Collection.class);
 
     @Override
-    public void setVanillaTags(Material material, Set<String> tags) {
+    public void setVanillaTags(Material material, Set<NamespacedKey> tags) {
         Holder<net.minecraft.world.level.block.Block> nmsHolder = CraftMagicNumbers.getBlock(material).builtInRegistryHolder();
         nmsHolder.tags().forEach(nmsTag -> {
             HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = BuiltInRegistries.BLOCK.getTag(nmsTag).orElse(null);
@@ -290,8 +287,8 @@ public class BlockHelperImpl implements BlockHelper {
             VanillaTagHelper.updateMaterialTag(new CraftBlockTag(BuiltInRegistries.BLOCK, nmsTag));
         });
         List<TagKey<net.minecraft.world.level.block.Block>> newNmsTags = new ArrayList<>();
-        for (String tag : tags) {
-            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(BuiltInRegistries.BLOCK.key(), new ResourceLocation(tag));
+        for (NamespacedKey tag : tags) {
+            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(BuiltInRegistries.BLOCK.key(), CraftNamespacedKey.toMinecraft(tag));
             HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = BuiltInRegistries.BLOCK.getOrCreateTag(newNmsTag);
             List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
             nmsHolders.add(nmsHolder);

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
@@ -14,8 +14,6 @@ import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.common.collect.Iterables;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.HolderSet;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.InclusiveRange;
 import net.minecraft.util.random.SimpleWeightedRandomList;
@@ -51,7 +49,7 @@ import org.bukkit.craftbukkit.v1_21_R3.util.CraftMagicNumbers;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.Optional;
 
 public class BlockHelperImpl implements BlockHelper {
 
@@ -257,50 +255,4 @@ public class BlockHelperImpl implements BlockHelper {
             Debug.echoError(ex);
         }
     }
-
-    public static final MethodHandle HOLDERSET_NAMED_BIND = ReflectionHelper.getMethodHandle(HolderSet.Named.class, ReflectionMappingsInfo.HolderSetNamed_bind_method, List.class);
-    public static final MethodHandle HOLDER_REFERENCE_BINDTAGS = ReflectionHelper.getMethodHandle(Holder.Reference.class, ReflectionMappingsInfo.HolderReference_bindTags_method, Collection.class);
-
-    // TODO: 1.21.3: decently large internal changes - should probably look into implementing with Paper's API?
-//    @Override
-//    public void setVanillaTags(Material material, Set<String> tags) {
-//        Holder<net.minecraft.world.level.block.Block> nmsHolder = CraftMagicNumbers.getBlock(material).builtInRegistryHolder();
-//        nmsHolder.tags().forEach(nmsTag -> {
-//            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = BuiltInRegistries.BLOCK.get(nmsTag).orElse(null);
-//            if (nmsHolderSet == null) {
-//                return;
-//            }
-//            List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
-//            nmsHolders.remove(nmsHolder);
-//            try {
-//                HOLDERSET_NAMED_BIND.invoke(nmsHolderSet, nmsHolders);
-//            }
-//            catch (Throwable ex) {
-//                Debug.echoError(ex);
-//            }
-//            VanillaTagHelper.updateMaterialTag(new CraftBlockTag(BuiltInRegistries.BLOCK, nmsTag));
-//        });
-//        List<TagKey<net.minecraft.world.level.block.Block>> newNmsTags = new ArrayList<>();
-//        for (String tag : tags) {
-//            TagKey<net.minecraft.world.level.block.Block> newNmsTag = TagKey.create(BuiltInRegistries.BLOCK.key(), ResourceLocation.withDefaultNamespace(tag));
-//            HolderSet.Named<net.minecraft.world.level.block.Block> nmsHolderSet = BuiltInRegistries.BLOCK.getOrCreateTag(newNmsTag);
-//            List<Holder<net.minecraft.world.level.block.Block>> nmsHolders = nmsHolderSet.stream().collect(Collectors.toCollection(ArrayList::new));
-//            nmsHolders.add(nmsHolder);
-//            try {
-//                HOLDERSET_NAMED_BIND.invoke(nmsHolderSet, nmsHolders);
-//            }
-//            catch (Throwable ex) {
-//                Debug.echoError(ex);
-//            }
-//            newNmsTags.add(newNmsTag);
-//            VanillaTagHelper.addOrUpdateMaterialTag(new CraftBlockTag(BuiltInRegistries.BLOCK, newNmsTag));
-//        }
-//        try {
-//            HOLDER_REFERENCE_BINDTAGS.invoke(nmsHolder, newNmsTags);
-//        }
-//        catch (Throwable ex) {
-//            Debug.echoError(ex);
-//        }
-//        PacketHelperImpl.broadcast(new ClientboundUpdateTagsPacket(TagNetworkSerialization.serializeTagsToNetwork(((CraftServer) Bukkit.getServer()).getServer().registries())));
-//    }
 }


### PR DESCRIPTION
## Additions

- `PaperEventHelpers#onServerResourcesReloaded` - calls `VanillaTagHelper#loadTagsCache` after server resources are reloaded to update for changes.
- `BlockTagsSetter` in the Paper module - handles storing tag changes, registering a tag event, and reloading server resources.
- `VanillaTagsHelper`'s `static` block is now in a new `loadTagsCache` method, which clears all existing cache as well (and is called within a static block).

## Changes

- `BlockHelper#setVanillaTags` now takes a `Set<NamespacedKey>` instead of `Set<String>`.
- `MaterialTag.vanilla_tags` now handles input by creating a `Set<NamespacedKey>` instead of `Set<String>`, and now uses `PaperAPITools#setMaterialTags`.

## Removals
- `VanillaTagsHelper#isValidTagName` has been removed, and the `update` methods have been `TODO`ed for removal.
- `BlockHelperImpl(1.21)#setVanillaTags` override has been removed.

> [!NOTE]
> ### `MaterialTag.vanilla_tags` input handling
> Used to use `VanillaTagHelper#isValidTagName`, which used `NamespacedKey#fromString`, so I made the new input handling use that.
> Most places use `Utilites#parseNamespacedKey`, which is less strict on input checking (I.e. would change the input there) - maybe more strict input makes sense for this, but let me know what do you think.

> [!NOTE]
> ### `BlockTagsSetter`
> 1. It can probably get some small optimizations (e.g. building `allTags` into a lookup map instead of looping over it), but imo with it only running once on server resource reloads, it's basically micro optimizations - lmk if that'd still be preferable though.
> 2. The reload batching uses `ServerTickEndEvent` since making sure the changes are applied by the end of the tick seemed like a safer option, but theoretically you could also make it work with the scheduler & applying it a tick later.
> 3. Has some stream usage, but like ^^ making the code messier by doing it manually with a loop (twice) feels like a micro optimization, especially for something that does an entire server resources reload.
> 4. `setTags` currently temporarily modifies `VanillaTagHelper.tagsByMaterial` so that chained mechanism usages don't override each other (e.g. if the same material gets it's tags modified within the same tick in separate calls, `.vanilla_tags` needs to return the updated list so that the later usage doesn't override the earlier usage) - could also modify `materialTagsByKey`, but that'd be messier, doesn't seem as needed imo, and will be updated by the server resource reload later.