### PR TITLE
Made determinations more clear in EntityExplosionPrimesScriptEvent meta

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExplosionPrimesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExplosionPrimesScriptEvent.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.events.entity;
 
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import org.bukkit.event.EventHandler;
@@ -35,6 +36,11 @@ public class EntityExplosionPrimesScriptEvent extends BukkitScriptEvent implemen
     public EntityExplosionPrimesScriptEvent() {
         registerCouldMatcher("<entity> explosion primes");
         this.<EntityExplosionPrimesScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, value) -> {
+            if (value.isBoolean()) {
+                BukkitImplDeprecations.explosionPrimeDetermination.warn();
+                evt.event.setFire(value.asBoolean());
+                return true;
+            }
             if (value.isFloat()) {
                 evt.event.setRadius(value.asFloat());
                 return true;

--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExplosionPrimesScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityExplosionPrimesScriptEvent.java
@@ -2,9 +2,7 @@ package com.denizenscript.denizen.events.entity;
 
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
-import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.ArgumentHelper;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -25,13 +23,31 @@ public class EntityExplosionPrimesScriptEvent extends BukkitScriptEvent implemen
     // @Triggers when an entity decides to explode.
     //
     // @Context
-    // <context.entity> returns the EntityTag.
-    // <context.radius> returns an ElementTag of the explosion's radius.
-    // <context.fire> returns an ElementTag with a value of "true" if the explosion will create fire and "false" otherwise.
+    // <context.entity> returns an EntityTag of the explosive.
+    // <context.radius> returns the explosion's radius.
+    // <context.fire> returns whether the explosion will create fire.
+    //
+    // @Determine
+    // ElementTag(Decimal) to change the explosion radius.
+    // "FIRE:<ElementTag(Boolean)>" to set whether the explosion will produce fire.
     // -->
 
     public EntityExplosionPrimesScriptEvent() {
         registerCouldMatcher("<entity> explosion primes");
+        this.<EntityExplosionPrimesScriptEvent, ElementTag>registerOptionalDetermination(null, ElementTag.class, (evt, context, value) -> {
+            if (value.isFloat()) {
+                evt.event.setRadius(value.asFloat());
+                return true;
+            }
+            return false;
+        });
+        this.<EntityExplosionPrimesScriptEvent, ElementTag>registerOptionalDetermination("fire", ElementTag.class, (evt, context, value) -> {
+            if (value.isBoolean()) {
+                evt.event.setFire(value.asBoolean());
+                return true;
+            }
+            return false;
+        });
     }
 
     public EntityTag entity;
@@ -49,30 +65,13 @@ public class EntityExplosionPrimesScriptEvent extends BukkitScriptEvent implemen
     }
 
     @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        String determination = determinationObj.toString();
-        if (ArgumentHelper.matchesDouble(determination)) {
-            event.setRadius(Float.parseFloat(determination));
-            return true;
-        }
-        if (Argument.valueOf(determination).matchesBoolean()) {
-            event.setFire(determination.equalsIgnoreCase("true"));
-            return true;
-        }
-        return super.applyDetermination(path, determinationObj);
-    }
-
-    @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "entity":
-                return entity;
-            case "radius":
-                return new ElementTag(event.getRadius());
-            case "fire":
-                return new ElementTag(event.getFire());
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "entity" -> entity.getDenizenObject();
+            case "radius" -> new ElementTag(event.getRadius());
+            case "fire" -> new ElementTag(event.getFire());
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -267,6 +267,9 @@ public class BukkitImplDeprecations {
     // Added 2025/07/10
     public static Warning entityKnockback = new Warning("entityKnockback", "The 'EntityTag.knockback' property is deprecated. You should adjust the knockback enchantment on the weapon itself.");
 
+    // Added 2025/10/24
+    public static Warning explosionPrimeDetermination = new Warning("explosionPrimeDetermination", "The determination to control fire in the '<entity> explosion primes' event is now formatted as 'FIRE:<ElementTag(Boolean)>'.");
+
     // ==================== SLOW deprecations ====================
     // These aren't spammed, but will show up repeatedly until fixed. Server owners will probably notice them.
 


### PR DESCRIPTION
Two determinations have been part of this event since it's creation, but have never been listed in the meta.

& modernization