### PR TITLE
EntityProfession 1.21 fix and modernization

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
@@ -36,7 +36,7 @@ public class EntityProfession extends EntityProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (Utilities.requireEnumlike(mechanism, Villager.Profession.class)) {
+        if (mechanism.requireEnum(Villager.Profession.class)) {
             if (getEntity() instanceof Villager villager) {
                 villager.setProfession(value.asEnum(Villager.Profession.class));
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
@@ -1,12 +1,9 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.ZombieVillager;
 
@@ -26,25 +23,15 @@ public class EntityProfession extends EntityProperty<ElementTag> {
                 || entity.getBukkitEntity() instanceof ZombieVillager;
     }
 
-    public EntityProfession(EntityTag entity) {
-        professional = entity;
-    }
-
-    EntityTag professional;
-
-    public Villager.Profession getProfession() {
-        if (professional.getBukkitEntityType() == EntityType.ZOMBIE_VILLAGER) {
-            return ((ZombieVillager) professional.getBukkitEntity()).getVillagerProfession();
-        }
-        return ((Villager) professional.getBukkitEntity()).getProfession();
-    }
-
     @Override
     public ElementTag getPropertyValue() {
-        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20)) {
-            return new ElementTag(String.valueOf(getProfession()), true);
+        if (getEntity() instanceof Villager villager) {
+            return Utilities.enumlikeToElement(villager.getProfession());
         }
-        return new ElementTag(Utilities.namespacedKeyToString(getProfession().getKey()).toUpperCase(), true);
+        else if (getEntity() instanceof ZombieVillager zvillager) {
+            return Utilities.enumlikeToElement(zvillager.getVillagerProfession());
+        }
+        return null;
     }
 
     @Override

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityProfession.java
@@ -1,44 +1,30 @@
 package com.denizenscript.denizen.objects.properties.entity;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.tags.Attribute;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.ZombieVillager;
 
-public class EntityProfession implements Property {
+public class EntityProfession extends EntityProperty<ElementTag> {
 
-    // TODO This technically has registries on all supported versions
-    public static boolean describes(ObjectTag entity) {
-        if (!(entity instanceof EntityTag)) {
-            return false;
-        }
-        return ((EntityTag) entity).getBukkitEntityType() == EntityType.VILLAGER
-                || ((EntityTag) entity).getBukkitEntityType() == EntityType.ZOMBIE_VILLAGER;
+    // <--[property]
+    // @object EntityTag
+    // @name profession
+    // @input ElementTag
+    // @description
+    // Controls the profession of a villager or zombie villager.
+    // For the list of possible professions, refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Villager.Profession.html>
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return entity.getBukkitEntity() instanceof Villager
+                || entity.getBukkitEntity() instanceof ZombieVillager;
     }
-
-    public static EntityProfession getFrom(ObjectTag entity) {
-        if (!describes(entity)) {
-            return null;
-        }
-        else {
-            return new EntityProfession((EntityTag) entity);
-        }
-    }
-
-    public static final String[] handledTags = new String[] {
-            "profession"
-    };
-
-    public static final String[] handledMechs = new String[] {
-            "profession"
-    };
 
     public EntityProfession(EntityTag entity) {
         professional = entity;
@@ -53,18 +39,24 @@ public class EntityProfession implements Property {
         return ((Villager) professional.getBukkitEntity()).getProfession();
     }
 
-    public void setProfession(Villager.Profession profession) {
-        if (professional.getBukkitEntityType() == EntityType.ZOMBIE_VILLAGER) {
-            ((ZombieVillager) professional.getBukkitEntity()).setVillagerProfession(profession);
+    @Override
+    public ElementTag getPropertyValue() {
+        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20)) {
+            return new ElementTag(String.valueOf(getProfession()), true);
         }
-        else {
-            ((Villager) professional.getBukkitEntity()).setProfession(profession);
-        }
+        return new ElementTag(Utilities.namespacedKeyToString(getProfession().getKey()).toUpperCase(), true);
     }
 
     @Override
-    public String getPropertyString() {
-        return CoreUtilities.toLowerCase(String.valueOf(getProfession()));
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (Utilities.requireEnumlike(mechanism, Villager.Profession.class)) {
+            if (getEntity() instanceof Villager villager) {
+                villager.setProfession(value.asEnum(Villager.Profession.class));
+            }
+            else if (getEntity() instanceof ZombieVillager zvillager) {
+                zvillager.setVillagerProfession(value.asEnum(Villager.Profession.class));
+            }
+        }
     }
 
     @Override
@@ -72,47 +64,7 @@ public class EntityProfession implements Property {
         return "profession";
     }
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-
-        if (attribute == null) {
-            return null;
-        }
-
-        // <--[tag]
-        // @attribute <EntityTag.profession>
-        // @returns ElementTag
-        // @mechanism EntityTag.profession
-        // @group properties
-        // @description
-        // If the entity can have professions, returns the entity's profession.
-        // Currently, only Villager-type and infected zombie entities can have professions.
-        // For the list of possible professions, refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Villager.Profession.html>
-        // -->
-        if (attribute.startsWith("profession")) {
-            return new ElementTag(String.valueOf(getProfession()), true)
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-
-        // <--[mechanism]
-        // @object EntityTag
-        // @name profession
-        // @input ElementTag
-        // @description
-        // Changes the entity's profession.
-        // Currently, only Villager-type entities can have professions.
-        // For the list of possible professions, refer to <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Villager.Profession.html>
-        // @tags
-        // <EntityTag.profession>
-        // -->
-        if (mechanism.matches("profession") && Utilities.requireEnumlike(mechanism, Villager.Profession.class)) {
-            setProfession(Utilities.elementToEnumlike(mechanism.getValue(), Villager.Profession.class));
-        }
+    public static void register() {
+        autoRegister("profession", EntityProfession.class, ElementTag.class, false);
     }
 }


### PR DESCRIPTION
There were some changes made to the Villager.Profession interface at some point in 1.21 so that it needs a `#getKey()` rather than a simple String conversion for the tag. The mechanism works across different versions.

Originally reported in https://discord.com/channels/315163488085475337/1439241589305249872