### PR TITLE
Fix `CommonListenerCookie` creation on Paper

### DIFF
--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/ReflectionMappingsInfo.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/ReflectionMappingsInfo.java
@@ -74,6 +74,7 @@ public class ReflectionMappingsInfo {
 
     // net.minecraft.server.network.ServerCommonPacketListenerImpl
     public static String ServerCommonPacketListenerImpl_connection = "e";
+    public static String ServerCommonPacketListenerImpl_createCookie_method = "a";
 
     // net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket
     public static String ClientboundPlayerAbilitiesPacket_walkingSpeed = "k";

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/AbstractListenerPlayInImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/AbstractListenerPlayInImpl.java
@@ -43,7 +43,7 @@ public class AbstractListenerPlayInImpl extends ServerGamePacketListenerImpl {
 
     public static final Field ServerGamePacketListenerImpl_chunkSender = ReflectionHelper.getFields(ServerGamePacketListenerImpl.class).get(ReflectionMappingsInfo.ServerGamePacketListenerImpl_chunkSender);
 
-    public static final MethodHandle SERVER_COMMON_PACKET_LISTENER_IMPL_CREATE_COOKIE = ReflectionHelper.getMethodHandle(ServerCommonPacketListenerImpl.class, "createCookie", ClientInformation.class);
+    public static final MethodHandle SERVER_COMMON_PACKET_LISTENER_IMPL_CREATE_COOKIE = ReflectionHelper.getMethodHandle(ServerCommonPacketListenerImpl.class, ReflectionMappingsInfo.ServerCommonPacketListenerImpl_createCookie_method, ClientInformation.class);
 
     public static CommonListenerCookie createCookie(ServerPlayer nmsPlayer) {
         try {

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/AbstractListenerPlayInImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/AbstractListenerPlayInImpl.java
@@ -22,8 +22,10 @@ import net.minecraft.network.protocol.cookie.ServerboundCookieResponsePacket;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.network.protocol.ping.ServerboundPingRequestPacket;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ClientInformation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.CommonListenerCookie;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
@@ -32,6 +34,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.net.SocketAddress;
 import java.util.Set;
@@ -40,11 +43,22 @@ public class AbstractListenerPlayInImpl extends ServerGamePacketListenerImpl {
 
     public static final Field ServerGamePacketListenerImpl_chunkSender = ReflectionHelper.getFields(ServerGamePacketListenerImpl.class).get(ReflectionMappingsInfo.ServerGamePacketListenerImpl_chunkSender);
 
+    public static final MethodHandle SERVER_COMMON_PACKET_LISTENER_IMPL_CREATE_COOKIE = ReflectionHelper.getMethodHandle(ServerCommonPacketListenerImpl.class, "createCookie", ClientInformation.class);
+
+    public static CommonListenerCookie createCookie(ServerPlayer nmsPlayer) {
+        try {
+            return (CommonListenerCookie) SERVER_COMMON_PACKET_LISTENER_IMPL_CREATE_COOKIE.invoke(nmsPlayer.connection, nmsPlayer.clientInformation());
+        }
+        catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public final ServerGamePacketListenerImpl oldListener;
     public final DenizenNetworkManagerImpl denizenNetworkManager;
 
-    public AbstractListenerPlayInImpl(DenizenNetworkManagerImpl networkManager, ServerPlayer entityPlayer, ServerGamePacketListenerImpl oldListener, CommonListenerCookie cookie) {
-        super(MinecraftServer.getServer(), networkManager, entityPlayer, cookie);
+    public AbstractListenerPlayInImpl(DenizenNetworkManagerImpl networkManager, ServerPlayer entityPlayer, ServerGamePacketListenerImpl oldListener) {
+        super(MinecraftServer.getServer(), networkManager, entityPlayer, createCookie(entityPlayer));
         this.oldListener = oldListener;
         this.denizenNetworkManager = networkManager;
         try {

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/DenizenPacketListenerImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/network/handlers/DenizenPacketListenerImpl.java
@@ -16,19 +16,16 @@ import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.ServerboundResourcePackPacket;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.network.CommonListenerCookie;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_21_R5.block.CraftBlock;
 import org.bukkit.event.block.SignChangeEvent;
 
 public class DenizenPacketListenerImpl extends AbstractListenerPlayInImpl {
 
-    public String brand = "unknown";
-
     public BlockPos fakeSignExpected;
 
     public DenizenPacketListenerImpl(DenizenNetworkManagerImpl networkManager, ServerPlayer entityPlayer) {
-        super(networkManager, entityPlayer, entityPlayer.connection, new CommonListenerCookie(entityPlayer.getGameProfile(), entityPlayer.connection.latency(), entityPlayer.clientInformation(), entityPlayer.connection.isTransferred()));
+        super(networkManager, entityPlayer, entityPlayer.connection);
     }
 
     @Override


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1389860226655715429).

Paper had a constructor change there, changed to use `ServerCommonPacketListenerImpl#createCookie` (exists on both Spigot and Paper, and handles the extra stuff for us on Paper).

Also moved the `CommonListenerCookie` stuff to `AbstractListenerPlayInImpl` instead of `DenizenPacketListenerImpl` as it makes more sense to have it in there imo, but lmk if I should revert that.

Also also removed the `brand` field from `DenizenPacketListenerImpl` as it seems to be unused now.