### PR TITLE
Paper fixes

### DIFF
--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.4-R0.1-SNAPSHOT</version>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityKnocksbackEntityScriptEvent.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/EntityKnocksbackEntityScriptEvent.java
@@ -96,7 +96,7 @@ public class EntityKnocksbackEntityScriptEvent extends BukkitScriptEvent impleme
             case "entity" -> entity.getDenizenObject();
             case "damager" -> hitBy.getDenizenObject();
             case "acceleration" -> new LocationTag(event.getAcceleration());
-            case "cause" -> new ElementTag(event.getCause());
+            case "cause" -> new ElementTag(event.getCause().name(), true); // TODO: once 1.20 is the minimum supported version, use the enum constructor
             default -> super.getContext(name);
         };
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/BlockHelper.java
@@ -65,7 +65,7 @@ public interface BlockHelper {
         return Material.matchMaterial(material).createBlockData(otherData);
     }
 
-    void makeBlockStateRaw(BlockState state);
+    default void makeBlockStateRaw(BlockState state) {} // TODO: once 1.19 is the minimum supported version, remove this
 
     void doRandomTick(Location location);
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -5253,13 +5253,13 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // -->
         if (mechanism.matches("jukebox_record")) {
             BlockState state = getBlockState();
-            if (state instanceof Jukebox) {
+            if (state instanceof Jukebox jukebox) {
                 if (mechanism.hasValue() && mechanism.requireObject(ItemTag.class)) {
-                    ((Jukebox) state).setRecord(mechanism.valueAsType(ItemTag.class).getItemStack());
+                    jukebox.setRecord(mechanism.valueAsType(ItemTag.class).getItemStack());
                 }
                 else {
                     NMSHandler.blockHelper.makeBlockStateRaw(state);
-                    ((Jukebox) state).setRecord(null);
+                    jukebox.setRecord(null);
                 }
                 state.update();
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -5252,20 +5252,21 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
         // <LocationTag.jukebox_record>
         // -->
         if (mechanism.matches("jukebox_record")) {
-            BlockState state = getBlockState();
-            if (state instanceof Jukebox jukebox) {
-                if (mechanism.hasValue() && mechanism.requireObject(ItemTag.class)) {
-                    jukebox.setRecord(mechanism.valueAsType(ItemTag.class).getItemStack());
+            if (!(getBlockState() instanceof Jukebox jukebox)) {
+                mechanism.echoError("'jukebox_record' mechanism can only be called on a jukebox block.");
+                return;
+            }
+            if (mechanism.hasValue()) {
+                if (!mechanism.requireObject(ItemTag.class)) {
+                    return;
                 }
-                else {
-                    NMSHandler.blockHelper.makeBlockStateRaw(state);
-                    jukebox.setRecord(null);
-                }
-                state.update();
+                jukebox.setRecord(mechanism.valueAsType(ItemTag.class).getItemStack());
             }
             else {
-                mechanism.echoError("'jukebox_record' mechanism can only be called on a jukebox block.");
+                NMSHandler.blockHelper.makeBlockStateRaw(jukebox);
+                jukebox.setRecord(null);
             }
+            jukebox.update();
         }
 
         // <--[mechanism]

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/helpers/BlockHelperImpl.java
@@ -38,7 +38,6 @@ import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.Skull;
 import org.bukkit.craftbukkit.v1_19_R3.CraftChunk;
@@ -65,16 +64,6 @@ public class BlockHelperImpl implements BlockHelper {
     public static final Field craftBlockEntityState_tileEntity = ReflectionHelper.getFields(CraftBlockEntityState.class).get("tileEntity");
     public static final Field craftBlockEntityState_snapshot = ReflectionHelper.getFields(CraftBlockEntityState.class).get("snapshot");
     public static final Field craftSkull_profile = ReflectionHelper.getFields(CraftSkull.class).get("profile");
-
-    @Override
-    public void makeBlockStateRaw(BlockState state) {
-        try {
-            craftBlockEntityState_snapshot.set(state, craftBlockEntityState_tileEntity.get(state));
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-        }
-    }
 
     @Override
     public void applyPhysics(Location location) {

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/helpers/BlockHelperImpl.java
@@ -37,7 +37,6 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.Skull;
 import org.bukkit.craftbukkit.v1_20_R4.CraftChunk;
@@ -65,16 +64,6 @@ public class BlockHelperImpl implements BlockHelper {
     public static final Field craftBlockEntityState_tileEntity = ReflectionHelper.getFields(CraftBlockEntityState.class).get("tileEntity");
     public static final Field craftBlockEntityState_snapshot = ReflectionHelper.getFields(CraftBlockEntityState.class).get("snapshot");
     public static final Field craftSkull_profile = ReflectionHelper.getFields(CraftSkull.class).get("profile");
-
-    @Override
-    public void makeBlockStateRaw(BlockState state) {
-        try {
-            craftBlockEntityState_snapshot.set(state, craftBlockEntityState_tileEntity.get(state));
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-        }
-    }
 
     @Override
     public void applyPhysics(Location location) {

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
@@ -32,7 +32,6 @@ import org.bukkit.Instrument;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.Skull;
 import org.bukkit.craftbukkit.v1_21_R4.CraftChunk;
@@ -53,18 +52,16 @@ import java.util.Optional;
 
 public class BlockHelperImpl implements BlockHelper {
 
-    public static final Field craftBlockEntityState_tileEntity = ReflectionHelper.getFields(CraftBlockEntityState.class).get("tileEntity");
+    public static final Field craftBlockEntityState_tileEntity;
     public static final Field craftBlockEntityState_snapshot = ReflectionHelper.getFields(CraftBlockEntityState.class).get("snapshot");
     public static final Field craftSkull_profile = ReflectionHelper.getFields(CraftSkull.class).get("profile");
 
-    @Override
-    public void makeBlockStateRaw(BlockState state) {
-        try {
-            craftBlockEntityState_snapshot.set(state, craftBlockEntityState_tileEntity.get(state));
+    static {
+        Field blockEntityField = ReflectionHelper.getFields(CraftBlockEntityState.class).getNoCheck("blockEntity");
+        if (blockEntityField == null) {
+            blockEntityField = ReflectionHelper.getFields(CraftBlockEntityState.class).get("tileEntity");
         }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
-        }
+        craftBlockEntityState_tileEntity = blockEntityField;
     }
 
     @Override


### PR DESCRIPTION
## Changes
- `context.cause` in `EntityKnocksbackEntityScriptEvent` errored on older versions due to the Enum not existing, now uses a workaround.
- Removed `BlockHelper#makeBlockStateRaw` implementations on versions that no longer need it.
- Minor cleanups to `LocationTag.jukebox_record` mechanism code.
- `BlockHelperImpl(1.21).craftBlockEntityState_tileEntity` - field name changed on Paper, updated to fix that.
- Bumped Paper API version.