### PR TITLE
Fix advancement background texture not shown

### DIFF
--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
@@ -147,9 +147,15 @@ public class AdvancementHelperImpl extends AdvancementHelper {
         AdvancementHolder parent = advancement.parent != null
                 ? getNMSAdvancementManager().advancements.get(CraftNamespacedKey.toMinecraft(advancement.parent))
                 : null;
+        ClientAsset clientAsset = Optional.ofNullable(advancement.background).map(Object::toString).map(ResourceLocation::parse)
+                .filter(rl -> rl.getPath().startsWith("textures/") && rl.getPath().endsWith(".png"))
+                .map(rl -> new ClientAsset(
+                        rl.withPath(p -> p.substring("textures/".length(), p.length() - ".png".length())),
+                        rl))
+                .orElse(null); // converts the background into a ClientAsset if it's a valid png texture path under "textures/", otherwise returns null
         DisplayInfo display = new DisplayInfo(CraftItemStack.asNMSCopy(advancement.icon),
                 Handler.componentToNMS(FormattedTextHelper.parse(advancement.title, ChatColor.WHITE)), Handler.componentToNMS(FormattedTextHelper.parse(advancement.description, ChatColor.WHITE)),
-                Optional.ofNullable(advancement.background).map(CraftNamespacedKey::toMinecraft).map(ClientAsset::new), AdvancementType.valueOf(advancement.frame.name()),
+                Optional.ofNullable(clientAsset), AdvancementType.valueOf(advancement.frame.name()),
                 advancement.toast, advancement.announceToChat, advancement.hidden);
         display.setLocation(advancement.xOffset, advancement.yOffset);
         Map<String, Criterion<?>> criteria = IMPOSSIBLE_CRITERIA;


### PR DESCRIPTION
Discord Thread link for bug: https://discord.com/channels/315163488085475337/1390747413144273007

Fixed `ClientAsset` path parsing for advancement background by building it with:
- the file id (Path to image file without `textures` + `.png`)
- the complete file path (Full file path to image which ends in `.png`)

If an invalid path is given then it will show the purple missing texture. 
If no background was set in the root advancement, then it will return to the default background.

This is my first PR here so please tell me if anything needs to be changed. Thanks!