### PR TITLE
Several minor 1.20/21 fixes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -3874,12 +3874,13 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Makes a player-type entity interact with a block.
         // -->
         if (mechanism.matches("interact_with") && mechanism.requireObject(LocationTag.class)) {
-            if (!isPlayer()) {
+            Player player = getPlayer();
+            if (player == null) {
                 mechanism.echoError("Only player-type entities can interact with blocks!");
                 return;
             }
             LocationTag interactLocation = mechanism.valueAsType(LocationTag.class);
-            NMSHandler.entityHelper.forceInteraction(getPlayer(), interactLocation);
+            NMSHandler.entityHelper.forceInteraction(player, interactLocation);
         }
 
         if (mechanism.matches("play_death")) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoatType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityBoatType.java
@@ -6,7 +6,7 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.denizencore.tags.Attribute;
 import org.bukkit.TreeSpecies;
 import org.bukkit.entity.Boat;
 
@@ -28,6 +28,20 @@ public class EntityBoatType extends EntityProperty<ElementTag> {
 
     @Override
     public ElementTag getPropertyValue() {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            return null;
+        }
+        return new ElementTag(as(Boat.class).getWoodType());
+    }
+
+    @Override
+    public ElementTag getTagValue(Attribute attribute) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            BukkitImplDeprecations.boatType.warn(attribute.context);
+        }
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            BukkitImplDeprecations.gettingBoatType.warn(attribute.context);
+        }
         return new ElementTag(as(Boat.class).getWoodType());
     }
 
@@ -38,24 +52,19 @@ public class EntityBoatType extends EntityProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag type, Mechanism mechanism) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            BukkitImplDeprecations.boatType.warn(mechanism.context);
+        }
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            BukkitImplDeprecations.settingBoatType.warn(mechanism.context);
+            return;
+        }
         if (mechanism.requireEnum(TreeSpecies.class)) {
             as(Boat.class).setWoodType(type.asEnum(TreeSpecies.class));
         }
     }
 
     public static void register() {
-        PropertyParser.registerTag(EntityBoatType.class, ElementTag.class, "boat_type", (attribute, object) -> {
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-                BukkitImplDeprecations.boatType.warn(attribute.context);
-            }
-            return object.getPropertyValue();
-        });
-
-        PropertyParser.registerMechanism(EntityBoatType.class, ElementTag.class, "boat_type", (object, mechanism, type) -> {
-           if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-               BukkitImplDeprecations.boatType.warn(mechanism.context);
-           }
-           object.setPropertyValue(type, mechanism);
-        });
+        autoRegister("boat_type", EntityBoatType.class, ElementTag.class, false);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -11,8 +11,11 @@ import com.denizenscript.denizencore.objects.core.ColorTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
-import org.bukkit.*;
+import org.bukkit.DyeColor;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.entity.*;
 
 import java.util.Arrays;
