### PR TITLE
Fix for null entries in PlayerPreparesEnchantScriptEvent

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
@@ -77,7 +77,7 @@ public class PlayerPreparesEnchantScriptEvent extends BukkitScriptEvent implemen
                 }
                 for (int i = 0; i < offers.size(); i++) {
                     MapTag map = MapTag.getMapFor(offers.getObject(i), getTagContext(path));
-                    if(map.isEmpty()){
+                    if (map.isEmpty()){
                         event.getOffers()[i] = null;
                         continue;
                     }
@@ -112,7 +112,7 @@ public class PlayerPreparesEnchantScriptEvent extends BukkitScriptEvent implemen
             case "offers":
                 ListTag output = new ListTag();
                 for (EnchantmentOffer offer : event.getOffers()) {
-                    if(offer == null) {
+                    if (offer == null) {
                         output.addObject(new MapTag());
                         continue;
                     }

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
@@ -76,7 +76,12 @@ public class PlayerPreparesEnchantScriptEvent extends BukkitScriptEvent implemen
                     return false;
                 }
                 for (int i = 0; i < offers.size(); i++) {
-                    MapTag map = MapTag.getMapFor(offers.getObject(i), getTagContext(path));
+                    var offer = offers.getObject(i);
+                    MapTag map = MapTag.getMapFor(offer, getTagContext(path));
+                    if(map.isEmpty()){
+                        event.getOffers()[i] = null;
+                        continue;
+                    }
                     event.getOffers()[i].setCost(map.getElement("cost").asInt());
                     EnchantmentTag enchantment = map.getObjectAs("enchantment_type", EnchantmentTag.class, getTagContext(path));
                     if (enchantment == null) {
@@ -108,6 +113,10 @@ public class PlayerPreparesEnchantScriptEvent extends BukkitScriptEvent implemen
             case "offers":
                 ListTag output = new ListTag();
                 for (EnchantmentOffer offer : event.getOffers()) {
+                    if(offer == null) {
+                        output.addObject(new MapTag());
+                        continue;
+                    }
                     MapTag map = new MapTag();
                     map.putObject("cost", new ElementTag(offer.getCost()));
                     map.putObject("enchantment", new ElementTag(offer.getEnchantment().getKey().getKey()));

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
@@ -76,8 +76,7 @@ public class PlayerPreparesEnchantScriptEvent extends BukkitScriptEvent implemen
                     return false;
                 }
                 for (int i = 0; i < offers.size(); i++) {
-                    var offer = offers.getObject(i);
-                    MapTag map = MapTag.getMapFor(offer, getTagContext(path));
+                    MapTag map = MapTag.getMapFor(offers.getObject(i), getTagContext(path));
                     if(map.isEmpty()){
                         event.getOffers()[i] = null;
                         continue;

--- a/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/player/PlayerPreparesEnchantScriptEvent.java
@@ -77,7 +77,7 @@ public class PlayerPreparesEnchantScriptEvent extends BukkitScriptEvent implemen
                 }
                 for (int i = 0; i < offers.size(); i++) {
                     MapTag map = MapTag.getMapFor(offers.getObject(i), getTagContext(path));
-                    if (map.isEmpty()){
+                    if (map.isEmpty()) {
                         event.getOffers()[i] = null;
                         continue;
                     }


### PR DESCRIPTION
I have noticed that the PlayerPreparesEnchant ScriptEvent errors in case of the minecraft provided offers having a null entry. I added some simple protections for null entries.