### PR TITLE
fix: `PlayerTag.vision` creating packet entities

### DIFF
--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PacketHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/PacketHelperImpl.java
@@ -141,6 +141,7 @@ public class PacketHelperImpl implements PacketHelper {
         send(player, new ClientboundAddEntityPacket(entity, 0, BlockPos.ZERO));
         send(player, new ClientboundSetCameraPacket(entity));
         NMSHandler.playerHelper.refreshPlayer(player);
+        send(player, new ClientboundRemoveEntitiesPacket(entity.getId()));
     }
 
     @Override


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1318926597277093939).

Uh, not much to say - not sure if this was always an issue or something that changed recently, but the shader update prevention and all seems to still work with removing the entity after.