### PR TITLE
Add support for entity WindCharge in `detonate` mechanism

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -4135,7 +4135,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @name detonate
         // @input None
         // @description
-        // If the entity is a firework, creeper, or wind charge, detonate it.
+        // If the entity is a firework, creeper, or wind charge, detonates it.
         // -->
         if (mechanism.matches("detonate")) {
             if (getBukkitEntity() instanceof Firework) {
@@ -4144,7 +4144,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             else if (getBukkitEntity() instanceof Creeper) {
                 ((Creeper) getBukkitEntity()).explode();
             }
-            else if (getBukkitEntity() instanceof WindCharge)
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && getBukkitEntity() instanceof WindCharge)
                 ((WindCharge) getBukkitEntity()).explode();
             else {
                 Debug.echoError("Cannot detonate entity of type '" + getBukkitEntityType().name() + "'.");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -4138,14 +4138,15 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // If the entity is a firework, creeper, or wind charge, detonates it.
         // -->
         if (mechanism.matches("detonate")) {
-            if (getBukkitEntity() instanceof Firework) {
-                ((Firework) getBukkitEntity()).detonate();
+            if (getBukkitEntity() instanceof Firework firework) {
+                firework.detonate();
             }
-            else if (getBukkitEntity() instanceof Creeper) {
-                ((Creeper) getBukkitEntity()).explode();
+            else if (getBukkitEntity() instanceof Creeper creeper) {
+               creeper.explode();
             }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && getBukkitEntity() instanceof WindCharge)
-                ((WindCharge) getBukkitEntity()).explode();
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && getBukkitEntity() instanceof WindCharge windCharge) {
+                windCharge.explode();
+            }
             else {
                 Debug.echoError("Cannot detonate entity of type '" + getBukkitEntityType().name() + "'.");
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -4135,7 +4135,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // @name detonate
         // @input None
         // @description
-        // If the entity is a firework or a creeper, detonates it.
+        // If the entity is a firework, creeper, or wind charge, detonate it.
         // -->
         if (mechanism.matches("detonate")) {
             if (getBukkitEntity() instanceof Firework) {
@@ -4144,6 +4144,8 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
             else if (getBukkitEntity() instanceof Creeper) {
                 ((Creeper) getBukkitEntity()).explode();
             }
+            else if (getBukkitEntity() instanceof WindCharge)
+                ((WindCharge) getBukkitEntity()).explode();
             else {
                 Debug.echoError("Cannot detonate entity of type '" + getBukkitEntityType().name() + "'.");
             }


### PR DESCRIPTION
Adds support for entity "Wind Charge" in `detonate` mechanism.
Discord thread link: https://discord.com/channels/315163488085475337/1413680425792180224

I updated the `@description` to include the Wind Charge. Will this automatically be updated on the meta website, or do I need to update something else as well? I wasn’t able to find any other references to `detonate` in this project that would suggest a connection to the meta website.

*Also I wanted to use pattern matching with a switch expression, but since the project was set to build with Java 16, IntelliJ told me no. I reverted to using another `else if` statement instead.*