### PR TITLE
10 block event modernizations

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
@@ -3,6 +3,7 @@ package com.denizenscript.denizen.events.block;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import org.bukkit.event.EventHandler;
@@ -31,13 +32,34 @@ public class BrewingStandFueledScriptEvent extends BukkitScriptEvent implements 
     //
     // @Determine
     // "FUEL_POWER:<ElementTag(Number)>" to set the fuel power level to be added.
-    // "CONSUMING" to indicate that the fuel item should be consumed.
-    // "NOT_CONSUMING" to indicate that the fuel item should not be consumed.
+    // "CONSUME:<ElementTag(Boolean)>" to indicate whether the fuel item should be consumed.
     //
     // -->
 
     public BrewingStandFueledScriptEvent() {
         registerCouldMatcher("brewing stand fueled (with <item>)");
+        this.<BrewingStandFueledScriptEvent, ElementTag>registerOptionalDetermination("fuel_power", ElementTag.class, (evt, context, power) -> {
+            if (power.isInt()) {
+                evt.event.setFuelPower(power.asInt());
+                return true;
+            }
+            return false;
+        });
+        this.<BrewingStandFueledScriptEvent, ElementTag>registerOptionalDetermination("consume", ElementTag.class, (evt, context, value) -> {
+            if (value.isBoolean()) {
+                evt.event.setConsuming(value.asBoolean());
+                return true;
+            }
+            return false;
+        });
+        this.<BrewingStandFueledScriptEvent>registerTextDetermination("consuming", (evt) -> {
+            BukkitImplDeprecations.brewingStandConsumeDetermination.warn();
+            evt.event.setConsuming(true);
+        });
+        this.<BrewingStandFueledScriptEvent>registerTextDetermination("not_consuming", (evt) -> {
+            BukkitImplDeprecations.brewingStandConsumeDetermination.warn();
+            evt.event.setConsuming(false);
+        });
     }
 
     public LocationTag location;
@@ -56,34 +78,14 @@ public class BrewingStandFueledScriptEvent extends BukkitScriptEvent implements 
     }
 
     @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag element) {
-            String val = element.asString();
-            if (val.startsWith("fuel_power:")) {
-                event.setFuelPower(Integer.parseInt(val.substring("fuel_power:".length())));
-                return true;
-            }
-            else if (val.equalsIgnoreCase("consuming")) {
-                event.setConsuming(true);
-                return true;
-            }
-            else if (val.equalsIgnoreCase("not_consuming")) {
-                event.setConsuming(false);
-                return true;
-            }
-        }
-        return super.applyDetermination(path, determinationObj);
-    }
-
-    @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "item": return item;
-            case "fuel_power": return new ElementTag(event.getFuelPower());
-            case "consuming": return new ElementTag(event.isConsuming());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "item" -> item;
+            case "fuel_power" -> new ElementTag(event.getFuelPower());
+            case "consuming" -> new ElementTag(event.isConsuming());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
@@ -32,7 +32,7 @@ public class BrewingStandFueledScriptEvent extends BukkitScriptEvent implements 
     //
     // @Determine
     // "FUEL_POWER:<ElementTag(Number)>" to set the fuel power level to be added.
-    // "CONSUME:<ElementTag(Boolean)>" to indicate whether the fuel item should be consumed.
+    // "CONSUMING:<ElementTag(Boolean)>" to indicate whether the fuel item should be consumed.
     //
     // -->
 
@@ -45,7 +45,7 @@ public class BrewingStandFueledScriptEvent extends BukkitScriptEvent implements 
             }
             return false;
         });
