### PR TITLE
Fix server version check on Paper

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -175,12 +175,13 @@ public class Denizen extends JavaPlugin {
         }
         if (!NMSHandler.instance.isExactServerVersionMatch()) {
             String serverSoftware = supportsPaper ? "Paper" : "Spigot";
-            getLogger().warning("-------------------------------------");
             getLogger().warning("""
+                    \n-------------------------------------
                     This build of Denizen was built for a different <server> revision! This may potentially cause issues.
                     If you are experiencing trouble, update Denizen and <server> both to latest builds!
-                    If this message appears with both Denizen and <server> fully up-to-date, contact the Denizen team (via Discord) to request an update be built.""".replace("<server>", serverSoftware));
-            getLogger().warning("-------------------------------------");
+                    If this message appears with both Denizen and <server> fully up-to-date, contact the Denizen team (via Discord) to request an update be built.
+                    -------------------------------------""".replace("<server>", serverSoftware)
+            );
         }
         triggerRegistry = new TriggerRegistry();
         boolean citizensBork = false;

--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -173,7 +173,7 @@ public class Denizen extends JavaPlugin {
         catch (Throwable ex) {
             Debug.echoError(ex);
         }
-        if (!NMSHandler.instance.isCorrectMappingsCode()) {
+        if (!NMSHandler.instance.isExactServerVersionMatch()) {
             String serverSoftware = supportsPaper ? "Paper" : "Spigot";
             getLogger().warning("-------------------------------------");
             getLogger().warning("""

--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -177,7 +177,7 @@ public class Denizen extends JavaPlugin {
             String serverSoftware = supportsPaper ? "Paper" : "Spigot";
             getLogger().warning("""
                     \n-------------------------------------
-                    This build of Denizen was built for a different <server> revision! This may potentially cause issues.
+                    This build of Denizen was built for a different Minecraft version! This may potentially cause issues.
                     If you are experiencing trouble, update Denizen and <server> both to latest builds!
                     If this message appears with both Denizen and <server> fully up-to-date, contact the Denizen team (via Discord) to request an update be built.
                     -------------------------------------""".replace("<server>", serverSoftware)

--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -162,11 +162,24 @@ public class Denizen extends JavaPlugin {
             startedSuccessful = false;
             return;
         }
+        try {
+            if (Class.forName("com.destroystokyo.paper.PaperConfig") != null) {
+                supportsPaper = true;
+            }
+        }
+        catch (ClassNotFoundException ex) {
+            // Ignore.
+        }
+        catch (Throwable ex) {
+            Debug.echoError(ex);
+        }
         if (!NMSHandler.instance.isCorrectMappingsCode()) {
+            String serverSoftware = supportsPaper ? "Paper" : "Spigot";
             getLogger().warning("-------------------------------------");
-            getLogger().warning("This build of Denizen was built for a different Spigot revision! This may potentially cause issues."
-                    + " If you are experiencing trouble, update Denizen and Spigot both to latest builds!"
-                    + " If this message appears with both Denizen and Spigot fully up-to-date, contact the Denizen team (via GitHub, Spigot, or Discord) to request an update be built.");
+            getLogger().warning("""
+                    This build of Denizen was built for a different {} revision! This may potentially cause issues.
+                    If you are experiencing trouble, update Denizen and {} both to latest builds!
+                    If this message appears with both Denizen and {} fully up-to-date, contact the Denizen team (via Discord) to request an update be built.""".replace("{}", serverSoftware));
             getLogger().warning("-------------------------------------");
         }
         triggerRegistry = new TriggerRegistry();
@@ -204,17 +217,6 @@ public class Denizen extends JavaPlugin {
         }
         catch (Exception e) {
             Debug.echoError(e);
-        }
-        try {
-            if (Class.forName("com.destroystokyo.paper.PaperConfig") != null) {
-                supportsPaper = true;
-            }
-        }
-        catch (ClassNotFoundException ex) {
-            // Ignore.
-        }
-        catch (Throwable ex) {
-            Debug.echoError(ex);
         }
         // bstats.org
         try {

--- a/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/Denizen.java
@@ -177,9 +177,9 @@ public class Denizen extends JavaPlugin {
             String serverSoftware = supportsPaper ? "Paper" : "Spigot";
             getLogger().warning("-------------------------------------");
             getLogger().warning("""
-                    This build of Denizen was built for a different {} revision! This may potentially cause issues.
-                    If you are experiencing trouble, update Denizen and {} both to latest builds!
-                    If this message appears with both Denizen and {} fully up-to-date, contact the Denizen team (via Discord) to request an update be built.""".replace("{}", serverSoftware));
+                    This build of Denizen was built for a different <server> revision! This may potentially cause issues.
+                    If you are experiencing trouble, update Denizen and <server> both to latest builds!
+                    If this message appears with both Denizen and <server> fully up-to-date, contact the Denizen team (via Discord) to request an update be built.""".replace("<server>", serverSoftware));
             getLogger().warning("-------------------------------------");
         }
         triggerRegistry = new TriggerRegistry();

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/NMSHandler.java
@@ -93,7 +93,7 @@ public abstract class NMSHandler {
     public static WorldHelper worldHelper;
     public static EnchantmentHelper enchantmentHelper;
 
-    public boolean isCorrectMappingsCode() {
+    public boolean isExactServerVersionMatch() {
         return true;
     }
 

--- a/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
+++ b/v1_17/src/main/java/com/denizenscript/denizen/nms/v1_17/Handler.java
@@ -94,7 +94,7 @@ public class Handler extends NMSHandler {
     }
 
     @Override
-    public boolean isCorrectMappingsCode() {
+    public boolean isExactServerVersionMatch() {
         return ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion().equals("f0e3dfc7390de285a4693518dd5bd126");
     }
 

--- a/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
+++ b/v1_18/src/main/java/com/denizenscript/denizen/nms/v1_18/Handler.java
@@ -103,7 +103,7 @@ public class Handler extends NMSHandler {
     }
 
     @Override
-    public boolean isCorrectMappingsCode() {
+    public boolean isExactServerVersionMatch() {
         return ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion().equals("eaeedbff51b16ead3170906872fda334");
     }
 

--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/Handler.java
@@ -107,7 +107,7 @@ public class Handler extends NMSHandler {
     }
 
     @Override
-    public boolean isCorrectMappingsCode() {
+    public boolean isExactServerVersionMatch() {
         return ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion().equals("3009edc0fff87fa34680686663bd59df");
     }
 

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/Handler.java
@@ -145,7 +145,7 @@ public class Handler extends NMSHandler {
     }
 
     @Override
-    public boolean isCorrectMappingsCode() {
+    public boolean isExactServerVersionMatch() {
         return ((CraftMagicNumbers) CraftMagicNumbers.INSTANCE).getMappingsVersion().equals("ee13f98a43b9c5abffdcc0bb24154460");
     }
 

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
@@ -152,7 +152,7 @@ public class Handler extends NMSHandler {
     }
 
     @Override
-    public boolean isCorrectMappingsCode() {
+    public boolean isExactServerVersionMatch() {
         return Denizen.supportsPaper ? SharedConstants.getCurrentVersion().id().equals("1.21.6") : CraftMagicNumbers.INSTANCE.getMappingsVersion().equals("164f8e872cb3dff744982fca079642b2");
     }
 

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/Handler.java
@@ -39,6 +39,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.DynamicOps;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.minecraft.SharedConstants;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Rotations;
@@ -152,7 +153,7 @@ public class Handler extends NMSHandler {
 
     @Override
     public boolean isCorrectMappingsCode() {
-        return CraftMagicNumbers.INSTANCE.getMappingsVersion().equals("164f8e872cb3dff744982fca079642b2");
+        return Denizen.supportsPaper ? SharedConstants.getCurrentVersion().id().equals("1.21.6") : CraftMagicNumbers.INSTANCE.getMappingsVersion().equals("164f8e872cb3dff744982fca079642b2");
     }
 
     @Override


### PR DESCRIPTION
Fix for recent Paper change: [CraftMagicNumbers.java](https://github.com/PaperMC/Paper/blob/5edcf6ddf6a3c279fce5a4feca58e9679a140aec/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java#L268-L275)

## Changes

- Moves the `Denizen.supportsPaper` detection up, right after `NMSHandler#initialize`.
- Renamed `NMSHandler#isCorrectMappingsCode` to `isExactServerVersionMatch`.
- Slightly updated the error message for ^ failing, made it have the correct server software name, and changed it to a String block thing.
- `NMSHandler#isExactServerVersionMatch` now uses a check like `SharedConstants.getCurrentVersion().id().equals("1.21.6")` on Paper servers.

Message before:
![Screenshot 2025-06-23 220609](https://github.com/user-attachments/assets/00c7f2f9-aea0-4570-8dde-2323a1bff722)

Message after:
![Screenshot 2025-06-23 162752](https://github.com/user-attachments/assets/b2f1bc2c-fe03-4604-9803-eaa7c354b99b)