### PR TITLE
`1.21.5` Area effect cloud fixes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -34,9 +34,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityAI.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAnger.class, EntityTag.class);
         PropertyParser.registerProperty(EntityAngry.class, EntityTag.class);
-        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
-            PropertyParser.registerProperty(EntityAreaEffectCloud.class, EntityTag.class);
-        }
+        PropertyParser.registerProperty(EntityAreaEffectCloud.class, EntityTag.class);
         PropertyParser.registerProperty(EntityArmorBonus.class, EntityTag.class);
         PropertyParser.registerProperty(EntityArrowDamage.class, EntityTag.class);
         PropertyParser.registerProperty(EntityArrowPierceLevel.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -16,6 +16,7 @@ import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
+import org.bukkit.Particle;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.potion.PotionEffect;
@@ -142,11 +143,11 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.particle.color>
             // @returns ColorTag
-            // @group properties
-            // @description
-            // Returns the Area Effect Cloud's particle color.
+            // @deprecated use 'EntityTag.color'.
+            // @description Deprecated in favor of <@link property EntityTag.color>.
             // -->
             if (attribute.startsWith("color")) {
+                BukkitImplDeprecations.areaEffectCloudControls.warn(attribute.context);
                 return BukkitColorExtensions.fromColor(getHelper().getColor())
                         .getObjectAttribute(attribute.fulfill(1));
             }
@@ -459,12 +460,13 @@ public class EntityAreaEffectCloud implements Property {
         // @object EntityTag
         // @name particle_color
         // @input ColorTag
-        // @description
-        // Sets the Area Effect Cloud's particle color.
+        // @deprecated use 'EntityTag.color'.
+        // @description Deprecated in favor of <@link property EntityTag.color>.
         // @tags
         // <EntityTag.particle.color>
         // -->
         if (mechanism.matches("particle_color") && mechanism.requireObject(ColorTag.class)) {
+            BukkitImplDeprecations.areaEffectCloudControls.warn(mechanism.context);
             getHelper().setColor(BukkitColorExtensions.getColor(mechanism.valueAsType(ColorTag.class)));
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -26,7 +26,7 @@ import org.bukkit.projectiles.ProjectileSource;
 
 import java.util.List;
 
-// TODO: 1.20.6: PotionData API
+// TODO: most of the tags and mechs here need to become properties/be merged into existing properties
 public class EntityAreaEffectCloud implements Property {
 
     public static boolean describes(ObjectTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -144,7 +144,8 @@ public class EntityAreaEffectCloud implements Property {
             // @attribute <EntityTag.particle.color>
             // @returns ColorTag
             // @deprecated use 'EntityTag.color'.
-            // @description Deprecated in favor of <@link property EntityTag.color>.
+            // @description
+            // Deprecated in favor of <@link property EntityTag.color>.
             // -->
             if (attribute.startsWith("color")) {
                 BukkitImplDeprecations.areaEffectCloudControls.warn(attribute.context);
@@ -319,7 +320,8 @@ public class EntityAreaEffectCloud implements Property {
             // @attribute <EntityTag.custom_effects[<#>].type>
             // @returns ElementTag
             // @deprecated use 'EntityTag.effects_data'.
-            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
+            // @description
+            // Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("type")) {
                 return new ElementTag(effect.getType().getName())
@@ -330,7 +332,8 @@ public class EntityAreaEffectCloud implements Property {
             // @attribute <EntityTag.custom_effects[<#>].amplifier>
             // @returns ElementTag(Number)
             // @deprecated use 'EntityTag.effects_data'.
-            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
+            // @description
+            // Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("amplifier")) {
                 return new ElementTag(effect.getAmplifier())
@@ -341,7 +344,8 @@ public class EntityAreaEffectCloud implements Property {
             // @attribute <EntityTag.custom_effects[<#>].duration>
             // @returns DurationTag
             // @deprecated use 'EntityTag.effects_data'.
-            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
+            // @description
+            // Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("duration")) {
                 return new DurationTag((long) effect.getDuration())
@@ -352,7 +356,8 @@ public class EntityAreaEffectCloud implements Property {
             // @attribute <EntityTag.custom_effects[<#>].has_particles>
             // @returns ElementTag(Boolean)
             // @deprecated use 'EntityTag.effects_data'.
-            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
+            // @description
+            // Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("has_particles")) {
                 return new ElementTag(effect.hasParticles())
@@ -363,7 +368,8 @@ public class EntityAreaEffectCloud implements Property {
             // @attribute <EntityTag.custom_effects[<#>].is_ambient>
             // @returns ElementTag(Boolean)
             // @deprecated use 'EntityTag.effects_data'.
-            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
+            // @description
+            // Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("is_ambient")) {
                 return new ElementTag(effect.isAmbient())

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -1,9 +1,14 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
-import com.denizenscript.denizen.objects.properties.bukkit.BukkitColorExtensions;
-import com.denizenscript.denizen.utilities.entity.AreaEffectCloudHelper;
-import com.denizenscript.denizencore.objects.*;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.properties.bukkit.BukkitColorExtensions;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizen.utilities.entity.AreaEffectCloudHelper;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ColorTag;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -74,21 +79,22 @@ public class EntityAreaEffectCloud implements Property {
         // <--[tag]
         // @attribute <EntityTag.base_potion>
         // @returns ElementTag
-        // @mechanism EntityTag.base_potion
-        // @group properties
+        // @deprecated use 'EntityTag.potion_type' on MC 1.20+.
         // @description
-        // Returns the Area Effect Cloud's base potion data.
-        // In the format Type,Upgraded,Extended
+        // Deprecated in favor of <@link property EntityTag.potion_type> on MC 1.20+.
         // -->
         if (attribute.startsWith("base_potion")) {
             attribute = attribute.fulfill(1);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                BukkitImplDeprecations.areaEffectCloudControls.warn(attribute.context);
+            }
 
             // <--[tag]
             // @attribute <EntityTag.base_potion.type>
             // @returns ElementTag
-            // @group properties
+            // @deprecated use 'EntityTag.potion_type' on MC 1.20+.
             // @description
-            // Returns the Area Effect Cloud's base potion type.
+            // Deprecated in favor of <@link property EntityTag.potion_type> on MC 1.20+.
             // -->
             if (attribute.startsWith("type")) {
                 return new ElementTag(getHelper().getBPName())
@@ -98,9 +104,9 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.base_potion.is_upgraded>
             // @returns ElementTag(Boolean)
-            // @group properties
+            // @deprecated use 'EntityTag.potion_type' on MC 1.20+.
             // @description
-            // Returns whether the Area Effect Cloud's base potion is upgraded.
+            // Deprecated in favor of <@link property EntityTag.potion_type> on MC 1.20+.
             // -->
             if (attribute.startsWith("is_upgraded")) {
                 return new ElementTag(getHelper().getBPUpgraded())
@@ -110,9 +116,9 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.base_potion.is_extended>
             // @returns ElementTag(Boolean)
-            // @group properties
+            // @deprecated use 'EntityTag.potion_type' on MC 1.20+.
             // @description
-            // Returns whether the Area Effect Cloud's base potion is extended.
+            // Deprecated in favor of <@link property EntityTag.potion_type> on MC 1.20+.
             // -->
             if (attribute.startsWith("is_extended")) {
                 return new ElementTag(getHelper().getBPExtended())
@@ -471,37 +477,31 @@ public class EntityAreaEffectCloud implements Property {
         // @object EntityTag
         // @name base_potion
         // @input ElementTag
+        // @deprecated use 'EntityTag.potion_type' on MC 1.20+.
         // @description
-        // Sets the Area Effect Cloud's base potion.
-        // In the form: Type,Upgraded,Extended
-        // NOTE: Potion cannot be both upgraded and extended
-        // @tags
-        // <EntityTag.base_potion>
-        // <EntityTag.base_potion.type>
-        // <EntityTag.base_potion.is_upgraded>
-        // <EntityTag.base_potion.is_extended>
-        // <server.potion_types>
+        // Deprecated in favor of <@link property EntityTag.potion_type> on MC 1.20+.
         // -->
         if (mechanism.matches("base_potion")) {
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+                BukkitImplDeprecations.areaEffectCloudControls.warn(mechanism.context);
+            }
             List<String> data = CoreUtilities.split(mechanism.getValue().asString().toUpperCase(), ',');
             if (data.size() != 3) {
-                mechanism.echoError(mechanism.getValue().asString() + " is not a valid base potion!");
+                mechanism.echoError(mechanism.getValue() + " is not a valid base potion!");
+                return;
+            }
+            PotionType type = Utilities.elementToEnumlike(new ElementTag(data.get(0)), PotionType.class);
+            if (type == null) {
+                mechanism.echoError(mechanism.getValue() + " is not a valid base potion!");
+                return;
+            }
+            boolean upgraded = type.isUpgradeable() && CoreUtilities.equalsIgnoreCase(data.get(1), "true");
+            boolean extended = type.isExtendable() && CoreUtilities.equalsIgnoreCase(data.get(2), "true");
+            if (extended && upgraded) {
+                mechanism.echoError("Potion cannot be both upgraded and extended");
             }
             else {
-                try {
-                    PotionType type = PotionType.valueOf(data.get(0));
-                    boolean upgraded = type.isUpgradeable() && CoreUtilities.equalsIgnoreCase(data.get(1), "true");
-                    boolean extended = type.isExtendable() && CoreUtilities.equalsIgnoreCase(data.get(2), "true");
-                    if (extended && upgraded) {
-                        mechanism.echoError("Potion cannot be both upgraded and extended");
-                    }
-                    else {
-                        getHelper().setBP(type, extended, upgraded);
-                    }
-                }
-                catch (Exception e) {
-                    mechanism.echoError(mechanism.getValue().asString() + " is not a valid base potion!");
-                }
+                getHelper().setBP(type, extended, upgraded);
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -252,12 +252,11 @@ public class EntityAreaEffectCloud implements Property {
         // @attribute <EntityTag.has_custom_effect[(<effect>)]>
         // @returns ElementTag(Boolean)
         // @mechanism EntityTag.custom_effects
-        // @group properties
-        // @description
-        // Returns whether the Area Effect Cloud has a specified effect.
-        // If no effect is specified, returns whether it has any custom effect.
+        // @deprecated use 'EntityTag.has_effect'.
+        // @description Deprecated in favor of <@link tag EntityTag.has_effect>.
         // -->
         if (attribute.startsWith("has_custom_effect")) {
+            BukkitImplDeprecations.areaEffectCloudControls.warn(attribute.context);
             if (attribute.hasParam()) {
                 PotionEffectType effectType = PotionEffectType.getByName(attribute.getParam());
                 for (PotionEffect effect : getHelper().getCustomEffects()) {
@@ -291,12 +290,11 @@ public class EntityAreaEffectCloud implements Property {
         // @attribute <EntityTag.custom_effects>
         // @returns ListTag
         // @mechanism EntityTag.custom_effects
-        // @group properties
-        // @description
-        // Returns a ListTag of the Area Effect Cloud's custom effects
-        // In the form Type,Amplifier,Duration,Ambient,Particles|...
+        // @deprecated use 'EntityTag.effects_data'.
+        // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
         // -->
         if (attribute.startsWith("custom_effects")) {
+            BukkitImplDeprecations.areaEffectCloudControls.warn(attribute.context);
             List<PotionEffect> effects = getHelper().getCustomEffects();
             if (!attribute.hasParam()) {
                 ListTag list = new ListTag();
@@ -319,9 +317,8 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.custom_effects[<#>].type>
             // @returns ElementTag
-            // @group properties
-            // @description
-            // Returns the specified Area Effect Cloud potion effect type.
+            // @deprecated use 'EntityTag.effects_data'.
+            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("type")) {
                 return new ElementTag(effect.getType().getName())
@@ -331,9 +328,8 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.custom_effects[<#>].amplifier>
             // @returns ElementTag(Number)
-            // @group properties
-            // @description
-            // Returns the specified Area Effect Cloud potion effect amplifier.
+            // @deprecated use 'EntityTag.effects_data'.
+            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("amplifier")) {
                 return new ElementTag(effect.getAmplifier())
@@ -343,9 +339,8 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.custom_effects[<#>].duration>
             // @returns DurationTag
-            // @group properties
-            // @description
-            // Returns the specified Area Effect Cloud potion effect duration.
+            // @deprecated use 'EntityTag.effects_data'.
+            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("duration")) {
                 return new DurationTag((long) effect.getDuration())
@@ -355,9 +350,8 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.custom_effects[<#>].has_particles>
             // @returns ElementTag(Boolean)
-            // @group properties
-            // @description
-            // Returns whether the specified Area Effect Cloud potion effect has particles.
+            // @deprecated use 'EntityTag.effects_data'.
+            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("has_particles")) {
                 return new ElementTag(effect.hasParticles())
@@ -367,9 +361,8 @@ public class EntityAreaEffectCloud implements Property {
             // <--[tag]
             // @attribute <EntityTag.custom_effects[<#>].is_ambient>
             // @returns ElementTag(Boolean)
-            // @group properties
-            // @description
-            // Returns whether the specified Area Effect Cloud potion effect is ambient.
+            // @deprecated use 'EntityTag.effects_data'.
+            // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
             // -->
             if (attribute.startsWith("is_ambient")) {
                 return new ElementTag(effect.isAmbient())
@@ -397,12 +390,13 @@ public class EntityAreaEffectCloud implements Property {
         // @object EntityTag
         // @name clear_custom_effects
         // @input None
-        // @description
-        // Clears all custom effects from the Area Effect Cloud
+        // @deprecated use 'EntityTag.potion_effects'.
+        // @description Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
         // @tags
         // <EntityTag.custom_effects>
         // -->
         if (mechanism.matches("clear_custom_effects")) {
+            BukkitImplDeprecations.areaEffectCloudControls.warn(mechanism.context);
             getHelper().clearEffects();
         }
 
@@ -410,12 +404,13 @@ public class EntityAreaEffectCloud implements Property {
         // @object EntityTag
         // @name remove_custom_effect
         // @input ElementTag
-        // @description
-        // Removes the specified custom effect from the Area Effect Cloud
+        // @deprecated use 'EntityTag.potion_effects'.
+        // @description Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
         // @tags
         // <EntityTag.custom_effects>
         // -->
         if (mechanism.matches("remove_custom_effect")) {
+            BukkitImplDeprecations.areaEffectCloudControls.warn(mechanism.context);
             PotionEffectType type = PotionEffectType.getByName(mechanism.getValue().asString().toUpperCase());
             if (type != null) {
                 getHelper().removeEffect(type);
@@ -426,13 +421,13 @@ public class EntityAreaEffectCloud implements Property {
         // @object EntityTag
         // @name custom_effects
         // @input ListTag
-        // @description
-        // Adds a list of custom potion effects to the Area Effect Cloud
-        // In the form Type,Amplifier,Duration(,Ambient,Particles)|...
+        // @deprecated use 'EntityTag.potion_effects'.
+        // @description Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
         // @tags
         // <EntityTag.custom_effects>
         // -->
         if (mechanism.matches("custom_effects")) {
+            BukkitImplDeprecations.areaEffectCloudControls.warn(mechanism.context);
             ListTag list = mechanism.valueAsType(ListTag.class);
             getHelper().clearEffects();
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -80,6 +80,7 @@ public class EntityAreaEffectCloud implements Property {
         // <--[tag]
         // @attribute <EntityTag.base_potion>
         // @returns ElementTag
+        // @mechanism EntityTag.base_potion
         // @deprecated use 'EntityTag.potion_type' on MC 1.20+.
         // @description
         // Deprecated in favor of <@link property EntityTag.potion_type> on MC 1.20+.
@@ -489,6 +490,8 @@ public class EntityAreaEffectCloud implements Property {
         // @deprecated use 'EntityTag.potion_type' on MC 1.20+.
         // @description
         // Deprecated in favor of <@link property EntityTag.potion_type> on MC 1.20+.
+        // @tags
+        // <EntityTag.base_potion>
         // -->
         if (mechanism.matches("base_potion")) {
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
@@ -499,7 +502,7 @@ public class EntityAreaEffectCloud implements Property {
                 mechanism.echoError(mechanism.getValue() + " is not a valid base potion!");
                 return;
             }
-            PotionType type = Utilities.elementToEnumlike(new ElementTag(data.get(0)), PotionType.class);
+            PotionType type = Utilities.elementToEnumlike(new ElementTag(data.get(0), true), PotionType.class);
             if (type == null) {
                 mechanism.echoError(mechanism.getValue() + " is not a valid base potion!");
                 return;

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -255,7 +255,8 @@ public class EntityAreaEffectCloud implements Property {
         // @returns ElementTag(Boolean)
         // @mechanism EntityTag.custom_effects
         // @deprecated use 'EntityTag.has_effect'.
-        // @description Deprecated in favor of <@link tag EntityTag.has_effect>.
+        // @description
+        // Deprecated in favor of <@link tag EntityTag.has_effect>.
         // -->
         if (attribute.startsWith("has_custom_effect")) {
             BukkitImplDeprecations.areaEffectCloudControls.warn(attribute.context);
@@ -293,7 +294,8 @@ public class EntityAreaEffectCloud implements Property {
         // @returns ListTag
         // @mechanism EntityTag.custom_effects
         // @deprecated use 'EntityTag.effects_data'.
-        // @description Deprecated in favor of <@link tag EntityTag.effects_data>.
+        // @description
+        // Deprecated in favor of <@link tag EntityTag.effects_data>.
         // -->
         if (attribute.startsWith("custom_effects")) {
             BukkitImplDeprecations.areaEffectCloudControls.warn(attribute.context);
@@ -398,7 +400,8 @@ public class EntityAreaEffectCloud implements Property {
         // @name clear_custom_effects
         // @input None
         // @deprecated use 'EntityTag.potion_effects'.
-        // @description Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
+        // @description
+        // Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
         // @tags
         // <EntityTag.custom_effects>
         // -->
@@ -412,7 +415,8 @@ public class EntityAreaEffectCloud implements Property {
         // @name remove_custom_effect
         // @input ElementTag
         // @deprecated use 'EntityTag.potion_effects'.
-        // @description Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
+        // @description
+        // Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
         // @tags
         // <EntityTag.custom_effects>
         // -->
@@ -429,7 +433,8 @@ public class EntityAreaEffectCloud implements Property {
         // @name custom_effects
         // @input ListTag
         // @deprecated use 'EntityTag.potion_effects'.
-        // @description Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
+        // @description
+        // Deprecated in favor of <@link mechanism EntityTag.potion_effects>.
         // @tags
         // <EntityTag.custom_effects>
         // -->
@@ -467,7 +472,8 @@ public class EntityAreaEffectCloud implements Property {
         // @name particle_color
         // @input ColorTag
         // @deprecated use 'EntityTag.color'.
-        // @description Deprecated in favor of <@link property EntityTag.color>.
+        // @description
+        // Deprecated in favor of <@link property EntityTag.color>.
         // @tags
         // <EntityTag.particle.color>
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityAreaEffectCloud.java
@@ -538,7 +538,8 @@ public class EntityAreaEffectCloud implements Property {
         // @tags
         // <EntityTag.particle>
         // -->
-        if (mechanism.matches("particle") && mechanism.hasValue()) {
+        // TODO: some particles require additional data - need a new property that supports playeffect's special_data input
+        if (mechanism.matches("particle") && Utilities.requireEnumlike(mechanism, Particle.class)) {
             getHelper().setParticle(mechanism.getValue().asString().toUpperCase());
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -55,6 +55,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 type == EntityType.TROPICAL_FISH ||
                 type == EntityType.GOAT ||
                 type == EntityType.AXOLOTL ||
+                type == EntityType.AREA_EFFECT_CLOUD ||
                 (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && MultiVersionHelper1_19.colorIsApplicable(type));
     }
 
@@ -214,6 +215,9 @@ public class EntityColor extends EntityProperty<ElementTag> {
         else if (type == EntityType.AXOLOTL && mechanism.requireEnum(Axolotl.Variant.class)) {
             as(Axolotl.class).setVariant(color.asEnum(Axolotl.Variant.class));
         }
+        else if (type == EntityType.AREA_EFFECT_CLOUD && mechanism.requireObject(ColorTag.class)) {
+            as(AreaEffectCloud.class).setColor(BukkitColorExtensions.getColor(mechanism.valueAsType(ColorTag.class)));
+        }
         else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && MultiVersionHelper1_19.colorIsApplicable(type)) {
             MultiVersionHelper1_19.setColor(getEntity(), mechanism);
         }
@@ -274,6 +278,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
             }
             case GOAT -> as(Goat.class).isScreaming() ? "screaming" : "normal";
             case AXOLOTL -> as(Axolotl.class).getVariant().name();
+            case AREA_EFFECT_CLOUD -> BukkitColorExtensions.fromColor(as(AreaEffectCloud.class).getColor()).identify();
             default -> null;
         };
     }
@@ -313,7 +318,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 yield result;
             }
             case AXOLOTL -> Utilities.listTypes(Axolotl.Variant.class);
-            default -> null; // includes Ocelot (deprecated) and arrow (ColorTag)
+            default -> null; // includes Ocelot (deprecated) and arrow/area effect cloud (ColorTag)
         };
     }
 
@@ -340,7 +345,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
     // For tropical_fish, the input is PATTERN|BODYCOLOR|PATTERNCOLOR, where BodyColor and PatterenColor are both DyeColor (see below),
     //          and PATTERN is KOB, SUNSTREAK, SNOOPER, DASHER, BRINELY, SPOTTY, FLOPPER, STRIPEY, GLITTER, BLOCKFISH, BETTY, is CLAYFISH.
     // For sheep, wolf, and shulker entities, the input is a Dye Color.
-    // For Tipped Arrow entities, the input is a ColorTag.
+    // For Tipped Arrow and Area effect cloud entities, the input is a ColorTag.
     // For goats, the input is SCREAMING or NORMAL.
     // For axolotl, the types are BLUE, CYAN, GOLD, LUCY, or WILD.
     // For frogs, the types are TEMPERATE, WARM, or COLD.

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionEffects.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionEffects.java
@@ -135,7 +135,7 @@ public class EntityPotionEffects implements Property {
         // @group attributes
         // @mechanism EntityTag.potion_effects
         // @description
-        // Returns whether the entity has a specified effect, or whether an arrow/area effect cloud would apply a certain effect.
+        // Returns whether the entity has a specified effect, or whether an arrow/area effect cloud will apply a certain effect.
         // If no effect is specified, returns whether the entity has any effect.
         // The effect type must be from <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/potion/PotionEffectType.html>.
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionEffects.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionEffects.java
@@ -12,6 +12,7 @@ import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
+import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Arrow;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -22,11 +23,12 @@ import java.util.Collection;
 public class EntityPotionEffects implements Property {
 
     public static boolean describes(ObjectTag object) {
-        if (!(object instanceof EntityTag)) {
+        if (!(object instanceof EntityTag entity)) {
             return false;
         }
-        return ((EntityTag) object).isLivingEntity()
-                || ((EntityTag) object).getBukkitEntity() instanceof Arrow;
+        return entity.isLivingEntity()
+                || entity.getBukkitEntity() instanceof Arrow
+                || entity.getBukkitEntity() instanceof AreaEffectCloud;
     }
 
     public static EntityPotionEffects getFrom(ObjectTag object) {
@@ -55,7 +57,9 @@ public class EntityPotionEffects implements Property {
         else if (isArrow()) {
             return getArrow().getCustomEffects();
         }
-        return new ArrayList<>();
+        else {
+            return getAreaEffectCloud().getCustomEffects();
+        }
     }
 
     public ListTag getEffectsListTag(TagContext context) {
@@ -80,6 +84,10 @@ public class EntityPotionEffects implements Property {
 
     public Arrow getArrow() {
         return (Arrow) entity.getBukkitEntity();
+    }
+
+    public AreaEffectCloud getAreaEffectCloud() {
+        return (AreaEffectCloud) entity.getBukkitEntity();
     }
 
     public String getPropertyString() {
@@ -114,7 +122,8 @@ public class EntityPotionEffects implements Property {
         // @group attribute
         // @mechanism EntityTag.potion_effects
         // @description
-        // Returns the active potion effects on the entity, as a list of maps in <@link language Potion Effect Format>.
+        // Returns the active potion effects on the entity, or the potion effects an arrow/area effect cloud will apply.
+        // The effects returned are a list of maps in <@link language Potion Effect Format>.
         // -->
         PropertyParser.registerTag(EntityPotionEffects.class, ListTag.class, "effects_data", (attribute, object) -> {
             return object.getEffectsMapTag(true);
@@ -126,7 +135,7 @@ public class EntityPotionEffects implements Property {
         // @group attributes
         // @mechanism EntityTag.potion_effects
         // @description
-        // Returns whether the entity has a specified effect.
+        // Returns whether the entity has a specified effect, or whether an arrow/area effect cloud would apply a certain effect.
         // If no effect is specified, returns whether the entity has any effect.
         // The effect type must be from <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/potion/PotionEffectType.html>.
         // -->
@@ -144,6 +153,9 @@ public class EntityPotionEffects implements Property {
                 else if (object.isArrow()) {
                     returnElement = object.getArrow().hasCustomEffect(effectType);
                 }
+                else {
+                    returnElement = object.getAreaEffectCloud().hasCustomEffect(effectType);
+                }
             }
             else if (!object.getEffectsList().isEmpty()) {
                 returnElement = true;
@@ -159,7 +171,7 @@ public class EntityPotionEffects implements Property {
         // @name potion_effects
         // @input ListTag
         // @description
-        // Set the entity's active potion effects.
+        // Set the entity's active potion effects, or the potion effects an arrow/area effect cloud will apply.
         // Each item in the list must be a MapTag in <@link language Potion Effect Format>.
         // @tags
         // <EntityTag.effects_data>
@@ -185,6 +197,9 @@ public class EntityPotionEffects implements Property {
                 }
                 else if (isArrow()) {
                     getArrow().addCustomEffect(effect, true);
+                }
+                else {
+                    getAreaEffectCloud().addCustomEffect(effect, true);
                 }
             }
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionType.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityPotionType.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.entity.Arrow;
 import org.bukkit.potion.PotionType;
 
@@ -14,31 +15,37 @@ public class EntityPotionType extends EntityProperty<ElementTag> {
     // @name potion_type
     // @input ElementTag
     // @description
-    // Controls an Arrow's base potion type, if any.
+    // Controls an Arrow or Area Effect Cloud's base potion type, if any.
     // See <@link url https://minecraft.wiki/w/Potion#Item_data> for a list of potion types.
-    // See <@link property EntityTag.potion_effects> to control the potion effects an arrow applies.
+    // See <@link property EntityTag.potion_effects> to control the potion effects applied.
     // @mechanism
     // Specify no input to remove the base potion type.
     // -->
 
     public static boolean describes(EntityTag entity) {
-        return entity.getBukkitEntity() instanceof Arrow;
+        return entity.getBukkitEntity() instanceof Arrow || entity.getBukkitEntity() instanceof AreaEffectCloud;
     }
 
     @Override
     public ElementTag getPropertyValue() {
-        PotionType type = as(Arrow.class).getBasePotionType();
+        PotionType type = getEntity() instanceof Arrow arrow ? arrow.getBasePotionType() : as(AreaEffectCloud.class).getBasePotionType();
         return type != null ? new ElementTag(Utilities.namespacedKeyToString(type.getKey()), true) : null;
     }
 
     @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (value == null) {
-            as(Arrow.class).setBasePotionType(null);
-            return;
+        PotionType type = null;
+        if (value != null) {
+            if (!Utilities.requireEnumlike(mechanism, PotionType.class)) {
+                return;
+            }
+            type = Utilities.elementToEnumlike(value, PotionType.class);
         }
-        if (Utilities.requireEnumlike(mechanism, PotionType.class)) {
-            as(Arrow.class).setBasePotionType(Utilities.elementToEnumlike(value, PotionType.class));
+        if (getEntity() instanceof Arrow arrow) {
+            arrow.setBasePotionType(type);
+        }
+        else {
+            as(AreaEffectCloud.class).setBasePotionType(type);
         }
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -459,6 +459,9 @@ public class BukkitImplDeprecations {
     // Added 2025/01/23
     public static Warning projectileLaunchedEntityContext = new FutureWarning("projectileLaunchedEntityContext", "'context.entity' in the 'projectile launched' event is deprecated in favor of 'context.projectile'.");
 
+    // Added 2025/03/29
+    public static Warning areaEffectCloudControls = new FutureWarning("areaEffectCloudControls", "Several tags/mechanisms for controlling area effect clouds have been merged into existing properties, check relevant meta docs for more information.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2023/10/29 without warning.

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/AreaEffectCloudHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/AreaEffectCloudHelper.java
@@ -14,7 +14,6 @@ import org.bukkit.projectiles.ProjectileSource;
 
 import java.util.List;
 
-// TODO: 1.20.6: PotionData API
 public class AreaEffectCloudHelper {
     private AreaEffectCloud entity;
 
@@ -26,7 +25,6 @@ public class AreaEffectCloudHelper {
     // Base Potion Data
     /////////
 
-    // TODO: 1.20.6: PotionData API
     private PotionData getBPData() {
         return entity.getBasePotionData();
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/AreaEffectCloudHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/entity/AreaEffectCloudHelper.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.utilities.entity;
 
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import org.bukkit.Color;
 import org.bukkit.Particle;
 import org.bukkit.entity.AreaEffectCloud;
@@ -62,7 +64,7 @@ public class AreaEffectCloudHelper {
     }
 
     public void setParticle(String name) {
-        Particle particle = Particle.valueOf(name);
+        Particle particle = Utilities.elementToEnumlike(new ElementTag(name, true), Particle.class);
         if (particle != null) {
             entity.setParticle(particle);
         }


### PR DESCRIPTION
## Changes

- `EntityAreaEffectCloud` is now registered on all versions again.
- Added a TODO in `EntityAreaEffectCloud` for some of the extra work that needs to be done there.
- Deprecated `EntityTag.base_potion` & sub-tags on 1.20+ in favor of adding area effect clouds to `EntityTag.potion_type`.
- Deprecated `EntityTag.particle.color` & `EntityTag.particle_color` mech in favor of adding area effect clouds to `EntityTag.color`.
- Deprecated `EntityTag.has_custom_effect`, `custom_effects`, `clear_custom_effects` mech, `remove_custom_effect` mech, and `custom_effects` mech, in favor of adding area effect clouds to `EntityPotionEffects` with all of its tags and mechs.
- Deprecated `EntityTag.base_potion` mech on 1.20+ in favor of `EntityTag.potion_type`, and gave it some minor code updates, mostly for backsupport on modern versions.
- Added a TODO for `EntityTag.particle`, as it technically works for now but is missing particle data input, causing some particles to be impossible to set.
- `AreaEffectCloudHelper#setParticle` now uses `Utilities` methods to allow older particle names as input.