### PR TITLE
Fix `toast` command not showing toasts

### DIFF
--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
@@ -113,7 +113,7 @@ public class AdvancementHelperImpl extends AdvancementHelper {
             AdvancementProgress progress = new AdvancementProgress();
             progress.update(new AdvancementRequirements(IMPOSSIBLE_REQUIREMENTS));
             progress.grantProgress(IMPOSSIBLE_KEY); // complete impossible criteria
-            PacketHelperImpl.send(player, new ClientboundUpdateAdvancementsPacket(false, List.of(nmsAdvancement), Set.of(), Map.of(nmsAdvancement.id(), progress), false));
+            PacketHelperImpl.send(player, new ClientboundUpdateAdvancementsPacket(false, List.of(nmsAdvancement), Set.of(), Map.of(nmsAdvancement.id(), progress), true));
         }
         else {
             AdvancementHolder nmsAdvancement = getNMSAdvancementManager().advancements.get(CraftNamespacedKey.toMinecraft(advancement.key));


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1383873363608342568).

# The Problem
The `toast` command did now show toasts when used, with no visible errors.

# The Cause
The `showToasts` boolean was set to `false` on the `ClientboundUpdateAdvancementsPacket` packet sent in `AdvancementHelper#grant`

# The Fix
I had changed the boolean value passed to the `showToasts` parameter `ClientboundUpdateAdvancementsPacket` to represent a positive value (or "`true`") as opposed to a negative value (or "`false`").
This change has made the packet handling occurring in the client's network handling code (specifically `ClientAdvancementManager#onAdvancements`, using Yarn mappings from the FabricMC organization), result in displaying a toast when handling said advancement, due to the result of `#shouldShowToast` (Yarn mappings, by the FabricMC organization) representing a positive value (or "`true`").