### PR TITLE
Add `Utilities#elementToRequiredEnumLike`

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -615,6 +615,15 @@ public class Utilities {
         return (T) registry.get(parseNamespacedKey(updatedName));
     }
 
+    public static <T> T elementToRequiredEnumLike(ElementTag element, Class<T> type, Mechanism mechanism) {
+        T converted = elementToEnumlike(element, type);
+        if (converted == null) {
+            mechanism.echoError("Invalid " + DebugInternals.getClassNameOpti(type) + " specified.");
+            return null;
+        }
+        return converted;
+    }
+
     public static <T> T findBestEnumlike(Class<T> type, String... names) {
         for (String name : names) {
             T val = elementToEnumlike(new ElementTag(name), type, false);


### PR DESCRIPTION
To make stuff like https://github.com/DenizenScript/Denizen/blob/9313d899ebca8aad54445b75ddf677c430cbddc1/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVariant.java#L51-L86 a bit cleaner without having to add 2 method calls and do all the potential legacy names updating logic and whatnot twice.