### PR TITLE
`ProfileEditorImpl`: support Paper skin editing

### DIFF
--- a/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
+++ b/v1_19/src/main/java/com/denizenscript/denizen/nms/v1_19/impl/ProfileEditorImpl.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.nms.v1_19.impl;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
@@ -84,7 +85,8 @@ public class ProfileEditorImpl extends ProfileEditor {
                         patchedProfile.getProperties().putAll(ownProfile.getProperties());
                     }
                     else {
-                        patchedProfile.getProperties().putAll(baseProfile.getProperties());
+                        // On Paper 1.19+, we use Paper's PlayerProfile API instead of this system
+                        patchedProfile.getProperties().putAll(Denizen.supportsPaper ? data.profile().getProperties() : baseProfile.getProperties());
                     }
                     String listRename = RenameCommand.getCustomNameFor(data.profileId(), manager.player.getBukkitEntity(), true);
                     Component displayName = listRename != null ? Handler.componentToNMS(FormattedTextHelper.parse(listRename, ChatColor.WHITE)) : data.displayName();

--- a/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/ProfileEditorImpl.java
+++ b/v1_20/src/main/java/com/denizenscript/denizen/nms/v1_20/impl/ProfileEditorImpl.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.nms.v1_20.impl;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
@@ -92,7 +93,8 @@ public class ProfileEditorImpl extends ProfileEditor {
                 modifiedProfile.getProperties().putAll(ownProfile.getProperties());
             }
             else {
-                modifiedProfile.getProperties().putAll(baseProfile.getProperties());
+                // On Paper 1.19+, we use Paper's PlayerProfile API instead of this system
+                modifiedProfile.getProperties().putAll(Denizen.supportsPaper ? entry.profile().getProperties() : baseProfile.getProperties());
             }
             String listRename = RenameCommand.getCustomNameFor(entry.profileId(), networkManager.player.getBukkitEntity(), true);
             Component displayName = listRename != null ? Handler.componentToNMS(FormattedTextHelper.parse(listRename, ChatColor.WHITE)) : entry.displayName();

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/ProfileEditorImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/ProfileEditorImpl.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.nms.v1_21.impl;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.abstracts.ProfileEditor;
 import com.denizenscript.denizen.nms.util.PlayerProfile;
@@ -92,7 +93,8 @@ public class ProfileEditorImpl extends ProfileEditor {
                 modifiedProfile.getProperties().putAll(ownProfile.getProperties());
             }
             else {
-                modifiedProfile.getProperties().putAll(baseProfile.getProperties());
+                // On Paper 1.19+, we use Paper's PlayerProfile API instead of this system
+                modifiedProfile.getProperties().putAll(Denizen.supportsPaper ? entry.profile().getProperties() : baseProfile.getProperties());
             }
             String listRename = RenameCommand.getCustomNameFor(entry.profileId(), networkManager.player.getBukkitEntity(), true);
             Component displayName = listRename != null ? Handler.componentToNMS(FormattedTextHelper.parse(listRename, ChatColor.WHITE)) : entry.displayName();


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1357508630982692987).

This code was written back when skin edits were still part of `ProfileEditor`, but now that we use Paper's API on modern versions it can just ignore the edited profile's properties and use the original ones (or the ones changed by Paper, in this case) when on Paper.