### PR TITLE
fix: PlayerTag.name mech breaks gamemode switching

### DIFF
--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PlayerHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PlayerHelperImpl.java
@@ -41,13 +41,16 @@ import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.server.players.ServerOpList;
 import net.minecraft.server.players.ServerOpListEntry;
 import net.minecraft.stats.ServerRecipeBook;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagNetworkSerialization;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Leashable;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.item.ItemCooldowns;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeManager;
@@ -455,18 +458,18 @@ public class PlayerHelperImpl extends PlayerHelper {
     @Override
     public void refreshPlayer(Player player) {
         ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
-        ServerLevel nmsWorld = (ServerLevel) nmsPlayer.level();
+        ServerLevel nmsWorld = nmsPlayer.level();
         nmsPlayer.connection.send(new ClientboundRespawnPacket(nmsPlayer.createCommonSpawnInfo(nmsWorld), ClientboundRespawnPacket.KEEP_ALL_DATA));
-        nmsPlayer.connection.teleport(player.getLocation());
+        nmsPlayer.connection.internalTeleport(PositionMoveRotation.of(nmsPlayer), Set.of());
         if (nmsPlayer.isPassenger()) {
            nmsPlayer.connection.send(new ClientboundSetPassengersPacket(nmsPlayer.getVehicle()));
         }
         if (nmsPlayer.isVehicle()) {
             nmsPlayer.connection.send(new ClientboundSetPassengersPacket(nmsPlayer));
         }
-        AABB boundingBox = new AABB(nmsPlayer.position(), nmsPlayer.position()).inflate(10);
-        for (Mob nmsMob : nmsWorld.getEntitiesOfClass(Mob.class, boundingBox, nmsMob -> nmsPlayer.equals(nmsMob.getLeashHolder()))) {
-            nmsPlayer.connection.send(new ClientboundSetEntityLinkPacket(nmsMob, nmsPlayer));
+        AABB boundingBox = AABB.ofSize(nmsPlayer.getBoundingBox().getCenter(), 32, 32, 32);
+        for (net.minecraft.world.entity.Entity nmsEntity : nmsWorld.getEntitiesOfClass(net.minecraft.world.entity.Entity.class, boundingBox, nmsEntity -> nmsEntity instanceof Leashable nmsLeashable && nmsPlayer.equals(nmsLeashable.getLeashHolder()))) {
+            nmsPlayer.connection.send(new ClientboundSetEntityLinkPacket(nmsEntity, nmsPlayer));
         }
         if (!nmsPlayer.getCooldowns().cooldowns.isEmpty()) {
             int tickCount = nmsPlayer.getCooldowns().tickCount;
@@ -474,9 +477,14 @@ public class PlayerHelperImpl extends PlayerHelper {
                 nmsPlayer.connection.send(new ClientboundCooldownPacket(entry.getKey(), entry.getValue().endTime - tickCount));
             }
         }
+        nmsPlayer.connection.send(new ClientboundSetExperiencePacket(nmsPlayer.experienceProgress, nmsPlayer.totalExperience, nmsPlayer.experienceLevel));
+        for (MobEffectInstance nmsEffect : nmsPlayer.getActiveEffects()) {
+            nmsPlayer.connection.send(new ClientboundUpdateMobEffectPacket(nmsPlayer.getId(), nmsEffect, false));
+        }
         nmsPlayer.onUpdateAbilities();
-        nmsPlayer.server.getPlayerList().sendPlayerPermissionLevel(nmsPlayer);
-        nmsPlayer.server.getPlayerList().sendLevelInfo(nmsPlayer, nmsWorld);
-        nmsPlayer.server.getPlayerList().sendAllPlayerInfo(nmsPlayer);
+        PlayerList nmsPlayerList = nmsPlayer.getServer().getPlayerList();
+        nmsPlayerList.sendPlayerPermissionLevel(nmsPlayer);
+        nmsPlayerList.sendLevelInfo(nmsPlayer, nmsWorld);
+        nmsPlayerList.sendAllPlayerInfo(nmsPlayer);
     }
 }

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/ProfileEditorImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/ProfileEditorImpl.java
@@ -53,6 +53,7 @@ public class ProfileEditorImpl extends ProfileEditor {
         if (isSkinChanging) {
             ((CraftServer) Bukkit.getServer()).getHandle().respawn(nmsPlayer, true, Entity.RemovalReason.CHANGED_DIMENSION, PlayerRespawnEvent.RespawnReason.PLUGIN);
         }
+        NMSHandler.playerHelper.refreshPlayer(player);
         player.updateInventory();
     }
 

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/ProfileEditorImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/impl/ProfileEditorImpl.java
@@ -53,7 +53,9 @@ public class ProfileEditorImpl extends ProfileEditor {
         if (isSkinChanging) {
             ((CraftServer) Bukkit.getServer()).getHandle().respawn(nmsPlayer, true, Entity.RemovalReason.CHANGED_DIMENSION, PlayerRespawnEvent.RespawnReason.PLUGIN);
         }
-        NMSHandler.playerHelper.refreshPlayer(player);
+        else {
+            NMSHandler.playerHelper.refreshPlayer(player);
+        }
         player.updateInventory();
     }
 


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1274312909794705481).

For some reason changing the game profile name blocked the client from properly changing gamemodes, which refreshing the player seems to fix (maybe because the respawn packet also contains gamemode information?).

Also updated `PlayerHelperImpl(1.21)#refreshPlayer` while I was at it:

- Now uses `#internalTeleport` instead of `#teleport`, for a more direct "just send the location".
- The re-sending leash links logic now accounts for the larger leash length & being able to leash non-living entities.
- Now re-sends current XP and potion effects as well.
- Accounted for `ServerPlayer.server` being `private` on Paper.