### PR TITLE
 Tag and mechanism to disable crafter slots

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4541,14 +4541,14 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // <LocationTag.crafter_disabled_slots>
             // @example
             // # Disables the slots in the top left and middle right
-            // - adjustblock <[block]> crafter_disabled_slots:1|6
+            // - adjustblock <[location]> crafter_disabled_slots:1|6
             // -->
             tagProcessor.registerMechanism("crafter_disabled_slots", false, ListTag.class, (object, mechanism, input) -> {
                 if (!(object.getBlockState() instanceof Crafter crafter)) {
                     mechanism.echoError("The 'LocationTag.crafter_disabled_slots' mechanism can only be called on a crafter block.");
                     return;
                 }
-                for (int i = 0; i < 9; i++) {
+                for (int i = 0; i <= 8; i++) {
                     crafter.setSlotDisabled(i, false);
                 }
                 for (String slot : input) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4553,8 +4553,11 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 }
                 for (String slot : input) {
                     ElementTag element = new ElementTag(slot);
-                    if (element.isInt() && element.asInt() > 0 && element.asInt() <= 9) {
-                        crafter.setSlotDisabled(element.asInt() - 1, true);
+                    if (element.isInt()) {
+                        int value = element.asInt();
+                        if (value > 0 && value <= 9) {
+                            crafter.setSlotDisabled(value - 1, true);
+                        }
                     }
                     else {
                         mechanism.echoError("'" + slot + "' is not a valid slot for the 'crafter_disabled_slots' mechanism.");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4514,7 +4514,8 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @mechanism LocationTag.crafter_disabled_slots
             // @group world
             // @description
-            // Returns the disabled slots of a crafter block from left to right, top to bottom.
+            // Returns which slots in a crafter are disabled.
+            // The slots are arranged from left to right, top to bottom.
             // -->
             tagProcessor.registerTag(ListTag.class, "crafter_disabled_slots", (attribute, object) -> {
                 if (!(object.getBlockStateForTag(attribute) instanceof Crafter crafter)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4517,8 +4517,8 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // Returns the disabled slots of a crafter block from left to right, top to bottom.
             // -->
             tagProcessor.registerTag(ListTag.class, "crafter_disabled_slots", (attribute, object) -> {
-                if (!(object.getBlockState() instanceof Crafter crafter)) {
-                    Debug.echoError("The 'LocationTag.crafter_disabled_slots' tag can only be called on a crafter block.");
+                if (!(object.getBlockStateForTag(attribute) instanceof Crafter crafter)) {
+                    attribute.echoError("The 'LocationTag.crafter_disabled_slots' tag can only be called on a crafter block.");
                     return null;
                 }
                 ListTag slots = new ListTag();
@@ -4535,7 +4535,8 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             // @name crafter_disabled_slots
             // @input ListTag
             // @description
-            // Sets which slots in a crafter are disabled from left to right, top to bottom.
+            // Sets which slots in a crafter are disabled.
+            // The slots are arranged from left to right, top to bottom.
             // Provide no input to enable all slots.
             // @tags
             // <LocationTag.crafter_disabled_slots>
@@ -4557,11 +4558,10 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                         int value = element.asInt();
                         if (value > 0 && value <= 9) {
                             crafter.setSlotDisabled(value - 1, true);
+                            continue;
                         }
                     }
-                    else {
-                        mechanism.echoError("'" + slot + "' is not a valid slot for the 'crafter_disabled_slots' mechanism.");
-                    }
+                    mechanism.echoError("'" + slot + "' is not a valid slot for the 'crafter_disabled_slots' mechanism.");
                 }
                 crafter.update();
             });

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4507,6 +4507,61 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 }
                 return new ElementTag(chiseledBookshelf.getSlot(input.toVector()) + 1);
             });
+
+            // <--[tag]
+            // @attribute <LocationTag.crafter_disabled_slots>
+            // @returns ListTag
+            // @mechanism LocationTag.crafter_disabled_slots
+            // @group world
+            // @description
+            // Returns the disabled slots of a crafter block from left to right, top to bottom.
+            // -->
+            tagProcessor.registerTag(ListTag.class, "crafter_disabled_slots", (attribute, object) -> {
+                if (!(object.getBlockState() instanceof Crafter crafter)) {
+                    Debug.echoError("The 'LocationTag.crafter_disabled_slots' tag can only be called on a crafter block.");
+                    return null;
+                }
+                ListTag slots = new ListTag();
+                for (int i = 0; i <= 8; i++) {
+                    if (crafter.isSlotDisabled(i)) {
+                        slots.addObject(new ElementTag(i + 1));
+                    }
+                }
+                return slots;
+            });
+
+            // <--[mechanism]
+            // @object LocationTag
+            // @name crafter_disabled_slots
+            // @input ListTag
+            // @description
+            // Sets which slots in a crafter are disabled from left to right, top to bottom.
+            // Provide no input to enable all slots.
+            // @tags
+            // <LocationTag.crafter_disabled_slots>
+            // @example
+            // # Disables the slots in the top left and middle right
+            // - adjustblock <[block]> crafter_disabled_slots:1|6
+            // -->
+            tagProcessor.registerMechanism("crafter_disabled_slots", false, ListTag.class, (object, mechanism, input) -> {
+                if (!(object.getBlockState() instanceof Crafter crafter)) {
+                    mechanism.echoError("The 'LocationTag.crafter_disabled_slots' mechanism can only be called on a crafter block.");
+                    return;
+                }
+                for (int i = 0; i < 9; i++) {
+                    crafter.setSlotDisabled(i, false);
+                }
+                for (String slot : input) {
+                    ElementTag element = new ElementTag(slot);
+                    if (element.isInt() && element.asInt() > 0 && element.asInt() <= 9) {
+                        crafter.setSlotDisabled(element.asInt() - 1, true);
+                    }
+                    else {
+                        mechanism.echoError("'" + slot + "' is not a valid slot for the 'crafter_disabled_slots' mechanism.");
+                    }
+                }
+                crafter.update();
+            });
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/LocationTag.java
@@ -4509,17 +4509,17 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
             });
 
             // <--[tag]
-            // @attribute <LocationTag.crafter_disabled_slots>
+            // @attribute <LocationTag.disabled_slots>
             // @returns ListTag
-            // @mechanism LocationTag.crafter_disabled_slots
+            // @mechanism LocationTag.disabled_slots
             // @group world
             // @description
             // Returns which slots in a crafter are disabled.
             // The slots are arranged from left to right, top to bottom.
             // -->
-            tagProcessor.registerTag(ListTag.class, "crafter_disabled_slots", (attribute, object) -> {
+            tagProcessor.registerTag(ListTag.class, "disabled_slots", (attribute, object) -> {
                 if (!(object.getBlockStateForTag(attribute) instanceof Crafter crafter)) {
-                    attribute.echoError("The 'LocationTag.crafter_disabled_slots' tag can only be called on a crafter block.");
+                    attribute.echoError("The 'LocationTag.disabled_slots' tag can only be called on a crafter block.");
                     return null;
                 }
                 ListTag slots = new ListTag();
@@ -4533,21 +4533,21 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
 
             // <--[mechanism]
             // @object LocationTag
-            // @name crafter_disabled_slots
+            // @name disabled_slots
             // @input ListTag
             // @description
             // Sets which slots in a crafter are disabled.
             // The slots are arranged from left to right, top to bottom.
             // Provide no input to enable all slots.
             // @tags
-            // <LocationTag.crafter_disabled_slots>
+            // <LocationTag.disabled_slots>
             // @example
             // # Disables the slots in the top left and middle right
-            // - adjustblock <[location]> crafter_disabled_slots:1|6
+            // - adjustblock <[location]> disabled_slots:1|6
             // -->
-            tagProcessor.registerMechanism("crafter_disabled_slots", false, ListTag.class, (object, mechanism, input) -> {
+            tagProcessor.registerMechanism("disabled_slots", false, ListTag.class, (object, mechanism, input) -> {
                 if (!(object.getBlockState() instanceof Crafter crafter)) {
-                    mechanism.echoError("The 'LocationTag.crafter_disabled_slots' mechanism can only be called on a crafter block.");
+                    mechanism.echoError("The 'LocationTag.disabled_slots' mechanism can only be called on a crafter block.");
                     return;
                 }
                 for (int i = 0; i <= 8; i++) {
@@ -4555,14 +4555,16 @@ public class LocationTag extends org.bukkit.Location implements VectorObject, Ob
                 }
                 for (String slot : input) {
                     ElementTag element = new ElementTag(slot);
-                    if (element.isInt()) {
-                        int value = element.asInt();
-                        if (value > 0 && value <= 9) {
-                            crafter.setSlotDisabled(value - 1, true);
-                            continue;
-                        }
+                    if (!element.isInt()) {
+                        mechanism.echoError("Invalid slot '" + slot + "' specified: must be an integer.");
+                        continue;
                     }
-                    mechanism.echoError("'" + slot + "' is not a valid slot for the 'crafter_disabled_slots' mechanism.");
+                    int value = element.asInt();
+                    if (value < 1 || value > 9) {
+                        mechanism.echoError("Invalid slot '" + slot + "' specified: must between 1 and 9.");
+                        continue;
+                    }
+                    crafter.setSlotDisabled(value - 1, true);
                 }
                 crafter.update();
             });


### PR DESCRIPTION
Adds in a tag and mechanism to return and change the slots of a crafter block that are disabled.

Requested in https://discord.com/channels/315163488085475337/1417201910489939988

Open to naming suggestions, this was kind of the cleanest thing I could think of since there's already an EntityTag.disabled_slots