### PR TITLE
Minor fix for mismatched switch key

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/SpawnChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/SpawnChangeScriptEvent.java
@@ -14,7 +14,7 @@ public class SpawnChangeScriptEvent extends BukkitScriptEvent implements Listene
     // @Events
     // spawn changes
     //
-    // @Switch for:<world> to only process the event when a specified world's spawn changes.
+    // @Switch world:<world> to only process the event when a specified world's spawn changes.
     //
     // @Group World
     //
@@ -29,14 +29,14 @@ public class SpawnChangeScriptEvent extends BukkitScriptEvent implements Listene
 
     public SpawnChangeScriptEvent() {
         registerCouldMatcher("spawn changes");
-        registerSwitches("for");
+        registerSwitches("world");
     }
 
     public SpawnChangeEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryObjectSwitch("for", new WorldTag(event.getWorld()))) {
+        if (!path.tryObjectSwitch("world", new WorldTag(event.getWorld()))) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/world/SpawnChangeScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/world/SpawnChangeScriptEvent.java
@@ -36,7 +36,7 @@ public class SpawnChangeScriptEvent extends BukkitScriptEvent implements Listene
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryObjectSwitch("world", new WorldTag(event.getWorld()))) {
+        if (!path.tryObjectSwitch("for", new WorldTag(event.getWorld()))) {
             return false;
         }
         return super.matches(path);
@@ -44,15 +44,12 @@ public class SpawnChangeScriptEvent extends BukkitScriptEvent implements Listene
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "world":
-                return new WorldTag(event.getWorld());
-            case "old_location":
-                return new LocationTag(event.getPreviousLocation());
-            case "new_location":
-                return new LocationTag(event.getWorld().getSpawnLocation());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "world" -> new WorldTag(event.getWorld());
+            case "old_location" -> new LocationTag(event.getPreviousLocation());
+            case "new_location" -> new LocationTag(event.getWorld().getSpawnLocation());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler


### PR DESCRIPTION
Replaced "world" switch in "SpawnChangeScriptEvent" with "for" like it is in the documentation