### PR TITLE
Fix `getBedSpawnLocation` null handling, cleanup

### DIFF
--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PlayerHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PlayerHelperImpl.java
@@ -63,6 +63,7 @@ import org.bukkit.craftbukkit.v1_21_R5.boss.CraftBossBar;
 import org.bukkit.craftbukkit.v1_21_R5.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_21_R5.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_21_R5.util.CraftLocation;
 import org.bukkit.craftbukkit.v1_21_R5.util.CraftMagicNumbers;
 import org.bukkit.craftbukkit.v1_21_R5.util.CraftNamespacedKey;
 import org.bukkit.entity.Entity;
@@ -398,15 +399,15 @@ public class PlayerHelperImpl extends PlayerHelper {
     @Override
     public Location getBedSpawnLocation(Player player) {
         ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
-        BlockPos spawnPosition = nmsPlayer.getRespawnConfig().pos();
-        if (spawnPosition == null) {
+        ServerPlayer.RespawnConfig nmsRespawnConfig = nmsPlayer.getRespawnConfig();
+        if (nmsRespawnConfig == null) {
             return null;
         }
-        Level nmsWorld = MinecraftServer.getServer().getLevel(nmsPlayer.getRespawnConfig().dimension());
+        Level nmsWorld = MinecraftServer.getServer().getLevel(nmsRespawnConfig.dimension() != null ? nmsRespawnConfig.dimension() : Level.OVERWORLD);
         if (nmsWorld == null) {
             return null;
         }
-        return new Location(nmsWorld.getWorld(), spawnPosition.getX(), spawnPosition.getY(), spawnPosition.getZ(), nmsPlayer.getRespawnConfig().angle(), 0);
+        return CraftLocation.toBukkit(nmsRespawnConfig.pos(), nmsWorld.getWorld(), nmsRespawnConfig.angle(), 0);
     }
 
     @Override


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1380561936638283888).

As far as I can see looking at internals, the main `RespawnConfig` is what needs null checking, and the position within it is guaranteed.
![image](https://github.com/user-attachments/assets/8df1c59c-24c9-442b-aaa0-c42eb01e9528)
It also now defaults the dimension to `OVERWORLD`, like NMS seems to do:
![image](https://github.com/user-attachments/assets/d9d680a5-9975-4914-b183-c4626755dc95)
And now uses `CraftLocation#toBukkit` to be a little cleaner.
