### PR TITLE
`time_lived` tag precision fix

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/EntityTag.java
@@ -2202,7 +2202,7 @@ public class EntityTag implements ObjectTag, Adjustable, EntityFormObject, Flagg
         // Returns how long the entity has lived.
         // -->
         registerSpawnedOnlyTag(DurationTag.class, "time_lived", (attribute, object) -> {
-            return new DurationTag(object.getBukkitEntity().getTicksLived() / 20);
+            return new DurationTag((long) object.getBukkitEntity().getTicksLived());
         });
 
         // <--[tag]


### PR DESCRIPTION
This fixes the https://discord.com/channels/315163488085475337/1417879777821331496 by using a constructor for ticks