### PR TITLE
Respawn dragon fix

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/WorldTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/WorldTag.java
@@ -36,7 +36,6 @@ import org.bukkit.util.BoundingBox;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 public class WorldTag implements ObjectTag, Adjustable, FlaggableObject {
@@ -1094,7 +1093,7 @@ public class WorldTag implements ObjectTag, Adjustable, FlaggableObject {
                 return;
             }
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) { // workaround for upstream bug
-                battle.initiateRespawn(Collections.emptyList());
+                battle.initiateRespawn(List.of());
             }
             else {
                 battle.initiateRespawn();

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/WorldTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/WorldTag.java
@@ -36,6 +36,7 @@ import org.bukkit.util.BoundingBox;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class WorldTag implements ObjectTag, Adjustable, FlaggableObject {
@@ -1092,7 +1093,12 @@ public class WorldTag implements ObjectTag, Adjustable, FlaggableObject {
                 mechanism.echoError("Provided world is not an end world!");
                 return;
             }
-            battle.initiateRespawn();
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) { // workaround for upstream bug
+                battle.initiateRespawn(Collections.emptyList());
+            }
+            else {
+                battle.initiateRespawn();
+            }
         });
 
         // <--[mechanism]


### PR DESCRIPTION
This is a workaround to fix upstream bug in `DragonBattle#initiateRespawn()`. (only on 1.20+ versions)
Reported in https://discord.com/channels/315163488085475337/1375284597918666783
(also discussion about the bug in paper discord https://discord.com/channels/289587909051416579/555462289851940864/1395841053537603584)