### PR TITLE
Freeze Ticks Locked property

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -116,10 +116,12 @@ public class PaperModule {
         PropertyParser.registerProperty(EntityDrinkingPotion.class, EntityTag.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             PropertyParser.registerProperty(EntityEggLayTime.class, EntityTag.class);
-            PropertyParser.registerProperty(EntityFriction.class, EntityTag.class);
         }
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
             PropertyParser.registerProperty(EntityFreezeTickingLocked.class, EntityTag.class);
+        }
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+            PropertyParser.registerProperty(EntityFriction.class, EntityTag.class);
         }
         PropertyParser.registerProperty(EntityLeftHanded.class, EntityTag.class);
         PropertyParser.registerProperty(EntityReputation.class, EntityTag.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/PaperModule.java
@@ -118,6 +118,9 @@ public class PaperModule {
             PropertyParser.registerProperty(EntityEggLayTime.class, EntityTag.class);
             PropertyParser.registerProperty(EntityFriction.class, EntityTag.class);
         }
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_18)) {
+            PropertyParser.registerProperty(EntityFreezeTickingLocked.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityLeftHanded.class, EntityTag.class);
         PropertyParser.registerProperty(EntityReputation.class, EntityTag.class);
         PropertyParser.registerProperty(EntityShouldBurn.class, EntityTag.class);

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFreezeTickingLocked.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFreezeTickingLocked.java
@@ -13,8 +13,8 @@ public class EntityFreezeTickingLocked extends EntityProperty<ElementTag> {
     // @input ElementTag(Boolean)
     // @plugin Paper
     // @description
-    // Controls whether an entity’s freeze ticks are locked to a fixed value, preventing vanilla freeze tick updates.
-    // NOTE: Clients may still show frost effects when in powder snow.
+    // Controls whether an entity’s freeze duration is locked to a fixed value, preventing changes from vanilla freezing mechanics.
+    // Note: This only affects the server; clients may still display frost visuals when in powder snow.
     // -->
 
     public static boolean describes(EntityTag entity) {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFreezeTickingLocked.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFreezeTickingLocked.java
@@ -17,7 +17,9 @@ public class EntityFreezeTickingLocked extends EntityProperty<ElementTag> {
     // NOTE: Clients may still show frost effects when in powder snow.
     // -->
 
-    public static boolean describes(EntityTag entity) { return true; }
+    public static boolean describes(EntityTag entity) {
+        return true;
+    }
 
     @Override
     public ElementTag getPropertyValue() {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFreezeTickingLocked.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntityFreezeTickingLocked.java
@@ -1,0 +1,42 @@
+package com.denizenscript.denizen.paper.properties;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.properties.entity.EntityProperty;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+
+public class EntityFreezeTickingLocked extends EntityProperty<ElementTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name freeze_locked
+    // @input ElementTag(Boolean)
+    // @plugin Paper
+    // @description
+    // Controls whether an entity’s freeze ticks are locked to a fixed value, preventing vanilla freeze tick updates.
+    // NOTE: Clients may still show frost effects when in powder snow.
+    // -->
+
+    public static boolean describes(EntityTag entity) { return true; }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(getEntity().isFreezeTickingLocked());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "freeze_locked";
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag param, Mechanism mechanism) {
+        if (mechanism.requireBoolean()) {
+            getEntity().lockFreezeTicks(param.asBoolean());
+        }
+    }
+
+    public static void register() {
+        autoRegister("freeze_locked", EntityFreezeTickingLocked.class, ElementTag.class, false);
+    }
+}


### PR DESCRIPTION
- Added paper-only `freeze_locked` property to control entity freeze duration changes