### PR TITLE
Optimize player cache creation

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/abstracts/ImprovedOfflinePlayer.java
@@ -108,6 +108,15 @@ public abstract class ImprovedOfflinePlayer {
         this.exists = loadPlayerData(playeruuid);
     }
 
+    public CompoundTag getBukkitData() {
+        return this.compound.getCompound("bukkit");
+    }
+
+    public String getName() {
+        CompoundTag bukkitData = getBukkitData();
+        return bukkitData != null ? bukkitData.getString("lastKnownName", null) : null;
+    }
+
     public abstract PlayerInventory getInventory();
 
     public abstract void setInventory(PlayerInventory inventory);

--- a/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/util/jnbt/CompoundTag.java
@@ -436,6 +436,10 @@ public abstract class CompoundTag extends Tag {
         }
     }
 
+    public String getString(String key, String defaultValue) {
+        return value.get(key) instanceof StringTag stringTag ? stringTag.getValue() : defaultValue;
+    }
+
     /**
      * Get a string named with the given key.
      * <p/>
@@ -446,13 +450,7 @@ public abstract class CompoundTag extends Tag {
      * @return a string
      */
     public String getString(String key) {
-        Tag tag = value.get(key);
-        if (tag instanceof StringTag) {
-            return ((StringTag) tag).getValue();
-        }
-        else {
-            return "";
-        }
+        return getString(key, "");
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -105,11 +105,9 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
      */
     public static void notePlayer(OfflinePlayer player) {
         UUID uuid = player.getUniqueId();
-        notePlayer(NMSHandler.playerHelper.getOfflineData(uuid).getName(), uuid);
-    }
-
-    public static void notePlayer(Player player) {
-        notePlayer(player.getName(), player.getUniqueId());
+        Player onlinePlayer = player.getPlayer();
+        String name = onlinePlayer != null ? onlinePlayer.getName() : NMSHandler.playerHelper.getOfflineData(uuid).getName();
+        notePlayer(name, uuid);
     }
 
     public static void notePlayer(String name, UUID uuid) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -106,8 +106,7 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
     public static void notePlayer(OfflinePlayer player) {
         UUID uuid = player.getUniqueId();
         Player onlinePlayer = player.getPlayer();
-        String name = onlinePlayer != null ? onlinePlayer.getName() : NMSHandler.playerHelper.getOfflineData(uuid).getName();
-        notePlayer(name, uuid);
+        notePlayer(onlinePlayer != null ? onlinePlayer.getName() : NMSHandler.playerHelper.getOfflineData(uuid).getName(), uuid);
     }
 
     public static void notePlayer(String name, UUID uuid) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/PlayerTag.java
@@ -104,13 +104,20 @@ public class PlayerTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
      * Notes that the player exists, for easy PlayerTag valueOf handling.
      */
     public static void notePlayer(OfflinePlayer player) {
-        if (player.getName() == null) {
-            Debug.echoError("Null named player " + player + " - may be file corruption, or player data imported from non-bukkit server?");
+        UUID uuid = player.getUniqueId();
+        notePlayer(NMSHandler.playerHelper.getOfflineData(uuid).getName(), uuid);
+    }
+
+    public static void notePlayer(Player player) {
+        notePlayer(player.getName(), player.getUniqueId());
+    }
+
+    public static void notePlayer(String name, UUID uuid) {
+        if (name == null) {
+            Debug.echoError("Null named player " + uuid + " - may be file corruption, or player data imported from non-bukkit server?");
             return;
         }
-        if (!playerNames.containsKey(CoreUtilities.toLowerCase(player.getName()))) {
-            playerNames.put(CoreUtilities.toLowerCase(player.getName()), player.getUniqueId());
-        }
+        playerNames.putIfAbsent(CoreUtilities.toLowerCase(name), uuid);
     }
 
     public static boolean isNoted(OfflinePlayer player) {


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1374088066670530591).

When getting names for offline players, `OfflinePlayer#getName` loads the player's data file and gets `bukkit.lastKnownName` from it.
Usually this is fast enough to not be a problem, but when there's a change to player data formats and it needs to run the DFU on every player (+ a server with a bunch of player files), this becomes an issue.
![image](https://github.com/user-attachments/assets/1231856f-7b29-45c0-add1-3a28b5548cb8)


This in theory fixes it by reading the data with our `ImprovedOfflinePlayer`, which doesn't run the DFU (which is technically a problem, but that's a matter for a different PR), as for just getting the `lastKnownName` string it shouldn't be needed.

## Additions

- `ImprovedOfflinePlayer#getBukkitData()` - gets the `bukkit` section of a player's data.
- `ImprovedOfflinePlayer#getName()` - gets `bukkit.lastKnownName` if present, or null otherwise.
- `CompoundTag#getString(key, defaultValue)` - gets the string under the key, or `defaultValue` otherwise.
- `PlayerTag#notePlayer(Player)` - for noting a player that's already online (e.g. in a join event).
- `PlayerTag#notePlayer(String, UUID)` - notes a name -> uuid pair, used by the other `notePlayer` variants.

## Changes

- `CompoundTag#getString(key)` now uses `#getString(key, defaultValue)` with a default value of `""`.
- `PlayerTag#notePlayer(OfflinePlayer)` is now just for offline players, and reads the name using the new `ImprovedOfflinePlayer#getName`.
- `PlayerTag#notePlayer(String, UUID)` now uses `Map#putIfAbsent` instead of `#containsKey` -> `#put`.