### PR TITLE
Moved 8 entity types from EntityTag.color to EntityTag.variant

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/utilities/PaperAPIToolsImpl.java
@@ -10,9 +10,11 @@ import com.denizenscript.denizen.scripts.containers.core.ItemScriptContainer;
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
 import com.denizenscript.denizen.utilities.FormattedTextHelper;
 import com.denizenscript.denizen.utilities.PaperAPITools;
+import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
@@ -421,12 +423,17 @@ public class PaperAPIToolsImpl extends PaperAPITools {
     }
 
     @Override
-    public String getCopperGolemState(CopperGolem copperGolem) {
+    public ListTag getCopperGolemVariants() {
+        return Utilities.listTypes(WeatheringCopperState.class);
+    }
+
+    @Override
+    public String getCopperGolemVariant(CopperGolem copperGolem) {
         return copperGolem.getWeatheringState().name();
     }
 
     @Override
-    public void setCopperGolemState(ElementTag variant, CopperGolem copperGolem, Mechanism mechanism) {
+    public void setCopperGolemVariant(ElementTag variant, CopperGolem copperGolem, Mechanism mechanism) {
         if (mechanism.requireEnum(WeatheringCopperState.class)) {
             copperGolem.setWeatheringState(variant.asEnum(WeatheringCopperState.class));
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -197,9 +197,7 @@ public class PropertyRegistry {
             PropertyParser.registerProperty(EntityTrapped.class, EntityTag.class);
             PropertyParser.registerProperty(EntityTrapTime.class, EntityTag.class);
         }
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
-            PropertyParser.registerProperty(EntityVariant.class, EntityTag.class);
-        }
+        PropertyParser.registerProperty(EntityVariant.class, EntityTag.class);
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             PropertyParser.registerProperty(EntityViewRange.class, EntityTag.class);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.properties.bukkit.BukkitColorExtensions;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.MultiVersionHelper1_19;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.objects.Mechanism;
@@ -112,12 +113,15 @@ public class EntityColor extends EntityProperty<ElementTag> {
             as(Ocelot.class).setCatType(color.asEnum(Ocelot.Type.class));
         }
         else if (type == EntityType.RABBIT && mechanism.requireEnum(Rabbit.Type.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn(mechanism.context);
             as(Rabbit.class).setRabbitType(color.asEnum(Rabbit.Type.class));
         }
         else if ((type == EntityType.LLAMA || type == EntityType.TRADER_LLAMA) && mechanism.requireEnum(Llama.Color.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn(mechanism.context);
             as(Llama.class).setColor(color.asEnum(Llama.Color.class));
         }
         else if (type == EntityType.PARROT && mechanism.requireEnum(Parrot.Variant.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn(mechanism.context);
             as(Parrot.class).setVariant(color.asEnum(Parrot.Variant.class));
         }
         else if (type == EntityType.SHULKER && mechanism.requireEnum(DyeColor.class)) {
@@ -156,6 +160,7 @@ public class EntityColor extends EntityProperty<ElementTag> {
             }
         }
         else if (type == EntityType.FOX && mechanism.requireEnum(Fox.Type.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn(mechanism.context);
             as(Fox.class).setFoxType(color.asEnum(Fox.Type.class));
         }
         else if (type == EntityType.CAT && mechanism.requireObject(ListTag.class)) {
@@ -201,9 +206,11 @@ public class EntityColor extends EntityProperty<ElementTag> {
         }
         // TODO This technically has registries on all supported versions
         else if (type == EntityType.VILLAGER && Utilities.requireEnumlike(mechanism, Villager.Type.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn(mechanism.context);
             as(Villager.class).setVillagerType(Utilities.elementToEnumlike(mechanism.getValue(), Villager.Type.class));
         }
         else if (type == EntityType.ZOMBIE_VILLAGER && Utilities.requireEnumlike(mechanism, Villager.Type.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn(mechanism.context);
             as(ZombieVillager.class).setVillagerType(Utilities.elementToEnumlike(mechanism.getValue(), Villager.Type.class));
         }
         else if (type == EntityType.ARROW && mechanism.requireObject(ColorTag.class)) {
@@ -244,18 +251,30 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 }
                 yield null;
             }
-            case RABBIT -> as(Rabbit.class).getRabbitType().name();
-            case LLAMA, TRADER_LLAMA -> as(Llama.class).getColor().name();
-            case PARROT -> as(Parrot.class).getVariant().name();
+            case RABBIT -> {
+                BukkitImplDeprecations.colorToVariantProperty.warn();
+                yield as(Rabbit.class).getRabbitType().name();
+            }
+            case LLAMA, TRADER_LLAMA -> {
+                BukkitImplDeprecations.colorToVariantProperty.warn();
+                yield as(Llama.class).getColor().name();
+            }
+            case PARROT -> {
+                BukkitImplDeprecations.colorToVariantProperty.warn();
+                yield as(Parrot.class).getVariant().name();
+            }
             case SHULKER -> {
                 DyeColor color = as(Shulker.class).getColor();
-                yield  color == null ? null : color.name();
+                yield color == null ? null : color.name();
             }
             case TROPICAL_FISH -> {
                 TropicalFish fish = as(TropicalFish.class);
                 yield new ListTag(Arrays.asList(fish.getPattern().name(), fish.getBodyColor().name(), fish.getPatternColor().name())).identify();
             }
-            case FOX -> as(Fox.class).getFoxType().name();
+            case FOX -> {
+                BukkitImplDeprecations.colorToVariantProperty.warn();
+                yield as(Fox.class).getFoxType().name();
+            }
             case CAT -> {
                 Cat cat = as(Cat.class);
                 // TODO once 1.21 is the minimum supported version, replace with direct registry-based handling
@@ -266,8 +285,14 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 yield panda.getMainGene().name() + "|" + panda.getHiddenGene().name();
             }
             // TODO This technically has registries on all supported versions
-            case VILLAGER -> String.valueOf(as(Villager.class).getVillagerType());
-            case ZOMBIE_VILLAGER -> String.valueOf(as(ZombieVillager.class).getVillagerType());
+            case VILLAGER -> {
+                BukkitImplDeprecations.colorToVariantProperty.warn();
+                yield String.valueOf(as(Villager.class).getVillagerType());
+            }
+            case ZOMBIE_VILLAGER -> {
+                BukkitImplDeprecations.colorToVariantProperty.warn();
+                yield String.valueOf(as(ZombieVillager.class).getVillagerType());
+            }
             case ARROW -> {
                 try {
                     yield BukkitColorExtensions.fromColor(as(Arrow.class).getColor()).identify();
@@ -298,19 +323,34 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 yield horseColors;
             }
             case SHEEP, WOLF, SHULKER -> Utilities.listTypes(DyeColor.class);
-            case RABBIT -> Utilities.listTypes(Rabbit.Type.class);
-            case LLAMA, TRADER_LLAMA -> Utilities.listTypes(Llama.Color.class);
-            case PARROT -> Utilities.listTypes(Parrot.Variant.class);
+            case RABBIT -> {
+                BukkitImplDeprecations.allowedColorsToVariants.warn();
+                yield Utilities.listTypes(Rabbit.Type.class);
+            }
+            case LLAMA, TRADER_LLAMA -> {
+                BukkitImplDeprecations.allowedColorsToVariants.warn();
+                yield Utilities.listTypes(Llama.Color.class);
+            }
+            case PARROT -> {
+                BukkitImplDeprecations.allowedColorsToVariants.warn();
+                yield Utilities.listTypes(Parrot.Variant.class);
+            }
             case TROPICAL_FISH -> {
                 ListTag patterns = Utilities.listTypes(TropicalFish.Pattern.class);
                 patterns.addAll(Utilities.listTypes(DyeColor.class));
                 yield patterns;
             }
-            case FOX -> Utilities.listTypes(Fox.Type.class);
+            case FOX -> {
+                BukkitImplDeprecations.allowedColorsToVariants.warn();
+                yield Utilities.listTypes(Fox.Type.class);
+            }
             case CAT -> Utilities.listTypes(Cat.Type.class);
             case PANDA -> Utilities.listTypes(Panda.Gene.class);
             // TODO This technically has registries on all supported versions
-            case VILLAGER, ZOMBIE_VILLAGER -> Utilities.listTypes(Villager.Type.class);
+            case VILLAGER, ZOMBIE_VILLAGER -> {
+                BukkitImplDeprecations.allowedColorsToVariants.warn();
+                yield Utilities.listTypes(Villager.Type.class);
+            }
             case GOAT -> {
                 ListTag result = new ListTag();
                 result.add("screaming");

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityColor.java
@@ -62,16 +62,16 @@ public class EntityColor extends EntityProperty<ElementTag> {
 
     @Override
     public ElementTag getPropertyValue() {
-        return getCleanedValue(false);
+        return getCleanedValue(null);
     }
 
     @Override
     public ElementTag getTagValue(Attribute attribute) {
-        return getCleanedValue(true);
+        return getCleanedValue(attribute);
     }
 
-    public ElementTag getCleanedValue(boolean includeDeprecated) {
-        String color = getColor(includeDeprecated);
+    public ElementTag getCleanedValue(Attribute attribute) {
+        String color = getColor(attribute);
         return color == null ? null : new ElementTag(CoreUtilities.toLowerCase(color));
     }
 
@@ -230,10 +230,10 @@ public class EntityColor extends EntityProperty<ElementTag> {
         }
     }
 
-    public String getColor(boolean includeDeprecated) {
+    public String getColor(Attribute attribute) {
         EntityType type = getType();
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && MultiVersionHelper1_19.colorIsApplicable(type)) {
-            return MultiVersionHelper1_19.getColor(getEntity(), includeDeprecated);
+            return MultiVersionHelper1_19.getColor(getEntity(), attribute);
         }
         if (getEntity() instanceof MushroomCow mushroomCow) {
             return mushroomCow.getVariant().name();
@@ -246,21 +246,27 @@ public class EntityColor extends EntityProperty<ElementTag> {
             case SHEEP -> as(Sheep.class).getColor().name();
             case WOLF -> as(Wolf.class).getCollarColor().name();
             case OCELOT -> {
-                if (includeDeprecated) {
+                if (attribute != null) {
                     yield as(Ocelot.class).getCatType().name();
                 }
                 yield null;
             }
             case RABBIT -> {
-                BukkitImplDeprecations.colorToVariantProperty.warn();
+                if (attribute != null) {
+                    BukkitImplDeprecations.colorToVariantProperty.warn(attribute.context);
+                }
                 yield as(Rabbit.class).getRabbitType().name();
             }
             case LLAMA, TRADER_LLAMA -> {
-                BukkitImplDeprecations.colorToVariantProperty.warn();
+                if (attribute != null) {
+                    BukkitImplDeprecations.colorToVariantProperty.warn(attribute.context);
+                }
                 yield as(Llama.class).getColor().name();
             }
             case PARROT -> {
-                BukkitImplDeprecations.colorToVariantProperty.warn();
+                if (attribute != null) {
+                    BukkitImplDeprecations.colorToVariantProperty.warn(attribute.context);
+                }
                 yield as(Parrot.class).getVariant().name();
             }
             case SHULKER -> {
@@ -272,7 +278,9 @@ public class EntityColor extends EntityProperty<ElementTag> {
                 yield new ListTag(Arrays.asList(fish.getPattern().name(), fish.getBodyColor().name(), fish.getPatternColor().name())).identify();
             }
             case FOX -> {
-                BukkitImplDeprecations.colorToVariantProperty.warn();
+                if (attribute != null) {
+                    BukkitImplDeprecations.colorToVariantProperty.warn(attribute.context);
+                }
                 yield as(Fox.class).getFoxType().name();
             }
             case CAT -> {
@@ -289,11 +297,15 @@ public class EntityColor extends EntityProperty<ElementTag> {
             }
             // TODO This technically has registries on all supported versions
             case VILLAGER -> {
-                BukkitImplDeprecations.colorToVariantProperty.warn();
+                if (attribute != null) {
+                    BukkitImplDeprecations.colorToVariantProperty.warn(attribute.context);
+                }
                 yield String.valueOf(as(Villager.class).getVillagerType());
             }
             case ZOMBIE_VILLAGER -> {
-                BukkitImplDeprecations.colorToVariantProperty.warn();
+                if (attribute != null) {
+                    BukkitImplDeprecations.colorToVariantProperty.warn(attribute.context);
+                }
                 yield String.valueOf(as(ZombieVillager.class).getVillagerType());
             }
             case ARROW -> {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVariant.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVariant.java
@@ -7,6 +7,8 @@ import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import org.bukkit.entity.*;
@@ -35,18 +37,27 @@ public class EntityVariant extends EntityProperty<ElementTag> {
     // @name variant
     // @input ElementTag
     // @description
-    // Controls which variant a chicken, copper golem, cow, pig, wolf, or zombie nautilus is.
+    // Controls which variant a chicken, copper golem, cow, fox, frog, llama, parrot, pig, trader llama, rabbit, villager, wolf, zombie nautilus, or zombie villager is.
     // A list of valid chicken variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Chicken.Variant.html>.
     // A list of valid copper golem variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/CopperGolem.CopperWeatherState.html>.
     // A list of valid cow variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Cow.Variant.html>.
+    // A list of valid fox variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Fox.Type.html>.
+    // A list of valid frog variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Frog.Variant.html>.
+    // A list of valid llama and trader llama variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Llama.Color.html>.
+    // A list of valid parrot variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Parrot.Variant.html>.
     // A list of valid pig variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Pig.Variant.html>.
+    // A list of valid rabbit variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Rabbit.Type.html>.
+    // A list of valid villager and zombie villager variants can be found at <@link urlhttps://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Villager.Type.html>.
     // A list of valid wolf variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Wolf.Variant.html>.
     // A list of valid zombie nautilus variants can be found at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/ZombieNautilus.Variant.html>.
     // -->
 
     public static boolean describes(EntityTag entityTag) {
         Entity entity = entityTag.getBukkitEntity();
-        return entity instanceof Wolf
+        return entity instanceof Fox || entity instanceof Llama || entity instanceof Parrot
+                || entity instanceof Rabbit || entity instanceof Villager || entity instanceof ZombieVillager
+                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog)
+                || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf)
                 || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && (entity instanceof Chicken
                                                                         || entity instanceof CopperGolem
                                                                         || entity instanceof Cow
@@ -56,75 +67,135 @@ public class EntityVariant extends EntityProperty<ElementTag> {
 
     @Override
     public ElementTag getPropertyValue() {
-        if (getEntity() instanceof Wolf wolf) {
+        Entity entity = getEntity();
+        if (entity instanceof Fox fox) {
+            return new ElementTag(fox.getFoxType());
+        }
+        else if (entity instanceof Llama llama) {
+            return new ElementTag(llama.getColor());
+        }
+        else if (entity instanceof Parrot parrot) {
+            return new ElementTag(parrot.getVariant());
+        }
+        else if (entity instanceof Rabbit rabbit) {
+            return new ElementTag(rabbit.getRabbitType());
+        }
+        else if (entity instanceof Villager villager) {
+            return new ElementTag(Utilities.namespacedKeyToString(villager.getVillagerType().getKey()), true);
+        }
+        else if (entity instanceof ZombieVillager zombieVillager) {
+            return new ElementTag(Utilities.namespacedKeyToString(zombieVillager.getVillagerType().getKey()), true);
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog frog) {
+            return new ElementTag(Utilities.namespacedKeyToString(frog.getVariant().getKey()), true);
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf wolf) {
             return new ElementTag(Utilities.namespacedKeyToString(wolf.getVariant().getKey()), true);
         }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-            if (getEntity() instanceof Chicken chicken) {
-                return new ElementTag(Utilities.namespacedKeyToString(chicken.getVariant().getKey()), true);
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Chicken chicken) {
+            return new ElementTag(Utilities.namespacedKeyToString(chicken.getVariant().getKey()), true);
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof CopperGolem copperGolem) {
+            return new ElementTag(PaperAPITools.instance.getCopperGolemVariant(copperGolem), true);
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && COW_GET_VARIANT != null && entity instanceof Cow cow) {
+            try {
+                return new ElementTag(Utilities.namespacedKeyToString(((Cow.Variant) COW_GET_VARIANT.invoke(cow)).getKey()), true);
             }
-            else if (getEntity() instanceof CopperGolem copperGolem) {
-                return new ElementTag(PaperAPITools.instance.getCopperGolemState(copperGolem), true);
+            catch (Throwable e) {
+                Debug.echoError(e);
+                return null;
             }
-            else if (COW_GET_VARIANT != null && getEntity() instanceof Cow cow) {
-                try {
-                    return new ElementTag(Utilities.namespacedKeyToString(((Cow.Variant) COW_GET_VARIANT.invoke(cow)).getKey()), true);
-                }
-                catch (Throwable e) {
-                    Debug.echoError(e);
-                    return null;
-                }
-            }
-            else if (getEntity() instanceof Pig pig) {
-                return new ElementTag(Utilities.namespacedKeyToString(pig.getVariant().getKey()), true);
-            }
-            else if (getEntity() instanceof ZombieNautilus zombieNautilus) {
-                return new ElementTag(Utilities.namespacedKeyToString(zombieNautilus.getVariant().getKey()), true);
-            }
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Pig pig) {
+            return new ElementTag(Utilities.namespacedKeyToString(pig.getVariant().getKey()), true);
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof ZombieNautilus zombieNautilus) {
+            return new ElementTag(Utilities.namespacedKeyToString(zombieNautilus.getVariant().getKey()), true);
         }
         return null;
     }
 
     @Override
     public void setPropertyValue(ElementTag variant, Mechanism mechanism) {
-        if (getEntity() instanceof Wolf wolf) {
+        Entity entity = getEntity();
+        if (entity instanceof Fox fox) {
+            Fox.Type foxVariant = Utilities.elementToRequiredEnumLike(variant, Fox.Type.class, mechanism);
+            if (foxVariant != null) {
+                fox.setFoxType(foxVariant);
+            }
+        }
+        else if (entity instanceof Llama llama) {
+            Llama.Color llamaVariant = Utilities.elementToRequiredEnumLike(variant, Llama.Color.class, mechanism);
+            if (llamaVariant != null) {
+                llama.setColor(llamaVariant);
+            }
+        }
+        else if (entity instanceof Parrot parrot) {
+            Parrot.Variant parrotVariant = Utilities.elementToRequiredEnumLike(variant, Parrot.Variant.class, mechanism);
+            if (parrotVariant != null) {
+                parrot.setVariant(parrotVariant);
+            }
+        }
+        else if (entity instanceof Rabbit rabbit) {
+            Rabbit.Type rabbitVariant = Utilities.elementToRequiredEnumLike(variant, Rabbit.Type.class, mechanism);
+            if (rabbitVariant != null) {
+                rabbit.setRabbitType(rabbitVariant);
+            }
+        }
+        else if (entity instanceof Villager || entity instanceof ZombieVillager) {
+            Villager.Type villagerVariant = Utilities.elementToRequiredEnumLike(variant, Villager.Type.class, mechanism);
+            if (villagerVariant != null) {
+                if (entity instanceof Villager villager) {
+                    villager.setVillagerType(villagerVariant);
+                }
+                else {
+                    as(ZombieVillager.class).setVillagerType(villagerVariant);
+                }
+            }
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog frog) {
+            Frog.Variant frogVariant = Utilities.elementToRequiredEnumLike(variant, Frog.Variant.class, mechanism);
+            if (frogVariant != null) {
+                frog.setVariant(frogVariant);
+            }
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf wolf) {
             Wolf.Variant wolfVariant = Utilities.elementToRequiredEnumLike(variant, Wolf.Variant.class, mechanism);
             if (wolfVariant != null) {
                 wolf.setVariant(wolfVariant);
             }
         }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-            if (getEntity() instanceof Chicken chicken) {
-                Chicken.Variant chickenVariant = Utilities.elementToRequiredEnumLike(variant, Chicken.Variant.class, mechanism);
-                if (chickenVariant != null) {
-                    chicken.setVariant(chickenVariant);
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Chicken chicken) {
+            Chicken.Variant chickenVariant = Utilities.elementToRequiredEnumLike(variant, Chicken.Variant.class, mechanism);
+            if (chickenVariant != null) {
+                chicken.setVariant(chickenVariant);
+            }
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof CopperGolem copperGolem) {
+            PaperAPITools.instance.setCopperGolemVariant(variant, copperGolem, mechanism);
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && COW_SET_VARIANT != null && entity instanceof Cow cow) {
+            Cow.Variant cowVariant = Utilities.elementToRequiredEnumLike(variant, Cow.Variant.class, mechanism);
+            if (cowVariant != null) {
+                try {
+                    COW_SET_VARIANT.invoke(cow, cowVariant);
+                }
+                catch (Throwable e) {
+                    Debug.echoError(e);
                 }
             }
-            else if (getEntity() instanceof CopperGolem copperGolem) {
-                PaperAPITools.instance.setCopperGolemState(variant, copperGolem, mechanism);
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Pig pig) {
+            Pig.Variant pigVariant = Utilities.elementToRequiredEnumLike(variant, Pig.Variant.class, mechanism);
+            if (pigVariant != null) {
+                pig.setVariant(pigVariant);
             }
-            else if (COW_SET_VARIANT != null && getEntity() instanceof Cow cow) {
-                Cow.Variant cowVariant = Utilities.elementToRequiredEnumLike(variant, Cow.Variant.class, mechanism);
-                if (cowVariant != null) {
-                    try {
-                        COW_SET_VARIANT.invoke(cow, cowVariant);
-                    }
-                    catch (Throwable e) {
-                        Debug.echoError(e);
-                    }
-                }
-            }
-            else if (getEntity() instanceof Pig pig) {
-                Pig.Variant pigVariant = Utilities.elementToRequiredEnumLike(variant, Pig.Variant.class, mechanism);
-                if (pigVariant != null) {
-                    pig.setVariant(pigVariant);
-                }
-            }
-            else if (getEntity() instanceof ZombieNautilus zombieNautilus) {
-                ZombieNautilus.Variant zombieNautilusVariant = Utilities.elementToRequiredEnumLike(variant, ZombieNautilus.Variant.class, mechanism);
-                if (zombieNautilusVariant != null) {
-                    zombieNautilus.setVariant(zombieNautilusVariant);
-                }
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof ZombieNautilus zombieNautilus) {
+            ZombieNautilus.Variant zombieNautilusVariant = Utilities.elementToRequiredEnumLike(variant, ZombieNautilus.Variant.class, mechanism);
+            if (zombieNautilusVariant != null) {
+                zombieNautilus.setVariant(zombieNautilusVariant);
             }
         }
     }
@@ -136,5 +207,55 @@ public class EntityVariant extends EntityProperty<ElementTag> {
 
     public static void register() {
         autoRegister("variant", EntityVariant.class, ElementTag.class, false);
+
+        // <--[tag]
+        // @attribute <EntityTag.allowed_variants>
+        // @returns ListTag
+        // @mechanism EntityTag.variant
+        // @group properties
+        // @description
+        // If the entity can have a variant, returns the list of allowed variants.
+        // See also <@link tag EntityTag.variant>.
+        // -->
+        PropertyParser.registerTag(EntityVariant.class, ListTag.class, "allowed_variants", (attribute, object) -> {
+            Entity entity = object.getEntity();
+            if (entity instanceof Fox) {
+                return new ListTag(Utilities.listTypes(Fox.Type.class));
+            }
+            else if (entity instanceof Llama) {
+                return new ListTag(Utilities.listTypes(Llama.Color.class));
+            }
+            else if (entity instanceof Parrot) {
+                return new ListTag(Utilities.listTypes(Parrot.Variant.class));
+            }
+            else if (entity instanceof Rabbit) {
+                return new ListTag(Utilities.listTypes(Rabbit.Type.class));
+            }
+            else if (entity instanceof Villager || entity instanceof ZombieVillager) {
+                return new ListTag(Utilities.listTypes(Villager.Type.class));
+            }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog) {
+                return new ListTag(Utilities.listTypes(Frog.Variant.class));
+            }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf) {
+                return new ListTag(Utilities.listTypes(Wolf.Variant.class));
+            }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Chicken) {
+                return new ListTag(Utilities.listTypes(Chicken.Variant.class));
+            }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof CopperGolem) {
+                return PaperAPITools.instance.getCopperGolemVariants();
+            }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Cow) {
+                return new ListTag(Utilities.listTypes(Cow.Variant.class));
+            }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Pig) {
+                return new ListTag(Utilities.listTypes(Pig.Variant.class));
+            }
+            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof ZombieNautilus) {
+                return new ListTag(Utilities.listTypes(ZombieNautilus.Variant.class));
+            }
+            return null;
+        });
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVariant.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityVariant.java
@@ -119,84 +119,52 @@ public class EntityVariant extends EntityProperty<ElementTag> {
     @Override
     public void setPropertyValue(ElementTag variant, Mechanism mechanism) {
         Entity entity = getEntity();
-        if (entity instanceof Fox fox) {
-            Fox.Type foxVariant = Utilities.elementToRequiredEnumLike(variant, Fox.Type.class, mechanism);
-            if (foxVariant != null) {
-                fox.setFoxType(foxVariant);
+        if (entity instanceof Fox fox && mechanism.requireEnum(Fox.Type.class)) {
+            fox.setFoxType(variant.asEnum(Fox.Type.class));
+        }
+        else if (entity instanceof Llama llama && mechanism.requireEnum(Llama.Color.class)) {
+            llama.setColor(variant.asEnum(Llama.Color.class));
+        }
+        else if (entity instanceof Parrot parrot && mechanism.requireEnum(Parrot.Variant.class)) {
+            parrot.setVariant(variant.asEnum(Parrot.Variant.class));
+        }
+        else if (entity instanceof Rabbit rabbit && mechanism.requireEnum(Rabbit.Type.class)) {
+            rabbit.setRabbitType(variant.asEnum(Rabbit.Type.class));
+        }
+        else if (entity instanceof Villager || entity instanceof ZombieVillager && mechanism.requireEnum(Villager.Type.class)) {
+            Villager.Type villagerVariant = variant.asEnum(Villager.Type.class);
+            if (entity instanceof Villager villager) {
+                villager.setVillagerType(villagerVariant);
+            }
+            else {
+                as(ZombieVillager.class).setVillagerType(villagerVariant);
             }
         }
-        else if (entity instanceof Llama llama) {
-            Llama.Color llamaVariant = Utilities.elementToRequiredEnumLike(variant, Llama.Color.class, mechanism);
-            if (llamaVariant != null) {
-                llama.setColor(llamaVariant);
-            }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog frog && mechanism.requireEnum(Frog.Variant.class)) {
+            frog.setVariant(variant.asEnum(Frog.Variant.class));
         }
-        else if (entity instanceof Parrot parrot) {
-            Parrot.Variant parrotVariant = Utilities.elementToRequiredEnumLike(variant, Parrot.Variant.class, mechanism);
-            if (parrotVariant != null) {
-                parrot.setVariant(parrotVariant);
-            }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf wolf && mechanism.requireEnum(Wolf.Variant.class)) {
+            wolf.setVariant(variant.asEnum(Wolf.Variant.class));
         }
-        else if (entity instanceof Rabbit rabbit) {
-            Rabbit.Type rabbitVariant = Utilities.elementToRequiredEnumLike(variant, Rabbit.Type.class, mechanism);
-            if (rabbitVariant != null) {
-                rabbit.setRabbitType(rabbitVariant);
-            }
-        }
-        else if (entity instanceof Villager || entity instanceof ZombieVillager) {
-            Villager.Type villagerVariant = Utilities.elementToRequiredEnumLike(variant, Villager.Type.class, mechanism);
-            if (villagerVariant != null) {
-                if (entity instanceof Villager villager) {
-                    villager.setVillagerType(villagerVariant);
-                }
-                else {
-                    as(ZombieVillager.class).setVillagerType(villagerVariant);
-                }
-            }
-        }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog frog) {
-            Frog.Variant frogVariant = Utilities.elementToRequiredEnumLike(variant, Frog.Variant.class, mechanism);
-            if (frogVariant != null) {
-                frog.setVariant(frogVariant);
-            }
-        }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf wolf) {
-            Wolf.Variant wolfVariant = Utilities.elementToRequiredEnumLike(variant, Wolf.Variant.class, mechanism);
-            if (wolfVariant != null) {
-                wolf.setVariant(wolfVariant);
-            }
-        }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Chicken chicken) {
-            Chicken.Variant chickenVariant = Utilities.elementToRequiredEnumLike(variant, Chicken.Variant.class, mechanism);
-            if (chickenVariant != null) {
-                chicken.setVariant(chickenVariant);
-            }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Chicken chicken && mechanism.requireEnum(Chicken.Variant.class)) {
+            chicken.setVariant(variant.asEnum(Chicken.Variant.class));
         }
         else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof CopperGolem copperGolem) {
             PaperAPITools.instance.setCopperGolemVariant(variant, copperGolem, mechanism);
         }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && COW_SET_VARIANT != null && entity instanceof Cow cow) {
-            Cow.Variant cowVariant = Utilities.elementToRequiredEnumLike(variant, Cow.Variant.class, mechanism);
-            if (cowVariant != null) {
-                try {
-                    COW_SET_VARIANT.invoke(cow, cowVariant);
-                }
-                catch (Throwable e) {
-                    Debug.echoError(e);
-                }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && COW_SET_VARIANT != null && entity instanceof Cow cow && mechanism.requireEnum(Cow.Variant.class)) {
+            try {
+                COW_SET_VARIANT.invoke(cow, variant.asEnum(Cow.Variant.class));
+            }
+            catch (Throwable e) {
+                Debug.echoError(e);
             }
         }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Pig pig) {
-            Pig.Variant pigVariant = Utilities.elementToRequiredEnumLike(variant, Pig.Variant.class, mechanism);
-            if (pigVariant != null) {
-                pig.setVariant(pigVariant);
-            }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Pig pig && mechanism.requireEnum(Pig.Variant.class)) {
+            pig.setVariant(variant.asEnum(Pig.Variant.class));
         }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof ZombieNautilus zombieNautilus) {
-            ZombieNautilus.Variant zombieNautilusVariant = Utilities.elementToRequiredEnumLike(variant, ZombieNautilus.Variant.class, mechanism);
-            if (zombieNautilusVariant != null) {
-                zombieNautilus.setVariant(zombieNautilusVariant);
-            }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof ZombieNautilus zombieNautilus && mechanism.requireEnum(ZombieNautilus.Variant.class)) {
+            zombieNautilus.setVariant(variant.asEnum(ZombieNautilus.Variant.class));
         }
     }
 
@@ -218,44 +186,48 @@ public class EntityVariant extends EntityProperty<ElementTag> {
         // See also <@link tag EntityTag.variant>.
         // -->
         PropertyParser.registerTag(EntityVariant.class, ListTag.class, "allowed_variants", (attribute, object) -> {
-            Entity entity = object.getEntity();
-            if (entity instanceof Fox) {
-                return new ListTag(Utilities.listTypes(Fox.Type.class));
-            }
-            else if (entity instanceof Llama) {
-                return new ListTag(Utilities.listTypes(Llama.Color.class));
-            }
-            else if (entity instanceof Parrot) {
-                return new ListTag(Utilities.listTypes(Parrot.Variant.class));
-            }
-            else if (entity instanceof Rabbit) {
-                return new ListTag(Utilities.listTypes(Rabbit.Type.class));
-            }
-            else if (entity instanceof Villager || entity instanceof ZombieVillager) {
-                return new ListTag(Utilities.listTypes(Villager.Type.class));
-            }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog) {
-                return new ListTag(Utilities.listTypes(Frog.Variant.class));
-            }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf) {
-                return new ListTag(Utilities.listTypes(Wolf.Variant.class));
-            }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Chicken) {
-                return new ListTag(Utilities.listTypes(Chicken.Variant.class));
-            }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof CopperGolem) {
-                return PaperAPITools.instance.getCopperGolemVariants();
-            }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Cow) {
-                return new ListTag(Utilities.listTypes(Cow.Variant.class));
-            }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Pig) {
-                return new ListTag(Utilities.listTypes(Pig.Variant.class));
-            }
-            else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof ZombieNautilus) {
-                return new ListTag(Utilities.listTypes(ZombieNautilus.Variant.class));
-            }
-            return null;
+            return getVariants(object.getEntity());
         });
+    }
+
+    private static ListTag getVariants(Entity entity) {
+        Class<?> enumType = null;
+        if (entity instanceof Fox) {
+            enumType = Fox.Type.class;
+        }
+        else if (entity instanceof Llama) {
+            enumType = Llama.Color.class;
+        }
+        else if (entity instanceof Parrot) {
+            enumType = Parrot.Variant.class;
+        }
+        else if (entity instanceof Rabbit) {
+            enumType = Rabbit.Type.class;
+        }
+        else if (entity instanceof Villager || entity instanceof ZombieVillager) {
+            enumType = Villager.Type.class;
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19) && entity instanceof Frog) {
+            enumType = Frog.Variant.class;
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && entity instanceof Wolf) {
+            enumType = Wolf.Variant.class;
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Chicken) {
+            enumType = Chicken.Variant.class;
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof CopperGolem) {
+            return PaperAPITools.instance.getCopperGolemVariants();
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Cow) {
+            enumType = Cow.Variant.class;
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof Pig) {
+            enumType = Pig.Variant.class;
+        }
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && entity instanceof ZombieNautilus) {
+            enumType = ZombieNautilus.Variant.class;
+        }
+        return enumType != null ? Utilities.listTypes(enumType) : null;
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -494,6 +494,12 @@ public class BukkitImplDeprecations {
     // Added 2025/09/22
     public static Warning playerSteerEntityEvent = new FutureWarning("playerSteerEntityEvent", "The 'player steers <entity>' event is deprecated in favor of the 'player input' event in MC 1.21+.");
 
+    // Added 2026/02/21
+    public static Warning colorToVariantProperty = new FutureWarning("colorToVariantProperty", "The usage of the 'EntityTag.color' property for this type of entity has been deprecated in favor of 'EntityTag.variant'.");
+
+    // Added 2026/02/21
+    public static Warning allowedColorsToVariants = new FutureWarning("allowedColorsToVariants", "The usage of the 'EntityTag.allowed_colors' tag for this type of entity has been deprecated in favor of 'EntityTag.allowed_variants'.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2023/10/29 without warning.

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -20,6 +20,7 @@ public class MultiVersionHelper1_19 {
     // TODO Frog variants technically have registries on all supported versions
     public static String getColor(Entity entity, boolean includeDeprecated) {
         if (entity instanceof Frog frog) {
+            BukkitImplDeprecations.colorToVariantProperty.warn();
             return String.valueOf(frog.getVariant());
         }
         else if (entity instanceof Boat boat) {
@@ -36,6 +37,7 @@ public class MultiVersionHelper1_19 {
 
     public static ListTag getAllowedColors(EntityType type) {
         if (type == EntityType.FROG) {
+            BukkitImplDeprecations.allowedColorsToVariants.warn();
             return Utilities.listTypes(Frog.Variant.class);
         }
         else if (Boat.class.isAssignableFrom(type.getEntityClass())) {
@@ -49,6 +51,7 @@ public class MultiVersionHelper1_19 {
 
     public static void setColor(Entity entity, Mechanism mech) {
         if (entity instanceof Frog frog && Utilities.requireEnumlike(mech, Frog.Variant.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn();
             frog.setVariant(Utilities.elementToEnumlike(mech.getValue(), Frog.Variant.class));
         }
         else if (entity instanceof Boat boat && mech.requireEnum(Boat.Type.class)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/MultiVersionHelper1_19.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.*;
+import com.denizenscript.denizencore.tags.Attribute;
 import org.bukkit.World;
 import org.bukkit.entity.*;
 
@@ -15,17 +16,17 @@ public class MultiVersionHelper1_19 {
     }
 
     // TODO Frog variants technically have registries on all supported versions
-    public static String getColor(Entity entity, boolean includeDeprecated) {
+    public static String getColor(Entity entity, Attribute attribute) {
         if (entity instanceof Frog frog) {
             BukkitImplDeprecations.colorToVariantProperty.warn();
             return Utilities.keyedToString(frog.getVariant());
         }
         else if (entity instanceof Boat boat) {
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                if (!includeDeprecated) {
+                if (attribute == null) {
                     return null;
                 }
-                BukkitImplDeprecations.gettingBoatType.warn();
+                BukkitImplDeprecations.gettingBoatType.warn(attribute.context);
             }
             return boat.getBoatType().name();
         }
@@ -46,17 +47,17 @@ public class MultiVersionHelper1_19 {
         return null;
     }
 
-    public static void setColor(Entity entity, Mechanism mech) {
-        if (entity instanceof Frog frog && Utilities.requireEnumlike(mech, Frog.Variant.class)) {
-            BukkitImplDeprecations.colorToVariantProperty.warn();
-            frog.setVariant(Utilities.elementToEnumlike(mech.getValue(), Frog.Variant.class));
+    public static void setColor(Entity entity, Mechanism mechanism) {
+        if (entity instanceof Frog frog && Utilities.requireEnumlike(mechanism, Frog.Variant.class)) {
+            BukkitImplDeprecations.colorToVariantProperty.warn(mechanism.context);
+            frog.setVariant(Utilities.elementToEnumlike(mechanism.getValue(), Frog.Variant.class));
         }
-        else if (entity instanceof Boat boat && mech.requireEnum(Boat.Type.class)) {
+        else if (entity instanceof Boat boat && mechanism.requireEnum(Boat.Type.class)) {
             if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                BukkitImplDeprecations.settingBoatType.warn(mech.context);
+                BukkitImplDeprecations.settingBoatType.warn(mechanism.context);
                 return;
             }
-            boat.setBoatType(mech.getValue().asEnum(Boat.Type.class));
+            boat.setBoatType(mechanism.getValue().asEnum(Boat.Type.class));
         }
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/PaperAPITools.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizen.scripts.containers.core.ItemScriptContainer;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.utilities.ReflectionHelper;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -242,11 +243,15 @@ public class PaperAPITools {
         return NMSHandler.instance.getRecentTps();
     }
 
-    public String getCopperGolemState(CopperGolem copperGolem) {
+    public ListTag getCopperGolemVariants() {
+        return Utilities.listTypes(CopperGolem.CopperWeatherState.class);
+    }
+
+    public String getCopperGolemVariant(CopperGolem copperGolem) {
         return copperGolem.getWeatherState().name();
     }
 
-    public void setCopperGolemState(ElementTag variant, CopperGolem copperGolem, Mechanism mechanism) {
+    public void setCopperGolemVariant(ElementTag variant, CopperGolem copperGolem, Mechanism mechanism) {
         if (mechanism.requireEnum(CopperGolem.CopperWeatherState.class)) {
             copperGolem.setWeatherState(variant.asEnum(CopperGolem.CopperWeatherState.class));
         }


### PR DESCRIPTION
Part 1 of moving some entity variants/types/colors from `EntityTag.color` to `EntityTag.variant`. The goal is to have EntityTag.color as primarily a DyeColor or ColorTag input rather than the current mix of DyeColors, ColorTags, ElementTags, and ListTags.
Also added `EntityTag.allowed_variants` to show what variants an entity can be.