### PR TITLE
`1.21.5` Item/NBT cleanups

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/ItemHelper.java
@@ -1,8 +1,9 @@
 package com.denizenscript.denizen.nms.interfaces;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
-import com.denizenscript.denizen.nms.util.jnbt.IntArrayTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.utilities.nbt.CustomNBT;
@@ -20,11 +21,11 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.ShieldMeta;
 import org.bukkit.map.MapView;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Consumer;
 
 public abstract class ItemHelper {
@@ -163,12 +164,23 @@ public abstract class ItemHelper {
         throw new UnsupportedOperationException();
     }
 
-    public DyeColor getShieldColor(ItemStack item) { // TODO: once 1.20 is the minimum supported version, remove default impl
+    public DyeColor getShieldColor(ItemStack item) { // TODO: once 1.21 is the minimum supported version, remove from NMS
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            return ((ShieldMeta) item.getItemMeta()).getBaseColor();
+        }
+        // TODO: once 1.20 is the minimum supported version, remove legacy code ↓
         BlockStateMeta stateMeta = (BlockStateMeta) item.getItemMeta();
         return stateMeta.hasBlockState() ? ((Banner) stateMeta.getBlockState()).getBaseColor() : null;
     }
 
-    public ItemStack setShieldColor(ItemStack item, DyeColor color) { // TODO: once 1.20 is the minimum supported version, remove default impl
+    public ItemStack setShieldColor(ItemStack item, DyeColor color) { // TODO: once 1.21 is the minimum supported version, remove from NMS
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+            ShieldMeta shieldMeta = (ShieldMeta) item.getItemMeta();
+            shieldMeta.setBaseColor(color);
+            item.setItemMeta(shieldMeta);
+            return item;
+        }
+        // TODO: once 1.20 is the minimum supported version, remove legacy code ↓
         if (color == null) {
             CompoundTag noStateNbt = getNbtData(item).createBuilder().remove("BlockEntityTag").build();
             return setNbtData(item, noStateNbt);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemRawNBT.java
@@ -354,7 +354,6 @@ public class ItemRawNBT extends ItemProperty<MapTag> {
         // Returns a map of all raw NBT on this item, including default values.
         // Refer to format details at <@link language Raw NBT Encoding>.
         // -->
-        // TODO: deprecate when raw properties property is added
         PropertyParser.registerTag(ItemRawNBT.class, MapTag.class, "all_raw_nbt", (attribute, prop) -> {
             return prop.getFullNBTMap();
         });

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/nbt/CustomNBT.java
@@ -38,6 +38,7 @@ public class CustomNBT {
      * custom NBT.
      */
 
+    // TODO: once 1.20 is the minimum supported version, remove this
     public static List<Material> getNBTMaterials(ItemStack itemStack, String key) {
         if (itemStack == null || itemStack.getType() == Material.AIR) {
             return null;
@@ -53,6 +54,7 @@ public class CustomNBT {
         return materials;
     }
 
+    // TODO: once 1.20 is the minimum supported version, remove this
     public static ItemStack setNBTMaterials(ItemStack itemStack, String key, List<Material> materials) {
         if (itemStack == null || itemStack.getType() == Material.AIR) {
             return null;
@@ -82,6 +84,7 @@ public class CustomNBT {
         return NMSHandler.itemHelper.setCustomData(itemStack, customData);
     }
 
+    // TODO: once 1.20 is the minimum supported version, remove this
     public static ItemStack clearNBT(ItemStack itemStack, String key) {
         if (itemStack == null || itemStack.getType() == Material.AIR) {
             return null;

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/ItemHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/ItemHelperImpl.java
@@ -3,7 +3,6 @@ package com.denizenscript.denizen.nms.v1_21.helpers;
 import com.denizenscript.denizen.nms.interfaces.ItemHelper;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
 import com.denizenscript.denizen.nms.util.jnbt.CompoundTag;
-import com.denizenscript.denizen.nms.util.jnbt.IntArrayTag;
 import com.denizenscript.denizen.nms.util.jnbt.Tag;
 import com.denizenscript.denizen.nms.v1_21.Handler;
 import com.denizenscript.denizen.nms.v1_21.ReflectionMappingsInfo;
@@ -27,7 +26,10 @@ import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JsonOps;
 import net.md_5.bungee.api.ChatColor;
 import net.minecraft.advancements.critereon.BlockPredicate;
-import net.minecraft.core.*;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
+import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
@@ -35,7 +37,6 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.NbtOps;
-import net.minecraft.nbt.NbtUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
@@ -50,12 +51,11 @@ import net.minecraft.world.item.alchemy.PotionBrewing;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.component.ItemLore;
 import net.minecraft.world.item.component.ResolvableProfile;
+import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.item.crafting.BlastingRecipe;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.ShapelessRecipe;
-import net.minecraft.world.item.crafting.SmithingTransformRecipe;
 import net.minecraft.world.item.crafting.SmokingRecipe;
-import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -68,7 +68,6 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.saveddata.maps.MapId;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
@@ -83,10 +82,10 @@ import org.bukkit.craftbukkit.v1_21_R4.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_21_R4.util.CraftNamespacedKey;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.*;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.SmithingTrimRecipe;
 import org.bukkit.inventory.TransmuteRecipe;
-import org.bukkit.inventory.*;
 import org.bukkit.map.MapView;
 
 import java.lang.reflect.Field;
@@ -769,23 +768,5 @@ public class ItemHelperImpl extends ItemHelper {
     @Override
     public int getFoodPoints(Material itemType) {
         return CraftMagicNumbers.getItem(itemType).components().get(DataComponents.FOOD).nutrition();
-    }
-
-    @Override
-    public DyeColor getShieldColor(ItemStack item) {
-        net.minecraft.world.item.DyeColor nmsColor = CraftItemStack.asNMSCopy(item).get(DataComponents.BASE_COLOR);
-        return nmsColor != null ? DyeColor.getByWoolData((byte) nmsColor.getId()) : null;
-    }
-
-    @Override
-    public ItemStack setShieldColor(ItemStack item, DyeColor color) {
-        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(item);
-        if (color != null) {
-            nmsItemStack.set(DataComponents.BASE_COLOR, net.minecraft.world.item.DyeColor.byId(color.getWoolData()));
-        }
-        else {
-            nmsItemStack.remove(DataComponents.BASE_COLOR);
-        }
-        return CraftItemStack.asBukkitCopy(nmsItemStack);
     }
 }


### PR DESCRIPTION
## Changes

- `ItemHelper#get/setShieldColor` now uses the `ShieldMeta` API on 1.21+, and has TODOs for future cleanups.
- Removed the 1.21 impl of `ItemHelper#get/setShieldColor` ^.
- Removed/Added some 1.21 TODO comments where needed.