### PR TITLE
Format scripts: fix `name` priority

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/implementation/DenizenCoreImplementation.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/implementation/DenizenCoreImplementation.java
@@ -410,11 +410,11 @@ public class DenizenCoreImplementation implements DenizenImplementation {
     public void addFormatScriptDefinitions(DefinitionProvider definitionProvider, TagContext context) {
         BukkitTagContext bukkitContext = (BukkitTagContext) context;
         String name = null;
-        if (bukkitContext.player != null) {
-            name = bukkitContext.player.getName();
-        }
-        else if (bukkitContext.npc != null) {
+        if (bukkitContext.npc != null) {
             name = bukkitContext.npc.getName();
+        }
+        else if (bukkitContext.player != null) {
+            name = bukkitContext.player.getName();
         }
         if (name != null) {
             definitionProvider.addDefinition("name", name);


### PR DESCRIPTION
Discord thread link where the issue was mentioned, that npc names will not get populated in format scripts with `<[name]>` tag with discussed solution: https://discord.com/channels/315163488085475337/1410716483335487530

Changes the priorities in the format script for `<[name]>` tag so npcs have more priority than players to populate it with their name.