### PR TITLE
`narrate` & `announce`: script formats support

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/NarrateCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/player/NarrateCommand.java
@@ -11,8 +11,10 @@ import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.core.ScriptTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.ScriptFormattingContext;
 import com.denizenscript.denizencore.scripts.ScriptRegistry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.containers.ScriptContainer;
 import com.denizenscript.denizencore.scripts.containers.core.FormatScriptContainer;
 import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
@@ -26,6 +28,8 @@ import java.util.List;
 import java.util.UUID;
 
 public class NarrateCommand extends AbstractCommand {
+
+    public static final String NARRATE_FORMAT_TYPE = ScriptFormattingContext.registerFormatType("narrate");
 
     public NarrateCommand() {
         setName("narrate");
@@ -46,7 +50,7 @@ public class NarrateCommand extends AbstractCommand {
     // @Description
     // Prints some text into the target's chat area. If no target is specified it will default to the attached player or the console.
     //
-    // Accepts the 'format:<script>' argument, which will reformat the text according to the specified format script. See <@link language Format Script Containers>.
+    // You can format the text with <@link language Format Script Containers> using the 'format' argument, or with the "narrate" format type (see <@link language Script Formats>).
     //
     // Optionally use 'per_player' with a list of player targets, to have the tags in the text input be reparsed for each and every player.
     // So, for example, "- narrate 'hello <player.name>' targets:<server.online_players>"
@@ -138,9 +142,16 @@ public class NarrateCommand extends AbstractCommand {
                 fromId = UUID.fromString(from.asString());
             }
         }
-        FormatScriptContainer format = formatObj == null ? null : (FormatScriptContainer) formatObj.getContainer();
+        ScriptFormattingContext formattingContext;
+        if (formatObj != null) {
+            formattingContext = ((FormatScriptContainer) formatObj.getContainer()).getAsFormattingContext();
+        }
+        else {
+            ScriptContainer scriptContainer = scriptEntry.getScriptContainer();
+            formattingContext = scriptContainer != null ? scriptContainer.getFormattingContext() : null;
+        }
         if (targets == null) {
-            Bukkit.getServer().getConsoleSender().spigot().sendMessage(FormattedTextHelper.parse(format != null ? format.getFormattedText(text, scriptEntry) : text, ChatColor.WHITE));
+            Bukkit.getServer().getConsoleSender().spigot().sendMessage(FormattedTextHelper.parse(formattingContext != null ? formattingContext.format(NARRATE_FORMAT_TYPE, text, scriptEntry) : text, ChatColor.WHITE));
             return;
         }
         for (PlayerTag player : targets) {
@@ -154,7 +165,7 @@ public class NarrateCommand extends AbstractCommand {
                     context.player = player;
                     personalText = TagManager.tag(personalText, context);
                 }
-                BaseComponent[] component = FormattedTextHelper.parse(format != null ? format.getFormattedText(personalText, scriptEntry) : personalText, ChatColor.WHITE);
+                BaseComponent[] component = FormattedTextHelper.parse(formattingContext != null ? formattingContext.format(NARRATE_FORMAT_TYPE, personalText, scriptEntry) : personalText, ChatColor.WHITE);
                 if (fromId == null) {
                     player.getPlayerEntity().spigot().sendMessage(component);
                 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/AnnounceCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/server/AnnounceCommand.java
@@ -7,8 +7,10 @@ import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.ScriptFormattingContext;
 import com.denizenscript.denizencore.scripts.ScriptRegistry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.containers.ScriptContainer;
 import com.denizenscript.denizencore.scripts.containers.core.FormatScriptContainer;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.api.ChatColor;
@@ -16,6 +18,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 public class AnnounceCommand extends AbstractCommand {
+
+    public static final String ANNOUNCE_FORMAT_TYPE = ScriptFormattingContext.registerFormatType("announce");
 
     public AnnounceCommand() {
         setName("announce");
@@ -40,7 +44,7 @@ public class AnnounceCommand extends AbstractCommand {
     // Or, using the 'to_flagged' argument will send the message to only players that have the specified flag.
     // You can also use the 'to_console' argument to make it so it only shows in the server console.
     //
-    // Announce can also utilize a format script with the 'format' argument. See <@link language Format Script Containers>.
+    // You can format the announcement with <@link language Format Script Containers> using the 'format' argument, or with the "announce" format type (see <@link language Script Formats>).
     //
     // Note that the default announce mode (that shows for all players) relies on the Spigot broadcast system, which requires the permission "bukkit.broadcast.user" to see broadcasts.
     //
@@ -122,7 +126,14 @@ public class AnnounceCommand extends AbstractCommand {
         if (scriptEntry.dbCallShouldDebug()) {
             Debug.report(scriptEntry, getName(), db("message", text), (format != null ? db("format", format.getName()) : ""), db("type", type.name()), flag);
         }
-        String message = format != null ? format.getFormattedText(text.asString(), scriptEntry) : text.asString();
+        String message;
+        if (format != null) {
+            message = format.getFormattedText(text.asString(), scriptEntry);
+        }
+        else {
+            ScriptContainer scriptContainer = scriptEntry.getScriptContainer();
+            message = scriptContainer != null && scriptContainer.getFormattingContext() != null ? scriptContainer.getFormattingContext().format(ANNOUNCE_FORMAT_TYPE, text.asString(), scriptEntry) : text.asString();
+        }
         // Use Bukkit to broadcast the message to everybody in the server.
         switch (type) {
             case ALL:


### PR DESCRIPTION
Adds support for the new script formats in `narrate` and `announce`.