@@ -57,7 +60,16 @@ public class EntityColor extends EntityProperty<ElementTag> {
 
     @Override
     public ElementTag getPropertyValue() {
-        String color = getColor(true);
+        return getCleanedValue(false);
+    }
+
+    @Override
+    public ElementTag getTagValue(Attribute attribute) {
+        return getCleanedValue(true);
+    }
+
+    public ElementTag getCleanedValue(boolean includeDeprecated) {
+        String color = getColor(includeDeprecated);
         return color == null ? null : new ElementTag(CoreUtilities.toLowerCase(color));
     }
 
@@ -210,7 +222,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
     public String getColor(boolean includeDeprecated) {
         EntityType type = getType();
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && MultiVersionHelper1_19.colorIsApplicable(type)) {
-            return MultiVersionHelper1_19.getColor(getEntity());
+            return MultiVersionHelper1_19.getColor(getEntity(), includeDeprecated);
         }
         if (getEntity() instanceof MushroomCow mushroomCow) {
             return mushroomCow.getVariant().name();

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -351,6 +351,10 @@ public class BukkitImplDeprecations {
     // Safe to remove now.
     public static Warning debugBlockAlpha = new SlowWarning("debugBlockAlpha", "The 'alpha' argument for the 'debugblock' command is deprecated: put the alpha in the color input instead.");
 
+    // Added 2025/03/16
+    // Bump once 1.21 is the minimum supported version (as that is where boat types were split)
+    public static Warning gettingBoatType = new SlowWarning("gettingBoatType", "Getting boat wood types is deprecated, as separate boat types are separate entity types now: should check the entity type.");
+
     // ==================== VERY SLOW deprecations ====================
     // These are only shown minimally, so server owners are aware of them but not bugged by them. Only servers with active scripters (using 'ex reload') will see them often.
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -266,7 +266,7 @@ public class BukkitImplDeprecations {
     public static Warning findStructureTags = new Warning("findStructureTags", "'LocationTag.find.structure' and related tags are deprecated in favor of 'LocationTag.find_structure'.");
 
     // Added 2025/03/14
-    public static Warning settingBoatType = new Warning("settingBoatType", "As of MC 1.21, separate boat types are separate entity types, meaning the type of an existing boat entity cannot be changed without spawning a new one.");
+    public static Warning settingBoatType = new Warning("settingBoatType", "As of MC 1.21, separate boat wood types are separate entity types, meaning the wood type of an existing boat entity cannot be changed without spawning a new one.");
 
     // ==================== SLOW deprecations ====================
     // These aren't spammed, but will show up repeatedly until fixed. Server owners will probably notice them.

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -265,6 +265,9 @@ public class BukkitImplDeprecations {
     public static Warning oldStructureTypes = new Warning("oldStructureTypes", "'server.structure_types' is based on outdated API and doesn't support modern datapack features. Use 'server.structures' instead.");
     public static Warning findStructureTags = new Warning("findStructureTags", "'LocationTag.find.structure' and related tags are deprecated in favor of 'LocationTag.find_structure'.");
 
+    // Added 2025/03/14
+    public static Warning settingBoatType = new Warning("settingBoatType", "As of MC 1.21, separate boat types are separate entity types, meaning the type of an existing boat entity cannot be changed without spawning a new one.");
+
     // ==================== SLOW deprecations ====================
     // These aren't spammed, but will show up repeatedly until fixed. Server owners will probably notice them.
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.utilities;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.DurationTag;
@@ -41,7 +43,10 @@ public class MultiVersionHelper1_19 {
             frog.setVariant(Utilities.elementToEnumlike(mech.getValue(), Frog.Variant.class));
         }
         else if (entity instanceof Boat boat && mech.requireEnum(Boat.Type.class)) {
-            // TODO: 1.21.3: Deprecate setting boat types
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                BukkitImplDeprecations.settingBoatType.warn(mech.context);
+                return;
+            }
             boat.setBoatType(mech.getValue().asEnum(Boat.Type.class));
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -18,11 +18,17 @@ public class MultiVersionHelper1_19 {
     }
 
     // TODO Frog variants technically have registries on all supported versions
-    public static String getColor(Entity entity) {
+    public static String getColor(Entity entity, boolean includeDeprecated) {
         if (entity instanceof Frog frog) {
             return String.valueOf(frog.getVariant());
         }
         else if (entity instanceof Boat boat) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                if (!includeDeprecated) {
+                    return null;
+                }
+                BukkitImplDeprecations.gettingBoatType.warn();
+            }
             return boat.getBoatType().name();
         }
         return null;
@@ -33,6 +39,9 @@ public class MultiVersionHelper1_19 {
             return Utilities.listTypes(Frog.Variant.class);
         }
         else if (Boat.class.isAssignableFrom(type.getEntityClass())) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                BukkitImplDeprecations.gettingBoatType.warn();
+            }
             return Utilities.listTypes(Boat.Type.class);
         }
         return null;

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
@@ -96,7 +96,6 @@ public class BlockHelperImpl implements BlockHelper {
 
     @Override
     public PlayerProfile getPlayerProfile(Skull skull) {
-        // TODO: 1.20.6: Seems to be a holder for data that can make the request to complete it later - do we want to do that here?
         ResolvableProfile profile = getTE(((CraftSkull) skull)).owner;
         if (profile == null) {
             return null;

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/EntityHelperImpl.java
@@ -172,10 +172,9 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public void forceInteraction(Player player, Location location) {
-        CraftPlayer craftPlayer = (CraftPlayer) player;
-        // TODO: 1.20.6: passing a null player isn't valid (and seemingly never was) - need to require HumanEntity in the mechanism
-        ((CraftBlock) location.getBlock()).getNMS().useItemOn(craftPlayer.getHandle().getMainHandItem(), ((CraftWorld) location.getWorld()).getHandle(),
-                craftPlayer.getHandle(), InteractionHand.MAIN_HAND,
+        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
+        ((CraftBlock) location.getBlock()).getNMS().useItemOn(nmsPlayer.getMainHandItem(), ((CraftWorld) location.getWorld()).getHandle(),
+                nmsPlayer, InteractionHand.MAIN_HAND,
                 new BlockHitResult(new Vec3(0, 0, 0), null, CraftLocation.toBlockPosition(location), false));
     }
 

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
@@ -86,7 +86,6 @@ public class BlockHelperImpl implements BlockHelper {
 
     @Override
     public PlayerProfile getPlayerProfile(Skull skull) {
-        // TODO: 1.20.6: Seems to be a holder for data that can make the request to complete it later - do we want to do that here?
         ResolvableProfile profile = getTE(((CraftSkull) skull)).owner;
         if (profile == null) {
             return null;

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/EntityHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/EntityHelperImpl.java
@@ -166,9 +166,9 @@ public class EntityHelperImpl extends EntityHelper {
 
     @Override
     public void forceInteraction(Player player, Location location) {
-        CraftPlayer craftPlayer = (CraftPlayer) player;
-        ((CraftBlock) location.getBlock()).getNMS().useItemOn(craftPlayer.getHandle().getMainHandItem(), ((CraftWorld) location.getWorld()).getHandle(),
-                craftPlayer.getHandle(), InteractionHand.MAIN_HAND,
+        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
+        ((CraftBlock) location.getBlock()).getNMS().useItemOn(nmsPlayer.getMainHandItem(), ((CraftWorld) location.getWorld()).getHandle(),
+                nmsPlayer, InteractionHand.MAIN_HAND,
                 new BlockHitResult(new Vec3(0, 0, 0), null, CraftLocation.toBlockPosition(location), false));
     }
 


### PR DESCRIPTION
- `EntityTag.interact_with` now more explicitly requires a player.
- Boat entity wood type controls are now deprecated as each wood type is now a separate entity type.
- Removed `TODO` from `BlockHelper#getPlayerProfile(Skull)` as it's not needed.
- `EntityBoatType` now handles it's deprecation warnings inside `setPropertyValue` and `getTagValue` instead of manually registering the tag and mech.
- Properly uses `includeDeprecated` in `EntityColor` (`false` in prop value, `true` in tag) - broke in a cleanup PR a while ago.
- `EntityColor` now passes `includeDeprecated` to `MultiVersionHelper1_19` so that it can know when to include/exclude boat types.
- Minor cleanup in `EntityHelperImpl(1.20/1.21)#forceInteraction`.

> [!NOTE]
> Split the warnings into `gettingBoatType` (`SlowWarning`) and `settingBoatType` (`Warning`), as getting it is deprecated but can still work by checking the entity type, but setting it is just not a thing anymore.
> Lmk if the warning levels should be changed or merged or anything (maybe the warning for setting should be a `StrongWarning` past warning as it's technically a removed feature?).