### PR TITLE
Fix getting/setting block entity nbt on Paper

### DIFF
--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/BlockHelperImpl.java
@@ -102,11 +102,16 @@ public class BlockHelperImpl implements BlockHelper {
         skull.update();
     }
 
+    public BlockEntity getBlockEntity(Block block) {
+        CraftBlock craftBlock = ((CraftBlock) block);
+        return craftBlock.getHandle().getBlockEntity(craftBlock.getPosition());
+    }
+
     @Override
     public CompoundTag getNbtData(Block block) {
-        BlockEntity te = ((CraftWorld) block.getWorld()).getHandle().getBlockEntity(new BlockPos(block.getX(), block.getY(), block.getZ()), true);
-        if (te != null) {
-            net.minecraft.nbt.CompoundTag compound = te.saveWithFullMetadata(CraftRegistry.getMinecraftRegistry());
+        BlockEntity nmsBlockEntity = getBlockEntity(block);
+        if (nmsBlockEntity != null) {
+            net.minecraft.nbt.CompoundTag compound = nmsBlockEntity.saveWithFullMetadata(CraftRegistry.getMinecraftRegistry());
             return CompoundTagImpl.fromNMSTag(compound);
         }
         return null;
@@ -119,9 +124,7 @@ public class BlockHelperImpl implements BlockHelper {
         builder.putInt("y", block.getY());
         builder.putInt("z", block.getZ());
         ctag = builder.build();
-        BlockPos blockPos = new BlockPos(block.getX(), block.getY(), block.getZ());
-        BlockEntity te = ((CraftWorld) block.getWorld()).getHandle().getBlockEntity(blockPos, true);
-        Handler.useValueInput(((CompoundTagImpl) ctag).toNMSTag(), te::loadWithComponents);
+        Handler.useValueInput(((CompoundTagImpl) ctag).toNMSTag(), getBlockEntity(block)::loadWithComponents);
     }
 
     @Override


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1390446917787586755).

Paper doesn't have the `getBlockEntity(BlockPos, boolean)` method anymore, but it looks like that boolean param was unused anyway (and on Spigot the method without it is an overload that passes in `true` like we did anyway), so I switched it to just `getBlockEntity(BlockPos)`
I also made a util `BlockHelperImpl(1.21)#getBlockEntity(Block)` method, which gets it by casting the `Block` to `CraftBlock` and getting the `BlockPos` and nms world from there, instead of constructing a new one (probably not a massive difference, but might do something for massive schematics).