### PR TITLE
1.21.5 Bungee chat fixes

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -18,7 +18,6 @@ import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
 
 public class PaperModule {
@@ -156,7 +155,7 @@ public class PaperModule {
         if (component == null) {
             return null;
         }
-        return FormattedTextHelper.stringify(ComponentSerializer.parse(componentToJson(component)));
+        return FormattedTextHelper.stringify(FormattedTextHelper.parseJson(componentToJson(component)));
     }
 
     public static Component jsonToComponent(String json) {

--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -371,7 +371,6 @@ public class Denizen extends JavaPlugin {
         ExSustainedCommandHandler exsCommand = new ExSustainedCommandHandler();
         exsCommand.enableFor(getCommand("exs"));
         FullBlockData.init();
-        HoverFormatHelper.tryInitializeItemHoverFix();
         // Load script files without processing.
         DenizenCore.preloadScripts(false, null);
         // Load the saves.yml into memory

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerReceivesMessageScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerReceivesMessageScriptEvent.java
@@ -1,17 +1,16 @@
 package com.denizenscript.denizen.events.player;
 
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 
 public class PlayerReceivesMessageScriptEvent extends BukkitScriptEvent {
 
@@ -97,7 +96,7 @@ public class PlayerReceivesMessageScriptEvent extends BukkitScriptEvent {
             if (lower.startsWith("raw_json:")) {
                 rawJson = new ElementTag(determination.substring("raw_json:".length()));
                 altMessageDetermination = null;
-                message = new ElementTag(FormattedTextHelper.stringify(ComponentSerializer.parse(rawJson.asString())), true);
+                message = new ElementTag(FormattedTextHelper.stringify(FormattedTextHelper.parseJson(rawJson.asString())), true);
                 modified = true;
                 return true;
             }
@@ -127,7 +126,7 @@ public class PlayerReceivesMessageScriptEvent extends BukkitScriptEvent {
     public PlayerReceivesMessageScriptEvent triggerNow() {
         PlayerReceivesMessageScriptEvent event = (PlayerReceivesMessageScriptEvent) fire();
         if (event.modified && event.altMessageDetermination == null) {
-            event.altMessageDetermination = ComponentSerializer.parse(event.rawJson.asString());
+            event.altMessageDetermination = FormattedTextHelper.parseJson(event.rawJson.asString());
         }
         return event;
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
@@ -5,7 +5,6 @@ import com.denizenscript.denizen.nms.interfaces.*;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
-import com.google.gson.Gson;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -147,6 +146,4 @@ public abstract class NMSHandler {
     public String updateLegacyName(Class<?> type, String legacyName) {
         return legacyName;
     }
-
-    public abstract Gson getVanillaStyleSpigotComponentGSON(); // TODO: Once 1.21 is the minimum version, de-module this
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
@@ -31,8 +31,7 @@ public abstract class NMSHandler {
     public static boolean debugPackets = false;
     public static String debugPacketFilter = "";
 
-    public static boolean initialize(JavaPlugin plugin) {
-        javaPlugin = plugin;
+    static {
         String bukkitVersion = Bukkit.getBukkitVersion();
         for (NMSVersion potentialVersion : NMSVersion.values()) {
             if (bukkitVersion.startsWith(potentialVersion.minecraftVersion)) {
@@ -42,6 +41,12 @@ public abstract class NMSHandler {
         }
         if (version == null) {
             version = NMSVersion.NOT_SUPPORTED;
+        }
+    }
+
+    public static boolean initialize(JavaPlugin plugin) {
+        javaPlugin = plugin;
+        if (getVersion() == NMSVersion.NOT_SUPPORTED) {
             instance = null;
             return false;
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/bukkit/BukkitElementExtensions.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/bukkit/BukkitElementExtensions.java
@@ -19,7 +19,6 @@ import com.denizenscript.denizencore.utilities.AsciiMatcher;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.Deprecations;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.chat.ComponentSerializer;
 
 import java.nio.charset.StandardCharsets;
 
@@ -442,7 +441,7 @@ public class BukkitElementExtensions {
         // Inverts <@link tag ElementTag.to_raw_json>.
         // -->
         ElementTag.tagProcessor.registerStaticTag(ElementTag.class, "from_raw_json", (attribute, object) -> {
-            return new ElementTag(FormattedTextHelper.stringify(ComponentSerializer.parse(object.asString())));
+            return new ElementTag(FormattedTextHelper.stringify(FormattedTextHelper.parseJson(object.asString())));
         });
 
         // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBook.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemBook.java
@@ -12,7 +12,6 @@ import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.core.EscapeTagUtil;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Material;
 import org.bukkit.inventory.meta.BookMeta;
 
@@ -277,7 +276,7 @@ public class ItemBook implements Property {
             if (data.get(0).equalsIgnoreCase("raw_pages")) {
                 List<BaseComponent[]> newPages = new ArrayList<>(data.size());
                 for (int i = 1; i < data.size(); i++) {
-                    newPages.add(ComponentSerializer.parse(EscapeTagUtil.unEscape(data.get(i))));
+                    newPages.add(FormattedTextHelper.parseJson(EscapeTagUtil.unEscape(data.get(i))));
                 }
                 bookMeta.spigot().setPages(newPages);
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -17,6 +17,9 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.*;
 import net.md_5.bungee.api.chat.hover.content.*;
 import net.md_5.bungee.chat.*;
+import net.md_5.bungee.chat.ChatVersion;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.md_5.bungee.chat.VersionedComponentSerializer;
 
 import java.util.List;
 
@@ -880,5 +883,12 @@ public class FormattedTextHelper {
             return vanillaStyleSpigotComponentGSON.toJson(components[0]);
         }
         return vanillaStyleSpigotComponentGSON.toJson(new TextComponent(components));
+    }
+
+    public static BaseComponent[] parseJson(String json) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            return VersionedComponentSerializer.forVersion(ChatVersion.V1_21_5).parse(json);
+        }
+        return ComponentSerializer.parse(json);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -12,8 +12,11 @@ import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.*;
+import net.md_5.bungee.api.chat.hover.content.*;
+import net.md_5.bungee.chat.*;
 
 import java.util.List;
 
@@ -857,12 +860,22 @@ public class FormattedTextHelper {
         return message;
     }
 
-    public static Gson vanillaStyleSpigotComponentGSON = null;
+    // Spigot ComponentSerializer
+    public static final Gson vanillaStyleSpigotComponentGSON = new GsonBuilder()
+            .registerTypeAdapter(BaseComponent.class, new ComponentSerializer())
+            .registerTypeAdapter(TextComponent.class, new TextComponentSerializer())
+            .registerTypeAdapter(TranslatableComponent.class, new TranslatableComponentSerializer())
+            .registerTypeAdapter(KeybindComponent.class, new KeybindComponentSerializer())
+            .registerTypeAdapter(ScoreComponent.class, new ScoreComponentSerializer())
+            .registerTypeAdapter(SelectorComponent.class, new SelectorComponentSerializer())
+            .registerTypeAdapter(Entity.class, new EntitySerializer())
+            .registerTypeAdapter(Text.class, new TextSerializer())
+            .registerTypeAdapter(Item.class, new ItemSerializer())
+            .registerTypeAdapter(ItemTag.class, new ItemTag.Serializer())
+            .disableHtmlEscaping() // Mojang
+            .create();
 
     public static String componentToJson(BaseComponent[] components) {
-        if (vanillaStyleSpigotComponentGSON == null) {
-            vanillaStyleSpigotComponentGSON = NMSHandler.instance.getVanillaStyleSpigotComponentGSON();
-        }
         if (components.length == 1) {
             return vanillaStyleSpigotComponentGSON.toJson(components[0]);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -870,6 +870,11 @@ public class FormattedTextHelper {
         }
     }
 
+    static {
+        // Explicitly before initializing vanillaStyleSpigotComponentGSON
+        HoverFormatHelper.tryInitializeItemHoverFix();
+    }
+
     public static final Gson vanillaStyleSpigotComponentGSON = getBungeeGson().newBuilder().disableHtmlEscaping().create();
 
     public static String componentToJson(BaseComponent[] components) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/FormattedTextHelper.java
@@ -10,13 +10,11 @@ import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.utilities.AsciiMatcher;
 import com.denizenscript.denizencore.utilities.CoreConfiguration;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.*;
-import net.md_5.bungee.chat.*;
 import net.md_5.bungee.chat.ChatVersion;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.chat.VersionedComponentSerializer;
@@ -863,20 +861,16 @@ public class FormattedTextHelper {
         return message;
     }
 
-    // Spigot ComponentSerializer
-    public static final Gson vanillaStyleSpigotComponentGSON = new GsonBuilder()
-            .registerTypeAdapter(BaseComponent.class, new ComponentSerializer())
-            .registerTypeAdapter(TextComponent.class, new TextComponentSerializer())
-            .registerTypeAdapter(TranslatableComponent.class, new TranslatableComponentSerializer())
-            .registerTypeAdapter(KeybindComponent.class, new KeybindComponentSerializer())
-            .registerTypeAdapter(ScoreComponent.class, new ScoreComponentSerializer())
-            .registerTypeAdapter(SelectorComponent.class, new SelectorComponentSerializer())
-            .registerTypeAdapter(Entity.class, new EntitySerializer())
-            .registerTypeAdapter(Text.class, new TextSerializer())
-            .registerTypeAdapter(Item.class, new ItemSerializer())
-            .registerTypeAdapter(ItemTag.class, new ItemTag.Serializer())
-            .disableHtmlEscaping() // Mojang
-            .create();
+    public static Gson getBungeeGson() {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            return VersionedComponentSerializer.forVersion(ChatVersion.V1_21_5).getGson();
+        }
+        else {
+            return ReflectionHelper.getFieldValue(ComponentSerializer.class, "gson", null);
+        }
+    }
+
+    public static final Gson vanillaStyleSpigotComponentGSON = getBungeeGson().newBuilder().disableHtmlEscaping().create();
 
     public static String componentToJson(BaseComponent[] components) {
         if (components.length == 1) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/HoverFormatHelper.java
@@ -13,7 +13,9 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.hover.content.*;
+import net.md_5.bungee.chat.ChatVersion;
 import net.md_5.bungee.chat.ComponentSerializer;
+import net.md_5.bungee.chat.VersionedComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Registry;
 import org.bukkit.inventory.ItemStack;
@@ -94,7 +96,7 @@ public class HoverFormatHelper {
         if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
             return;
         }
-        Gson bungeeGson = ReflectionHelper.getFieldValue(ComponentSerializer.class, "gson", null);
+        Gson bungeeGson = FormattedTextHelper.getBungeeGson();
         if (bungeeGson == null) {
             return;
         }
@@ -103,7 +105,12 @@ public class HoverFormatHelper {
                 .registerTypeAdapter(Item.class, new FixedItemHoverSerializer())
                 .create();
         try {
-            ReflectionHelper.getFinalSetter(ComponentSerializer.class, "gson").invoke(fixedGson);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                ReflectionHelper.setFieldValue(VersionedComponentSerializer.class, "gson", VersionedComponentSerializer.forVersion(ChatVersion.V1_21_5), fixedGson);
+            }
+            else {
+                ReflectionHelper.getFinalSetter(ComponentSerializer.class, "gson").invoke(fixedGson);
+            }
         }
         catch (Throwable e) {
             Debug.echoError(e);

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
@@ -19,13 +19,10 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.common.collect.Iterables;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
-import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.*;
-import net.md_5.bungee.chat.*;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.StringTag;
@@ -290,22 +287,5 @@ public class Handler extends NMSHandler {
     public static MutableComponent componentToNMS(BaseComponent[] spigot) {
         String json = ComponentSerializer.toString(spigot);
         return Component.Serializer.fromJson(json);
-    }
-
-    @Override
-    public Gson getVanillaStyleSpigotComponentGSON() {
-        return new GsonBuilder()
-                .registerTypeAdapter(BaseComponent.class, new ComponentSerializer())
-                .registerTypeAdapter(TextComponent.class, new TextComponentSerializer())
-                .registerTypeAdapter(TranslatableComponent.class, new TranslatableComponentSerializer())
-                .registerTypeAdapter(KeybindComponent.class, new KeybindComponentSerializer())
-                .registerTypeAdapter(ScoreComponent.class, new ScoreComponentSerializer())
-                .registerTypeAdapter(SelectorComponent.class, new SelectorComponentSerializer())
-                .registerTypeAdapter(net.md_5.bungee.api.chat.hover.content.Entity.class, new EntitySerializer())
-                .registerTypeAdapter(Text.class, new TextSerializer())
-                .registerTypeAdapter(Item.class, new ItemSerializer())
-                .registerTypeAdapter(ItemTag.class, new ItemTag.Serializer())
-                .disableHtmlEscaping() // Mojang
-                .create();
     }
 }

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
@@ -22,14 +22,11 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.common.collect.Iterables;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.*;
-import net.md_5.bungee.chat.*;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.ByteArrayTag;
@@ -320,22 +317,5 @@ public class Handler extends NMSHandler {
         }
         String json = ComponentSerializer.toString(spigot);
         return Component.Serializer.fromJson(json);
-    }
-
-    @Override
-    public Gson getVanillaStyleSpigotComponentGSON() {
-        return new GsonBuilder()
-                .registerTypeAdapter(BaseComponent.class, new ComponentSerializer())
-                .registerTypeAdapter(TextComponent.class, new TextComponentSerializer())
-                .registerTypeAdapter(TranslatableComponent.class, new TranslatableComponentSerializer())
-                .registerTypeAdapter(KeybindComponent.class, new KeybindComponentSerializer())
-                .registerTypeAdapter(ScoreComponent.class, new ScoreComponentSerializer())
-                .registerTypeAdapter(SelectorComponent.class, new SelectorComponentSerializer())
-                .registerTypeAdapter(net.md_5.bungee.api.chat.hover.content.Entity.class, new EntitySerializer())
-                .registerTypeAdapter(Text.class, new TextSerializer())
-                .registerTypeAdapter(Item.class, new ItemSerializer())
-                .registerTypeAdapter(ItemTag.class, new ItemTag.Serializer())
-                .disableHtmlEscaping() // Mojang
-                .create();
     }
 }

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
@@ -22,14 +22,11 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.common.collect.Iterables;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.*;
-import net.md_5.bungee.chat.*;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.ByteArrayTag;
@@ -341,22 +338,5 @@ public class Handler extends NMSHandler {
         }
         String json = FormattedTextHelper.componentToJson(spigot);
         return Component.Serializer.fromJson(json);
-    }
-
-    @Override
-    public Gson getVanillaStyleSpigotComponentGSON() {
-        return new GsonBuilder()
-                .registerTypeAdapter(BaseComponent.class, new ComponentSerializer())
-                .registerTypeAdapter(TextComponent.class, new TextComponentSerializer())
-                .registerTypeAdapter(TranslatableComponent.class, new TranslatableComponentSerializer())
-                .registerTypeAdapter(KeybindComponent.class, new KeybindComponentSerializer())
-                .registerTypeAdapter(ScoreComponent.class, new ScoreComponentSerializer())
-                .registerTypeAdapter(SelectorComponent.class, new SelectorComponentSerializer())
-                .registerTypeAdapter(net.md_5.bungee.api.chat.hover.content.Entity.class, new EntitySerializer())
-                .registerTypeAdapter(Text.class, new TextSerializer())
-                .registerTypeAdapter(Item.class, new ItemSerializer())
-                .registerTypeAdapter(ItemTag.class, new ItemTag.Serializer())
-                .disableHtmlEscaping() // Mojang
-                .create();
     }
 }

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
@@ -31,16 +31,13 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.google.common.collect.Iterables;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.yggdrasil.ProfileResult;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.*;
-import net.md_5.bungee.chat.*;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Rotations;
@@ -391,22 +388,5 @@ public class Handler extends NMSHandler {
             return null;
         }
         return CraftChatMessage.fromJSONOrNull(FormattedTextHelper.componentToJson(spigot));
-    }
-
-    @Override
-    public Gson getVanillaStyleSpigotComponentGSON() {
-        return new GsonBuilder()
-                .registerTypeAdapter(BaseComponent.class, new ComponentSerializer())
-                .registerTypeAdapter(TextComponent.class, new TextComponentSerializer())
-                .registerTypeAdapter(TranslatableComponent.class, new TranslatableComponentSerializer())
-                .registerTypeAdapter(KeybindComponent.class, new KeybindComponentSerializer())
-                .registerTypeAdapter(ScoreComponent.class, new ScoreComponentSerializer())
-                .registerTypeAdapter(SelectorComponent.class, new SelectorComponentSerializer())
-                .registerTypeAdapter(net.md_5.bungee.api.chat.hover.content.Entity.class, new EntitySerializer())
-                .registerTypeAdapter(Text.class, new TextSerializer())
-                .registerTypeAdapter(Item.class, new ItemSerializer())
-                .registerTypeAdapter(net.md_5.bungee.api.chat.ItemTag.class, new net.md_5.bungee.api.chat.ItemTag.Serializer())
-                .disableHtmlEscaping() // Mojang
-                .create();
     }
 }

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
@@ -32,16 +32,13 @@ import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
 import com.google.common.collect.Iterables;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.yggdrasil.ProfileResult;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.*;
-import net.md_5.bungee.chat.*;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Rotations;
@@ -394,22 +391,5 @@ public class Handler extends NMSHandler {
     @Override
     public String updateLegacyName(Class<?> type, String legacyName) {
         return FieldRename.rename(ApiVersion.FIELD_NAME_PARITY, DebugInternals.getFullClassNameOpti(type).replace('.', '/'), legacyName);
-    }
-
-    @Override
-    public Gson getVanillaStyleSpigotComponentGSON() {
-        return new GsonBuilder()
-                .registerTypeAdapter(BaseComponent.class, new ComponentSerializer())
-                .registerTypeAdapter(TextComponent.class, new TextComponentSerializer(VersionedComponentSerializer.getDefault()))
-                .registerTypeAdapter(TranslatableComponent.class, new TranslatableComponentSerializer(VersionedComponentSerializer.getDefault()))
-                .registerTypeAdapter(KeybindComponent.class, new KeybindComponentSerializer(VersionedComponentSerializer.getDefault()))
-                .registerTypeAdapter(ScoreComponent.class, new ScoreComponentSerializer(VersionedComponentSerializer.getDefault()))
-                .registerTypeAdapter(SelectorComponent.class, new SelectorComponentSerializer(VersionedComponentSerializer.getDefault()))
-                .registerTypeAdapter(net.md_5.bungee.api.chat.hover.content.Entity.class, new EntitySerializer(VersionedComponentSerializer.getDefault()))
-                .registerTypeAdapter(Text.class, new TextSerializer())
-                .registerTypeAdapter(Item.class, new ItemSerializer())
-                .registerTypeAdapter(net.md_5.bungee.api.chat.ItemTag.class, new net.md_5.bungee.api.chat.ItemTag.Serializer())
-                .disableHtmlEscaping() // Mojang
-                .create();
     }
 }

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
@@ -38,7 +38,6 @@ import com.mojang.authlib.yggdrasil.ProfileResult;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Rotations;
@@ -378,7 +377,7 @@ public class Handler extends NMSHandler {
         if (nms == null) {
             return null;
         }
-        return ComponentSerializer.parse(CraftChatMessage.toJSON(nms));
+        return FormattedTextHelper.parseJson(CraftChatMessage.toJSON(nms));
     }
 
     public static Component componentToNMS(BaseComponent[] spigot) {

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/packets/PacketOutChatImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/packets/PacketOutChatImpl.java
@@ -18,14 +18,14 @@ public class PacketOutChatImpl extends PacketOutChat {
     public PacketOutChatImpl(ClientboundSystemChatPacket internal) {
         systemPacket = internal;
         rawJson = CraftChatMessage.toJSON(internal.content());
-        message = FormattedTextHelper.stringify(ComponentSerializer.parse(rawJson));
+        message = FormattedTextHelper.stringify(FormattedTextHelper.parseJson(rawJson));
         isOverlayActionbar = internal.overlay();
     }
 
     public PacketOutChatImpl(ClientboundPlayerChatPacket internal) {
         playerPacket = internal;
         rawJson = ComponentSerializer.toString(internal.body().content());
-        message = FormattedTextHelper.stringify(ComponentSerializer.parse(rawJson));
+        message = FormattedTextHelper.stringify(FormattedTextHelper.parseJson(rawJson));
     }
 
     @Override


### PR DESCRIPTION
This turned out to be a bunch of stuff in one PR, but will try splitting the commits and description at least.

## `NMSHandler#getVersion` calls before initialization
Needed to check the version in `FormattedTextHelper`'s initialization (before `NMSHandler`), so the version is now checked and stored in a `static` block so that it's accessible at all times.

## Component JSON parsing
`ComponentSerializer#parse` can no longer be used, as that uses `VersionedComponentSerializer#getDefault` which returns the 1.16 serializer.

- Adds `FormattedTextHelper#parseJson` which checks the version and runs it though the proper serializer.

## Base `vanillaStyleSpigotComponentGSON` off of default Bungee serializer

- Adds `FormattedTextHelper#getBungeeGson`, which returns the Bungee `Gson` instance.
- `vanillaStyleSpigotComponentGSON` now uses `getBungeeGson` + `Gson#newBuilder` to `#disableHtmlEscaping` without having to redefine the entire serializer.

## Fixes to `HoverFormatHelper`'s workaround

- `HoverFormatHelper#tryInitializeItemHoverFix` is now called right before `FormattedTextHelper.vanillaStyleSpigotComponentGSON` is initialized, so that it contains the item hover workarounds.
- `tryInitializeItemHoverFix` now uses `FormattedTextHelper#getBungeeGson`.
- `tryInitializeItemHoverFix` now has different reflection logic for setting a `VersionComponentSerializer` vs `ComponentSerializer`.