-        this.<BrewingStandFueledScriptEvent, ElementTag>registerOptionalDetermination("consume", ElementTag.class, (evt, context, value) -> {
+        this.<BrewingStandFueledScriptEvent, ElementTag>registerOptionalDetermination("consuming", ElementTag.class, (evt, context, value) -> {
             if (value.isBoolean()) {
                 evt.event.setConsuming(value.asBoolean());
                 return true;

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
@@ -45,16 +45,14 @@ public class BrewingStandFueledScriptEvent extends BukkitScriptEvent implements 
             }
             return false;
         });
-        this.<BrewingStandFueledScriptEvent, ElementTag>registerOptionalDetermination("consuming", ElementTag.class, (evt, context, value) -> {
+        this.<BrewingStandFueledScriptEvent, ElementTag>registerDetermination("consuming", ElementTag.class, (evt, context, value) -> {
             if (value.isBoolean()) {
                 evt.event.setConsuming(value.asBoolean());
-                return true;
             }
-            return false;
-        });
-        this.<BrewingStandFueledScriptEvent>registerTextDetermination("consuming", (evt) -> {
-            BukkitImplDeprecations.brewingStandConsumeDetermination.warn();
-            evt.event.setConsuming(true);
+            else {
+                BukkitImplDeprecations.brewingStandConsumeDetermination.warn();
+                evt.event.setConsuming(true);
+            }
         });
         this.<BrewingStandFueledScriptEvent>registerTextDetermination("not_consuming", (evt) -> {
             BukkitImplDeprecations.brewingStandConsumeDetermination.warn();

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/BrewingStandFueledScriptEvent.java
@@ -45,14 +45,12 @@ public class BrewingStandFueledScriptEvent extends BukkitScriptEvent implements 
             }
             return false;
         });
-        this.<BrewingStandFueledScriptEvent, ElementTag>registerDetermination("consuming", ElementTag.class, (evt, context, value) -> {
+        this.<BrewingStandFueledScriptEvent, ElementTag>registerOptionalDetermination("consuming", ElementTag.class, (evt, context, value) -> {
             if (value.isBoolean()) {
                 evt.event.setConsuming(value.asBoolean());
+                return true;
             }
-            else {
-                BukkitImplDeprecations.brewingStandConsumeDetermination.warn();
-                evt.event.setConsuming(true);
-            }
+            return false;
         });
         this.<BrewingStandFueledScriptEvent>registerTextDetermination("not_consuming", (evt) -> {
             BukkitImplDeprecations.brewingStandConsumeDetermination.warn();

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.block.data.Levelled;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.CauldronLevelChangeEvent;
@@ -39,10 +40,20 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
     public CauldronLevelChangeScriptEvent() {
         registerCouldMatcher("cauldron level changes|raises|lowers");
         registerSwitches("cause");
+        this.<CauldronLevelChangeScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, level) -> {
+            if (level.isInt()) {
+                evt.newLevel = level.asInt();
+                ((Levelled) evt.event.getNewState().getBlockData()).setLevel(newLevel);
+                return true;
+            }
+            return false;
+        });
     }
 
     public LocationTag location;
     public CauldronLevelChangeEvent event;
+    public int oldLevel;
+    public int newLevel;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -54,12 +65,12 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
         }
         String changeType = path.eventArgLowerAt(2);
         if (changeType.equals("raises")) {
-            if (event.getNewLevel() <= event.getOldLevel()) {
+            if (newLevel <= oldLevel) {
                 return false;
             }
         }
         else if (changeType.equals("lowers")) {
-            if (event.getNewLevel() >= event.getOldLevel()) {
+            if (newLevel >= oldLevel) {
                 return false;
             }
         }
@@ -70,32 +81,22 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
     }
 
     @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag element && element.isInt()) {
-            event.setNewLevel(element.asInt());
-        }
-        return super.applyDetermination(path, determinationObj);
-    }
-
-    @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "cause": return new ElementTag(event.getReason());
-            case "old_level": return new ElementTag(event.getOldLevel());
-            case "new_level": return new ElementTag(event.getNewLevel());
-            case "entity":
-                if (event.getEntity() != null) {
-                    return new EntityTag(event.getEntity()).getDenizenObject();
-                }
-                break;
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "cause" -> new ElementTag(event.getReason());
+            case "old_level" -> new ElementTag(oldLevel);
+            case "new_level" -> new ElementTag(newLevel);
+            case "entity" -> event.getEntity() != null ? new EntityTag(event.getEntity()).getDenizenObject() : null;
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler
     public void onCauldronLevelChange(CauldronLevelChangeEvent event) {
         location = new LocationTag(event.getBlock().getLocation());
+        oldLevel = ((Levelled) event.getBlock().getBlockData()).getLevel();
+        newLevel = ((Levelled) event.getNewState().getBlockData()).getLevel();
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -55,13 +55,13 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
             if (level > 3) {
                 return false;
             }
-            if (cauldronType != Material.WATER_CAULDRON && cauldronType != Material.LAVA_CAULDRON) {
+            if (cauldronState.getType() != Material.WATER_CAULDRON && cauldronState.getType() != Material.LAVA_CAULDRON) {
                 cauldronState.setType(cauldronType);
             }
             if (cauldronState.getBlockData() instanceof Levelled levelled) {
                 levelled.setLevel(level);
                 cauldronState.setBlockData(levelled);
-                newLevel = level;
+                evt.newLevel = level;
                 return true;
             }
             return false;

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -63,18 +63,13 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
         if (!runGenericSwitchCheck(path, "cause", event.getReason().name())) {
             return false;
         }
-        String changeType = path.eventArgLowerAt(2);
-        if (changeType.equals("raises")) {
-            if (newLevel <= oldLevel) {
-                return false;
-            }
+        if (path.eventArgLowerAt(2).equals("raises") && newLevel <= oldLevel) {
+            return false;
         }
-        else if (changeType.equals("lowers")) {
-            if (newLevel >= oldLevel) {
-                return false;
-            }
+        if (path.eventArgLowerAt(2).equals("lowers") && newLevel >= oldLevel) {
+            return false;
         }
-        else if (!changeType.equals("changes")) {
+        if (!path.eventArgLowerAt(2).equals("changes")) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -47,9 +47,12 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
                 return false;
             }
             BlockState cauldronState = evt.event.getNewState();
-            if (level.asInt() == 0) {
+            if (level.asInt() <= 0) {
                 cauldronState.setType(Material.CAULDRON);
                 return true;
+            }
+            if (level.asInt() > 3) {
+                return false;
             }
             Material cauldronType = cauldronState.getType();
             if (cauldronType != Material.WATER_CAULDRON && cauldronType != Material.LAVA_CAULDRON) {

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -42,25 +42,26 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
     public CauldronLevelChangeScriptEvent() {
         registerCouldMatcher("cauldron level changes|raises|lowers");
         registerSwitches("cause");
-        this.<CauldronLevelChangeScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, level) -> {
-            if (!level.isInt()) {
+        this.<CauldronLevelChangeScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, value) -> {
+            if (!value.isInt()) {
                 return false;
             }
+            int level = value.asInt();
             BlockState cauldronState = evt.event.getNewState();
-            if (level.asInt() <= 0) {
+            if (level <= 0) {
                 cauldronState.setType(Material.CAULDRON);
                 return true;
             }
-            if (level.asInt() > 3) {
+            if (level > 3) {
                 return false;
             }
-            Material cauldronType = cauldronState.getType();
             if (cauldronType != Material.WATER_CAULDRON && cauldronType != Material.LAVA_CAULDRON) {
-                cauldronState.setType(event.getBlock().getType());
+                cauldronState.setType(cauldronType);
             }
             if (cauldronState.getBlockData() instanceof Levelled levelled) {
-                levelled.setLevel(level.asInt());
+                levelled.setLevel(level);
                 cauldronState.setBlockData(levelled);
+                newLevel = level;
                 return true;
             }
             return false;
@@ -69,6 +70,9 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
 
     public LocationTag location;
     public CauldronLevelChangeEvent event;
+    public Material cauldronType;
+    public int oldLevel;
+    public int newLevel;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -79,8 +83,6 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
             return false;
         }
         String changeType = path.eventArgLowerAt(2);
-        int oldLevel = event.getBlock().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0;
-        int newLevel = event.getNewState().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0;
         if (changeType.equals("raises")) {
             if (newLevel <= oldLevel) {
                 return false;
@@ -102,8 +104,8 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
         return switch (name) {
             case "location" -> location;
             case "cause" -> new ElementTag(event.getReason());
-            case "old_level" -> new ElementTag(event.getBlock().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0);
-            case "new_level" -> new ElementTag(event.getNewState().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0);
+            case "old_level" -> new ElementTag(oldLevel);
+            case "new_level" -> new ElementTag(newLevel);
             case "entity" -> event.getEntity() != null ? new EntityTag(event.getEntity()).getDenizenObject() : null;
             default -> super.getContext(name);
         };
@@ -112,6 +114,9 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
     @EventHandler
     public void onCauldronLevelChange(CauldronLevelChangeEvent event) {
         location = new LocationTag(event.getBlock().getLocation());
+        cauldronType = event.getBlock().getType();
+        oldLevel = event.getBlock().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0;
+        newLevel = event.getNewState().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0;
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -63,17 +63,18 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
         if (!runGenericSwitchCheck(path, "cause", event.getReason().name())) {
             return false;
         }
-        if (path.eventArgLowerAt(2).equals("raises")) {
+        String changeType = path.eventArgLowerAt(2);
+        if (changeType.equals("raises")) {
             if (newLevel <= oldLevel) {
                 return false;
             }
         }
-        else if (path.eventArgLowerAt(2).equals("lowers")) {
+        else if (changeType.equals("lowers")) {
             if (newLevel >= oldLevel) {
                 return false;
             }
         }
-        else if (!path.eventArgLowerAt(2).equals("changes")) {
+        else if (!changeType.equals("changes")) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -5,6 +5,8 @@ import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import org.bukkit.Material;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -41,9 +43,21 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
         registerCouldMatcher("cauldron level changes|raises|lowers");
         registerSwitches("cause");
         this.<CauldronLevelChangeScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, level) -> {
-            if (level.isInt()) {
-                evt.newLevel = level.asInt();
-                ((Levelled) evt.event.getNewState().getBlockData()).setLevel(newLevel);
+            if (!level.isInt()) {
+                return false;
+            }
+            BlockState cauldronState = evt.event.getNewState();
+            if (level.asInt() == 0) {
+                cauldronState.setType(Material.CAULDRON);
+                return true;
+            }
+            Material cauldronType = cauldronState.getType();
+            if (cauldronType != Material.WATER_CAULDRON && cauldronType != Material.LAVA_CAULDRON) {
+                cauldronState.setType(event.getBlock().getType());
+            }
+            if (cauldronState.getBlockData() instanceof Levelled levelled) {
+                levelled.setLevel(level.asInt());
+                cauldronState.setBlockData(levelled);
                 return true;
             }
             return false;
@@ -52,8 +66,6 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
 
     public LocationTag location;
     public CauldronLevelChangeEvent event;
-    public int oldLevel;
-    public int newLevel;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -64,6 +76,8 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
             return false;
         }
         String changeType = path.eventArgLowerAt(2);
+        int oldLevel = event.getBlock().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0;
+        int newLevel = event.getNewState().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0;
         if (changeType.equals("raises")) {
             if (newLevel <= oldLevel) {
                 return false;
@@ -85,8 +99,8 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
         return switch (name) {
             case "location" -> location;
             case "cause" -> new ElementTag(event.getReason());
-            case "old_level" -> new ElementTag(oldLevel);
-            case "new_level" -> new ElementTag(newLevel);
+            case "old_level" -> new ElementTag(event.getBlock().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0);
+            case "new_level" -> new ElementTag(event.getNewState().getBlockData() instanceof Levelled levelled ? levelled.getLevel() : 0);
             case "entity" -> event.getEntity() != null ? new EntityTag(event.getEntity()).getDenizenObject() : null;
             default -> super.getContext(name);
         };
@@ -95,8 +109,6 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
     @EventHandler
     public void onCauldronLevelChange(CauldronLevelChangeEvent event) {
         location = new LocationTag(event.getBlock().getLocation());
-        oldLevel = ((Levelled) event.getBlock().getBlockData()).getLevel();
-        newLevel = ((Levelled) event.getNewState().getBlockData()).getLevel();
         this.event = event;
         fire(event);
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/CauldronLevelChangeScriptEvent.java
@@ -63,13 +63,17 @@ public class CauldronLevelChangeScriptEvent extends BukkitScriptEvent implements
         if (!runGenericSwitchCheck(path, "cause", event.getReason().name())) {
             return false;
         }
-        if (path.eventArgLowerAt(2).equals("raises") && newLevel <= oldLevel) {
-            return false;
+        if (path.eventArgLowerAt(2).equals("raises")) {
+            if (newLevel <= oldLevel) {
+                return false;
+            }
         }
-        if (path.eventArgLowerAt(2).equals("lowers") && newLevel >= oldLevel) {
-            return false;
+        else if (path.eventArgLowerAt(2).equals("lowers")) {
+            if (newLevel >= oldLevel) {
+                return false;
+            }
         }
-        if (!path.eventArgLowerAt(2).equals("changes")) {
+        else if (!path.eventArgLowerAt(2).equals("changes")) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
@@ -5,7 +5,6 @@ import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.DurationTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.FurnaceBurnEvent;
@@ -35,6 +34,9 @@ public class FurnaceBurnsItemScriptEvent extends BukkitScriptEvent implements Li
 
     public FurnaceBurnsItemScriptEvent() {
         registerCouldMatcher("furnace burns <item>");
+        this.<FurnaceBurnsItemScriptEvent, DurationTag>registerDetermination(null, DurationTag.class, (evt, context, time) -> {
+            evt.event.setBurnTime(time.getTicksAsInt());
+        });
     }
 
     public ItemTag item;
@@ -53,25 +55,12 @@ public class FurnaceBurnsItemScriptEvent extends BukkitScriptEvent implements Li
     }
 
     @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag element && element.isInt()) {
-            event.setBurnTime(element.asInt());
-            return true;
-        }
-        else if (determinationObj.canBeType(DurationTag.class)) {
-            event.setBurnTime(determinationObj.asType(DurationTag.class, getTagContext(path)).getTicksAsInt());
-            return true;
-        }
-        return super.applyDetermination(path, determinationObj);
-    }
-
-    @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "item": return item;
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "item" -> item;
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
@@ -36,7 +36,7 @@ public class FurnaceBurnsItemScriptEvent extends BukkitScriptEvent implements Li
     public FurnaceBurnsItemScriptEvent() {
         registerCouldMatcher("furnace burns <item>");
         this.<FurnaceBurnsItemScriptEvent, ObjectTag>registerOptionalDetermination(null, ObjectTag.class, (evt, context, time) -> {
-            if (time instanceof ElementTag elementTag && time.asElement().isInt()) {
+            if (time instanceof ElementTag elementTag && elementTag.isInt()) {
                 evt.event.setBurnTime(elementTag.asInt());
                 return true;
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
@@ -36,7 +36,7 @@ public class FurnaceBurnsItemScriptEvent extends BukkitScriptEvent implements Li
     public FurnaceBurnsItemScriptEvent() {
         registerCouldMatcher("furnace burns <item>");
         this.<FurnaceBurnsItemScriptEvent, ObjectTag>registerOptionalDetermination(null, ObjectTag.class, (evt, context, time) -> {
-            if (time instanceof ElementTag elementTag && elementTag.isInt()) {
+            if (time instanceof ElementTag elementTag && elementTag.isInt()) { // Backwards compatibility for non-duration tick input
                 evt.event.setBurnTime(elementTag.asInt());
                 return true;
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceBurnsItemScriptEvent.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.FurnaceBurnEvent;
@@ -34,8 +35,16 @@ public class FurnaceBurnsItemScriptEvent extends BukkitScriptEvent implements Li
 
     public FurnaceBurnsItemScriptEvent() {
         registerCouldMatcher("furnace burns <item>");
-        this.<FurnaceBurnsItemScriptEvent, DurationTag>registerDetermination(null, DurationTag.class, (evt, context, time) -> {
-            evt.event.setBurnTime(time.getTicksAsInt());
+        this.<FurnaceBurnsItemScriptEvent, ObjectTag>registerOptionalDetermination(null, ObjectTag.class, (evt, context, time) -> {
+            if (time instanceof ElementTag elementTag && time.asElement().isInt()) {
+                evt.event.setBurnTime(elementTag.asInt());
+                return true;
+            }
+            else if (time.canBeType(DurationTag.class)) {
+                evt.event.setBurnTime(time.asType(DurationTag.class, context).getTicksAsInt());
+                return true;
+            }
+            return false;
         });
     }
 
@@ -64,7 +73,7 @@ public class FurnaceBurnsItemScriptEvent extends BukkitScriptEvent implements Li
     }
 
     @EventHandler
-    public void onBrews(FurnaceBurnEvent event) {
+    public void onFurnaceBurns(FurnaceBurnEvent event) {
         location = new LocationTag(event.getBlock().getLocation());
         item = new ItemTag(event.getFuel());
         this.event = event;

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceStartsSmeltingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/FurnaceStartsSmeltingScriptEvent.java
@@ -31,19 +31,13 @@ public class FurnaceStartsSmeltingScriptEvent extends BukkitScriptEvent implemen
     // @Determine
     // DurationTag to set the total cook time for the item being smelted.
     //
-    // @Example
-    // # Sets the total cook time of every item to always be 2 seconds.
-    // on furnace starts smelting item:
-    // - determine 2s
-    //
-    // @Example
-    // # Sets the total cook time of iron ore to be 2 seconds.
-    // on furnace starts smelting iron_ore:
-    // - determine 2s
     // -->
 
     public FurnaceStartsSmeltingScriptEvent() {
         registerCouldMatcher("furnace starts smelting <item>");
+        this.<FurnaceStartsSmeltingScriptEvent, DurationTag>registerDetermination(null, DurationTag.class, (evt, context, time) -> {
+            evt.event.setTotalCookTime(time.getTicksAsInt());
+        });
     }
 
     public ItemTag item;
@@ -62,23 +56,14 @@ public class FurnaceStartsSmeltingScriptEvent extends BukkitScriptEvent implemen
     }
 
     @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj.canBeType(DurationTag.class)) {
-            event.setTotalCookTime(determinationObj.asType(DurationTag.class, getTagContext(path)).getTicksAsInt());
-            return true;
-        }
-        return super.applyDetermination(path, determinationObj);
-    }
-
-    @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "item": return item;
-            case "recipe_id": return new ElementTag(event.getRecipe().getKey().toString());
-            case "total_cook_time": return new DurationTag((long) event.getTotalCookTime());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "item" -> item;
+            case "recipe_id" -> new ElementTag(event.getRecipe().getKey().toString(), true);
+            case "total_cook_time" -> new DurationTag((long) event.getTotalCookTime());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/LeafDecaysScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/LeafDecaysScriptEvent.java
@@ -52,11 +52,11 @@ public class LeafDecaysScriptEvent extends BukkitScriptEvent implements Listener
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "material": return material;
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "material" -> material;
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/LiquidLevelChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/LiquidLevelChangeScriptEvent.java
@@ -62,12 +62,12 @@ public class LiquidLevelChangeScriptEvent extends BukkitScriptEvent implements L
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "old_material": return old_material;
-            case "new_material": return new MaterialTag(event.getNewData());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "old_material" -> old_material;
+            case "new_material" -> new MaterialTag(event.getNewData());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/NoteBlockPlaysNoteScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/NoteBlockPlaysNoteScriptEvent.java
@@ -62,55 +62,39 @@ public class NoteBlockPlaysNoteScriptEvent extends BukkitScriptEvent implements 
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
             return event.getInstrument().getSound();
         }
-        switch (event.getInstrument()) {
-            case PIANO:
-                return Sound.BLOCK_NOTE_BLOCK_HARP;
-            case BASS_DRUM:
-                return Sound.BLOCK_NOTE_BLOCK_BASEDRUM;
-            case SNARE_DRUM:
-                return Sound.BLOCK_NOTE_BLOCK_SNARE;
-            case STICKS:
-                return Sound.BLOCK_NOTE_BLOCK_HAT;
-            case BASS_GUITAR:
-                return Sound.BLOCK_NOTE_BLOCK_BASS;
-            case FLUTE:
-                return Sound.BLOCK_NOTE_BLOCK_FLUTE;
-            case BELL:
-                return Sound.BLOCK_NOTE_BLOCK_BELL;
-            case GUITAR:
-                return Sound.BLOCK_NOTE_BLOCK_GUITAR;
-            case CHIME:
-                return Sound.BLOCK_NOTE_BLOCK_CHIME;
-            case XYLOPHONE:
-                return Sound.BLOCK_NOTE_BLOCK_XYLOPHONE;
-            case IRON_XYLOPHONE:
-                return Sound.BLOCK_NOTE_BLOCK_IRON_XYLOPHONE;
-            case COW_BELL:
-                return Sound.BLOCK_NOTE_BLOCK_COW_BELL;
-            case DIDGERIDOO:
-                return Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO;
-            case BIT:
-                return Sound.BLOCK_NOTE_BLOCK_BIT;
-            case BANJO:
-                return Sound.BLOCK_NOTE_BLOCK_BANJO;
-            case PLING:
-                return Sound.BLOCK_NOTE_BLOCK_PLING;
-        }
-        return null;
+        return switch (event.getInstrument()) {
+            case PIANO -> Sound.BLOCK_NOTE_BLOCK_HARP;
+            case BASS_DRUM -> Sound.BLOCK_NOTE_BLOCK_BASEDRUM;
+            case SNARE_DRUM -> Sound.BLOCK_NOTE_BLOCK_SNARE;
+            case STICKS -> Sound.BLOCK_NOTE_BLOCK_HAT;
+            case BASS_GUITAR -> Sound.BLOCK_NOTE_BLOCK_BASS;
+            case FLUTE -> Sound.BLOCK_NOTE_BLOCK_FLUTE;
+            case BELL -> Sound.BLOCK_NOTE_BLOCK_BELL;
+            case GUITAR -> Sound.BLOCK_NOTE_BLOCK_GUITAR;
+            case CHIME -> Sound.BLOCK_NOTE_BLOCK_CHIME;
+            case XYLOPHONE -> Sound.BLOCK_NOTE_BLOCK_XYLOPHONE;
+            case IRON_XYLOPHONE -> Sound.BLOCK_NOTE_BLOCK_IRON_XYLOPHONE;
+            case COW_BELL -> Sound.BLOCK_NOTE_BLOCK_COW_BELL;
+            case DIDGERIDOO -> Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO;
+            case BIT -> Sound.BLOCK_NOTE_BLOCK_BIT;
+            case BANJO -> Sound.BLOCK_NOTE_BLOCK_BANJO;
+            case PLING -> Sound.BLOCK_NOTE_BLOCK_PLING;
+            default -> null;
+        };
     }
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "instrument": return new ElementTag(event.getInstrument());
-            case "sound": return Utilities.enumLikeToLegacyElement(getSound());
-            case "tone": return new ElementTag(event.getNote().getTone());
-            case "octave": return new ElementTag(event.getNote().getOctave());
-            case "sharp": return new ElementTag(event.getNote().isSharped());
-            case "pitch": return new ElementTag(Math.pow(2.0, (double) (event.getNote().getId() - 12) / 12.0)); // based on minecraft source
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "instrument" -> new ElementTag(event.getInstrument());
+            case "sound" -> Utilities.enumLikeToLegacyElement(getSound());
+            case "tone" -> new ElementTag(event.getNote().getTone());
+            case "octave" -> new ElementTag(event.getNote().getOctave());
+            case "sharp" -> new ElementTag(event.getNote().isSharped());
+            case "pitch" -> new ElementTag(Math.pow(2.0, (double) (event.getNote().getId() - 12) / 12.0)); // based on minecraft source
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/PistonExtendsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/PistonExtendsScriptEvent.java
@@ -6,7 +6,6 @@ import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPistonExtendEvent;
@@ -59,22 +58,16 @@ public class PistonExtendsScriptEvent extends BukkitScriptEvent implements Liste
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "material": return material;
-            case "sticky": return new ElementTag(event.isSticky());
-            case "direction": return new LocationTag(event.getDirection().getDirection());
-            case "relative": return new LocationTag(event.getBlock().getRelative(event.getDirection()).getLocation()); // Silently deprecated
-            case "blocks": {
-                ListTag blocks = new ListTag();
-                for (Block block : event.getBlocks()) {
-                    blocks.addObject(new LocationTag(block.getLocation()));
-                }
-                return blocks;
-            }
-            case "length": return new ElementTag(event.getBlocks().size());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "material" -> material;
+            case "sticky" -> new ElementTag(event.isSticky());
+            case "direction" -> new LocationTag(event.getDirection().getDirection());
+            case "relative" -> new LocationTag(event.getBlock().getRelative(event.getDirection()).getLocation()); // Silently deprecated
+            case "blocks" -> new ListTag(event.getBlocks(), block -> new LocationTag(block.getLocation()));
+            case "length" -> new ElementTag(event.getBlocks().size());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/PistonRetractsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/PistonRetractsScriptEvent.java
@@ -6,7 +6,6 @@ import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPistonRetractEvent;
@@ -59,22 +58,16 @@ public class PistonRetractsScriptEvent extends BukkitScriptEvent implements List
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "material": return material;
-            case "sticky": return new ElementTag(event.isSticky());
-            case "direction": return new LocationTag(event.getDirection().getDirection());
-            case "relative": return new LocationTag(event.getBlock().getRelative(event.getDirection().getOppositeFace()).getLocation()); // Silently deprecated
-            case "blocks": {
-                ListTag blocks = new ListTag();
-                for (Block block : event.getBlocks()) {
-                    blocks.addObject(new LocationTag(block.getLocation()));
-                }
-                return blocks;
-            }
-            case "retract_location": return new LocationTag(event.getBlock().getRelative(event.getDirection().getOppositeFace(), 2).getLocation());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "material" -> material;
+            case "sticky" -> new ElementTag(event.isSticky());
+            case "direction" -> new LocationTag(event.getDirection().getDirection());
+            case "relative" -> new LocationTag(event.getBlock().getRelative(event.getDirection().getOppositeFace()).getLocation()); // Silently deprecated
+            case "blocks" -> new ListTag(event.getBlocks(), block -> new LocationTag(block.getLocation()));
+            case "retract_location" -> new LocationTag(event.getBlock().getRelative(event.getDirection().getOppositeFace(), 2).getLocation());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/events/block/RedstoneScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/block/RedstoneScriptEvent.java
@@ -28,14 +28,20 @@ public class RedstoneScriptEvent extends BukkitScriptEvent implements Listener {
     // <context.new_current> returns what the redstone power level is becoming.
     //
     // @Determine
-    // ElementTag (Number) set the current value to a specific value.
+    // ElementTag(Number) set the current value to a specific value.
     //
     // -->
 
     public RedstoneScriptEvent() {
         registerCouldMatcher("redstone recalculated");
+        this.<RedstoneScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, power) -> {
+            if (power.isInt()) {
+                evt.event.setNewCurrent(power.asInt());
+                return true;
+            }
+            return false;
+        });
     }
-
 
     public LocationTag location;
     public BlockRedstoneEvent event;
@@ -49,22 +55,13 @@ public class RedstoneScriptEvent extends BukkitScriptEvent implements Listener {
     }
 
     @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag element && element.isInt()) {
-            event.setNewCurrent(element.asInt());
-            return true;
-        }
-        return super.applyDetermination(path, determinationObj);
-    }
-
-    @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "old_current": return new ElementTag(event.getOldCurrent());
-            case "new_current": return new ElementTag(event.getNewCurrent());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "old_current" -> new ElementTag(event.getOldCurrent());
+            case "new_current" -> new ElementTag(event.getNewCurrent());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -486,7 +486,7 @@ public class BukkitImplDeprecations {
     public static Warning advancementBackgroundFormat = new FutureWarning("advancementBackgroundFormat", "The 'background:' input in the advancement command no longer uses the 'textures/' path or '.png' suffix, so for example 'minecraft:textures/gui/advancements/backgrounds/stone.png' would be 'minecraft:gui/advancements/backgrounds/stone'.");
 
     // Added 2025/09/07
-    public static Warning brewingStandConsumeDetermination = new FutureWarning("brewingStandConsumeDetermination", "The 'consuming' and 'not_consuming' determinations in the 'brewing stand fueled' event have been deprecated in favor of 'CONSUME:<ElementTag(Boolean)>'.");
+    public static Warning brewingStandConsumeDetermination = new FutureWarning("brewingStandConsumeDetermination", "The 'consuming' and 'not_consuming' determinations in the 'brewing stand fueled' event have been deprecated in favor of 'CONSUMING:<ElementTag(Boolean)>'.");
 
     // Added 2025/09/22
     public static Warning playerSteerEntityEvent = new FutureWarning("playerSteerEntityEvent", "The 'player steers <entity>' event is deprecated in favor of the 'player input' event in MC 1.21+.");

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -479,7 +479,7 @@ public class BukkitImplDeprecations {
     // Added 2025/06/29
     public static Warning blockDispensesItemDetermination = new FutureWarning("blockDispensesItemDetermination", "The determination to control the item in the 'block dispenses' script event has been changed into the 'ITEM:<ItemTag>' format.");
 
-    // Added 2025/09/07
+    // Added 2025/08/23
     public static Warning advancementBackgroundFormat = new FutureWarning("advancementBackgroundFormat", "The 'background:' input in the advancement command no longer uses the 'textures/' path or '.png' suffix, so for example 'minecraft:textures/gui/advancements/backgrounds/stone.png' would be 'minecraft:gui/advancements/backgrounds/stone'.");
 
     // Added 2025/09/07

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -482,6 +482,9 @@ public class BukkitImplDeprecations {
     // Added 2025/08/23
     public static Warning advancementBackgroundFormat = new FutureWarning("advancementBackgroundFormat", "The 'background:' input in the advancement command no longer uses the 'textures/' path or '.png' suffix, so for example 'minecraft:textures/gui/advancements/backgrounds/stone.png' would be 'minecraft:gui/advancements/backgrounds/stone'.");
 
+    // Added 2025/08/25
+    public static Warning brewingStandConsumeDetermination = new FutureWarning("brewingStandConsumeDetermination", "The 'consuming' and 'not_consuming' determinations in the 'brewing stand fueled' event have been deprecated in favor of 'CONSUME:<ElementTag(Boolean)>'.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2023/10/29 without warning.

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -479,10 +479,10 @@ public class BukkitImplDeprecations {
     // Added 2025/06/29
     public static Warning blockDispensesItemDetermination = new FutureWarning("blockDispensesItemDetermination", "The determination to control the item in the 'block dispenses' script event has been changed into the 'ITEM:<ItemTag>' format.");
 
-    // Added 2025/08/23
+    // Added 2025/09/07
     public static Warning advancementBackgroundFormat = new FutureWarning("advancementBackgroundFormat", "The 'background:' input in the advancement command no longer uses the 'textures/' path or '.png' suffix, so for example 'minecraft:textures/gui/advancements/backgrounds/stone.png' would be 'minecraft:gui/advancements/backgrounds/stone'.");
 
-    // Added 2025/08/25
+    // Added 2025/09/07
     public static Warning brewingStandConsumeDetermination = new FutureWarning("brewingStandConsumeDetermination", "The 'consuming' and 'not_consuming' determinations in the 'brewing stand fueled' event have been deprecated in favor of 'CONSUME:<ElementTag(Boolean)>'.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================


### PR DESCRIPTION
- BrewingStandFueledScriptEvent: Deprecated "consuming" and "not_consuming" determinations into just "consume:<ElementTag(Boolean)>", modernized determination format, minor getContext format change
- CauldronLevelChangeScriptEvent: Removed deprecated methods of `#getOldLevel` and `#getNewLevel`, modernized determination format, minor getContext format change
- FurnaceBurnsItemScriptEvent: Modernized determination format, minor getContext format change
- FurnaceStartsSmeltingScriptEvent: Removed examples, modernized determination format, minor getContext format change
- LeafDecaysScriptEvent: Minor getContext format change
- LiquidLevelChangesScriptEvent: Minor getContext format change
- NoteBlockPlaysNoteScriptEvent: Minor getContext and getSound format changes
- PistonExtendsScriptEvent: Minor getContext format change
- PistonRetractsScriptEvent: Minor getContext format change
- RedstoneScriptEvent: Modernized determination format, minor getContext format change