### PR TITLE
Fix 'advancement revoke' with progress_length & Added support for progress_length in 'advancement revoke' command

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/AdvancementHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/nms/interfaces/AdvancementHelper.java
@@ -21,6 +21,10 @@ public abstract class AdvancementHelper {
 
     public abstract void grant(Advancement advancement, Player player);
 
+    public void revokePartial(Advancement advancement, Player player, int len) {
+        throw new UnsupportedOperationException();
+    }
+
     public abstract void revoke(Advancement advancement, Player player);
 
     public abstract void update(Player player);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/AdvancementCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/AdvancementCommand.java
@@ -269,7 +269,12 @@ public class AdvancementCommand extends AbstractCommand {
             for (PlayerTag target : revoke.filter(PlayerTag.class, scriptEntry)) {
                 Player player = target.getPlayerEntity();
                 if (player != null) {
-                    NMSHandler.advancementHelper.revoke(advancement, player);
+                    if (progressLength == null) {
+                        NMSHandler.advancementHelper.revoke(advancement, player);
+                    }
+                    else {
+                        NMSHandler.advancementHelper.revokePartial(advancement, player, progressLength.asInt());
+                    }
                 }
             }
         }

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
@@ -128,7 +128,10 @@ public class AdvancementHelperImpl extends AdvancementHelper {
         }
         else {
             AdvancementHolder nmsAdvancement = getNMSAdvancementManager().advancements.get(CraftNamespacedKey.toMinecraft(advancement.key));
-            ((CraftPlayer) player).getHandle().getAdvancements().revoke(nmsAdvancement, IMPOSSIBLE_KEY);
+            PlayerAdvancements advancements = ((CraftPlayer) player).getHandle().getAdvancements();
+            for (String criterion : nmsAdvancement.value().criteria().keySet()) {
+                advancements.revoke(nmsAdvancement, criterion);
+            }
         }
     }
 

--- a/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
+++ b/v1_21/src/main/java/com/denizenscript/denizen/nms/v1_21/helpers/AdvancementHelperImpl.java
@@ -122,6 +122,30 @@ public class AdvancementHelperImpl extends AdvancementHelper {
     }
 
     @Override
+    public void revokePartial(com.denizenscript.denizen.nms.util.Advancement advancement, Player player, int len) {
+        if (advancement.length <= 1) {
+            revoke(advancement, player);
+            return;
+        }
+        if (advancement.temporary) {
+            AdvancementHolder nmsAdvancement = asNMSCopy(advancement);
+            AdvancementProgress progress = new AdvancementProgress();
+            progress.update(new AdvancementRequirements(IMPOSSIBLE_REQUIREMENTS));
+            for (int i = 0; i < len; i++) {
+                progress.grantProgress(IMPOSSIBLE_KEY + i); // complete impossible criteria
+            }
+            PacketHelperImpl.send(player, new ClientboundUpdateAdvancementsPacket(false, List.of(nmsAdvancement), Set.of(), Map.of(nmsAdvancement.id(), progress), false));
+        }
+        else {
+            AdvancementHolder nmsAdvancement = getNMSAdvancementManager().advancements.get(CraftNamespacedKey.toMinecraft(advancement.key));
+            PlayerAdvancements advancements = ((CraftPlayer) player).getHandle().getAdvancements();
+            for (int i = len; i < advancement.length; i++) {
+                advancements.revoke(nmsAdvancement, IMPOSSIBLE_KEY + i);
+            }
+        }
+    }
+
+    @Override
     public void revoke(com.denizenscript.denizen.nms.util.Advancement advancement, Player player) {
         if (advancement.temporary) {
             PacketHelperImpl.send(player, new ClientboundUpdateAdvancementsPacket(false, List.of(), Set.of(CraftNamespacedKey.toMinecraft(advancement.key)), Map.of(), false));


### PR DESCRIPTION
Discord Thread links where the issue is mentioned, that `advancement revoke` won't work, when advancement has `progress_length` set:
- my thread: https://discord.com/channels/315163488085475337/1202754065566670848
- another thread: https://discord.com/channels/315163488085475337/1325038328176967690

Also added support for `progress_length` in the `advancement revoke` command. Previously, you had to revoke the entire advancement and re-grant it with a different `progress_length` value.
Now `advancement revoke` works similary to `advancement grant` with `progress_length`:
- For example, if an advancement with `progress_length:5` is fully granted to the player, running `advancement revoke progress_length:2` will reduce the progress to stage 2/5
- Repeating the same command will have no effect once the progress is already at or below the specified `progress_length`. Just like `advancement grant progress_length:1` doesn't increase the stage beyond 1/5 if run multiple times