### PR TITLE
`ItemTag.can_place_on`/`can_destroy`: 1.21 fix

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCanDestroy.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCanDestroy.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.List;
 import java.util.stream.Collectors;
 
+// TODO: this should be deprecated in favor of a new property that properly represents the underlying data
 public class ItemCanDestroy implements Property {
 
     public static boolean describes(ObjectTag item) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCanPlaceOn.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemCanPlaceOn.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.List;
 import java.util.stream.Collectors;
 
+// TODO: this should be deprecated in favor of a new property that properly represents the underlying data
 public class ItemCanPlaceOn implements Property {
 
     public static boolean describes(ObjectTag item) {

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/ItemHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/ItemHelperImpl.java
@@ -26,10 +26,8 @@ import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JsonOps;
 import net.md_5.bungee.api.ChatColor;
 import net.minecraft.advancements.critereon.BlockPredicate;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.core.Holder;
-import net.minecraft.core.NonNullList;
+import net.minecraft.advancements.critereon.DataComponentMatchers;
+import net.minecraft.core.*;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
@@ -537,13 +535,10 @@ public class ItemHelperImpl extends ItemHelper {
             nmsItemStack.remove(nmsComponent);
             return CraftItemStack.asBukkitCopy(nmsItemStack);
         }
-        // TODO: 1.21.5: upstream code change
-        /*
         BlockPredicate nmsPredicate = new BlockPredicate(Optional.of(
                 HolderSet.direct(material -> BuiltInRegistries.BLOCK.get(CraftNamespacedKey.toMinecraft(material.getKey())).orElseThrow(), materials)
-        ), Optional.empty(), Optional.empty());
-        nmsItemStack.set(nmsComponent, new AdventureModePredicate(List.of(nmsPredicate), nmsAdventurePredicate == null || nmsAdventurePredicate.showInTooltip()));
-        */
+        ), Optional.empty(), Optional.empty(), DataComponentMatchers.ANY);
+        nmsItemStack.set(nmsComponent, new AdventureModePredicate(List.of(nmsPredicate)));
         return CraftItemStack.asBukkitCopy(nmsItemStack);
     }
 


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1370806341903319191).

Fixes `ItemHelperImpl(1.21)#setAdventureModePredicateMaterials`, and adds `TODO` comments to `ItemCanPlaceOn` and `ItemCanDestroy`.