### PR TITLE
Deprecated `ChunkTag.regenerate` on 1.21+

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -902,7 +902,7 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
                 getBukkitWorld().regenerateChunk(getX(), getZ());
             }
             else {
-                mechanism.echoError("The 'ChunkTag.regenerate' mechanism has been deprecated upstream and is no longer supported.");
+                BukkitImplDeprecations.chunkRegeneration.warn(mechanism.context);
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/ChunkTag.java
@@ -889,15 +889,21 @@ public class ChunkTag implements ObjectTag, Adjustable, FlaggableObject {
         // <--[mechanism]
         // @object ChunkTag
         // @name regenerate
+        // @deprecated This functionality was removed from Spigot and Paper as of 1.21.
         // @input None
         // @description
+        // Deprecated on MC 1.21+.
         // Causes the chunk to be entirely deleted and reformed from the world's seed.
-        // At time of writing this method only works as expected on Paper, and will error on Spigot.
         // @example
         // - adjust <player.location.chunk> regenerate
         // -->
         if (mechanism.matches("regenerate")) {
-            getBukkitWorld().regenerateChunk(getX(), getZ());
+            if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20)) {
+                getBukkitWorld().regenerateChunk(getX(), getZ());
+            }
+            else {
+                mechanism.echoError("The 'ChunkTag.regenerate' mechanism has been deprecated upstream and is no longer supported.");
+            }
         }
 
         // <--[mechanism]

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -496,6 +496,9 @@ public class BukkitImplDeprecations {
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
+    // Removed upstream 2025/02/15
+    public static Warning chunkRegeneration = new StrongWarning("chunkRegeneration", "The 'ChunkTag.regenerate' mechanism has been deprecated upstream and is no longer supported.");
+
     // Removed upstream 2023/10/29 without warning.
     public static Warning npcHologramDirection = new StrongWarning("npcHologramDirection", "NPCTag's 'hologram_direction' is deprecated: it was removed from Citizens. Ask in the Citizens channel on the Discord if you need it.");
 


### PR DESCRIPTION
Spigot and Paper both removed functionality for this mechanism in 1.21, so it no longer works.