### PR TITLE
`Sign` command fixes

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntitySize.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntitySize.java
@@ -13,7 +13,7 @@ public class EntitySize extends EntityProperty<ElementTag> {
     // <--[property]
     // @object EntityTag
     // @name size
-    // @input ElementTag
+    // @input ElementTag(Number)
     // @description
     // Controls the size of an entity.
     // Cube-type (slime, magma cube, sulfur cube) mob sizes are between 1 and 127.

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -1,34 +1,33 @@
 package com.denizenscript.denizen.scripts.commands.world;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
+import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.objects.properties.material.MaterialDirectional;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.objects.LocationTag;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
-import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
 import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
-import org.bukkit.block.Sign;
+import org.bukkit.Tag;
+import org.bukkit.block.*;
 
 public class SignCommand extends AbstractCommand {
 
     public SignCommand() {
         setName("sign");
-        setSyntax("sign (type:{automatic}/sign_post/wall_sign) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)");
+        setSyntax("sign (type:{automatic}/sign_post/wall_sign/hanging) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)");
         setRequiredArguments(1, 5);
         isProcedural = false;
+        autoCompile();
     }
 
     // <--[command]
     // @Name Sign
-    // @Syntax sign (type:{automatic}/sign_post/wall_sign) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)
+    // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)
     // @Required 1
     // @Maximum 5
     // @Short Modifies a sign.
@@ -69,101 +68,23 @@ public class SignCommand extends AbstractCommand {
         tab.addNotesOfType(LocationTag.class);
     }
 
-    private enum Type {AUTOMATIC, SIGN_POST, WALL_SIGN}
+    public enum Type {AUTOMATIC, SIGN_POST, WALL_SIGN, HANGING}
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        for (Argument arg : scriptEntry) {
-            if (!scriptEntry.hasObject("type")
-                    && arg.matchesEnum(Type.class)) {
-                scriptEntry.addObject("type", arg.asElement());
-            }
-            else if (!scriptEntry.hasObject("location")
-                    && arg.matchesArgumentType(LocationTag.class)) {
-                scriptEntry.addObject("location", arg.asType(LocationTag.class).setPrefix("location"));
-            }
-            else if (!scriptEntry.hasObject("direction")
-                    && arg.matchesPrefix("direction", "dir")) {
-                scriptEntry.addObject("direction", arg.asElement());
-            }
-            else if (!scriptEntry.hasObject("material")
-                    && arg.matchesPrefix("material")
-                    && arg.matchesArgumentType(MaterialTag.class)) {
-                scriptEntry.addObject("material", arg.asType(MaterialTag.class));
-            }
-            else if (!scriptEntry.hasObject("text")) {
-                scriptEntry.addObject("text", arg.asType(ListTag.class));
-            }
-            else {
-                arg.reportUnhandled();
-            }
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("type") @ArgPrefixed @ArgDefaultText("automatic") Type type,
+                                   @ArgName("material") @ArgPrefixed @ArgDefaultNull MaterialTag material,
+                                   @ArgName("text") @ArgLinear @ArgDefaultNull ListTag text,
+                                   @ArgName("location") @ArgLinear @ArgDefaultNull LocationTag location,
+                                   @ArgName("direction") @ArgPrefixed @ArgDefaultNull String direction) {
+        if (location == null) {
+            throw new InvalidArgumentsRuntimeException("Must specify a Sign location!");
         }
-        if (!scriptEntry.hasObject("location")) {
-            throw new InvalidArgumentsException("Must specify a Sign location!");
+        if (text == null) {
+            throw new InvalidArgumentsRuntimeException("Must specify sign text!");
         }
-        if (!scriptEntry.hasObject("text")) {
-            throw new InvalidArgumentsException("Must specify sign text!");
-        }
-        scriptEntry.defaultObject("type", new ElementTag(Type.AUTOMATIC));
-    }
-
-    public void setWallSign(Block sign, BlockFace bf, MaterialTag material) {
-        sign.setType(material == null ? Material.OAK_WALL_SIGN : material.getMaterial(), false);
-        MaterialTag signMaterial = new MaterialTag(sign);
-        MaterialDirectional.getFrom(signMaterial).setFacing(bf);
-        sign.setBlockData(signMaterial.getModernData());
-    }
-
-    public static boolean isStandingSign(Material material) {
-        switch (material) {
-            case CRIMSON_SIGN:
-            case WARPED_SIGN:
-            case ACACIA_SIGN:
-            case BIRCH_SIGN:
-            case DARK_OAK_SIGN:
-            case JUNGLE_SIGN:
-            case OAK_SIGN:
-            case SPRUCE_SIGN:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    public static boolean isWallSign(Material material) {
-        switch (material) {
-            case CRIMSON_WALL_SIGN:
-            case WARPED_WALL_SIGN:
-            case ACACIA_WALL_SIGN:
-            case BIRCH_WALL_SIGN:
-            case DARK_OAK_WALL_SIGN:
-            case JUNGLE_WALL_SIGN:
-            case OAK_WALL_SIGN:
-            case SPRUCE_WALL_SIGN:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    public static boolean isAnySign(Material material) {
-        return isStandingSign(material) || isWallSign(material);
-    }
-
-    @Override
-    public void execute(final ScriptEntry scriptEntry) {
-        String direction = scriptEntry.hasObject("direction") ? ((ElementTag) scriptEntry.getObject("direction")).asString() : null;
-        ElementTag typeElement = scriptEntry.getElement("type");
-        ListTag text = scriptEntry.getObjectTag("text");
-        LocationTag location = scriptEntry.getObjectTag("location");
-        MaterialTag material = scriptEntry.getObjectTag("material");
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), typeElement, location, db("direction", direction), material, text);
-        }
-        Type type = Type.valueOf(typeElement.asString().toUpperCase());
         Block sign = location.getBlock();
         if (type != Type.AUTOMATIC || !isAnySign(sign.getType())) {
-            if (type == Type.WALL_SIGN) {
+            if (type == Type.WALL_SIGN || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && type == Type.HANGING)) {
                 BlockFace bf;
                 if (direction != null) {
                     bf = Utilities.chooseSignRotation(direction);
@@ -171,7 +92,12 @@ public class SignCommand extends AbstractCommand {
                 else {
                     bf = Utilities.chooseSignRotation(sign);
                 }
-                setWallSign(sign, bf, material);
+                if (type == Type.WALL_SIGN) {
+                    setWallSign(sign, bf, material);
+                }
+                else {
+                    setHangingSign(sign, bf, material);
+                }
             }
             else {
                 sign.setType(material == null ? Material.OAK_SIGN : material.getMaterial(), false);
@@ -191,5 +117,53 @@ public class SignCommand extends AbstractCommand {
         }
         BlockState signState = sign.getState();
         Utilities.setSignLines((Sign) signState, text.toArray(new String[4]));
+    }
+
+    public static void setWallSign(Block sign, BlockFace bf, MaterialTag material) {
+        sign.setType(material == null ? Material.OAK_WALL_SIGN : material.getMaterial(), false);
+        MaterialTag signMaterial = new MaterialTag(sign);
+        MaterialDirectional.getFrom(signMaterial).setFacing(bf);
+        sign.setBlockData(signMaterial.getModernData());
+    }
+
+    public static void setHangingSign(Block sign, BlockFace bf, MaterialTag material) {
+        sign.setType(material == null ? Material.OAK_HANGING_SIGN : material.getMaterial(), false);
+        MaterialTag signMaterial = new MaterialTag(sign);
+        MaterialDirectional.getFrom(signMaterial).setFacing(bf);
+        sign.setBlockData(signMaterial.getModernData());
+    }
+
+    public static boolean isStandingSign(Material material) {
+        for (Material signType : Tag.STANDING_SIGNS.getValues()) {
+            if (signType == material) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isWallSign(Material material) {
+        for (Material signType : Tag.WALL_SIGNS.getValues()) {
+            if (signType == material) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isHangingSign(Material material) {
+        if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+            return false;
+        }
+        for (Material signType : Tag.ALL_HANGING_SIGNS.getValues()) {
+            if (signType == material) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isAnySign(Material material) {
+        return isStandingSign(material) || isWallSign(material) || isHangingSign(material);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -155,7 +155,7 @@ public class SignCommand extends AbstractCommand {
         if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
             return false;
         }
-        for (Material signType : Tag.ALL_HANGING_SIGNS.getValues()) {
+        for (Material signType : Tag.CEILING_HANGING_SIGNS.getValues()) {
             if (signType == material) {
                 return true;
             }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -21,7 +21,7 @@ public class SignCommand extends AbstractCommand {
 
     public SignCommand() {
         setName("sign");
-        setSyntax("sign (type:{automatic}/sign_post/wall_sign/hanging) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)");
+        setSyntax("sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)");
         setRequiredArguments(1, 5);
         isProcedural = false;
         autoCompile();
@@ -29,7 +29,7 @@ public class SignCommand extends AbstractCommand {
 
     // <--[command]
     // @Name Sign
-    // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)
+    // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)
     // @Required 1
     // @Maximum 5
     // @Short Modifies a sign.
@@ -76,7 +76,7 @@ public class SignCommand extends AbstractCommand {
         tab.addNotesOfType(LocationTag.class);
     }
 
-    public enum Type {AUTOMATIC, SIGN_POST, WALL_SIGN, HANGING}
+    public enum Type {AUTOMATIC, SIGN_POST, WALL_SIGN, HANGING, HANGING_WALL}
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("type") @ArgPrefixed @ArgDefaultText("automatic") Type type,
@@ -92,7 +92,7 @@ public class SignCommand extends AbstractCommand {
         }
         Block sign = location.getBlock();
         if (type != Type.AUTOMATIC || !isAnySign(sign.getType())) {
-            if (type == Type.WALL_SIGN || (SIGN_SIDES_SUPPORTED && type == Type.HANGING)) {
+            if (type == Type.WALL_SIGN || (SIGN_SIDES_SUPPORTED && (type == Type.HANGING || type == Type.HANGING_WALL))) {
                 BlockFace bf;
                 if (direction != null) {
                     bf = Utilities.chooseSignRotation(direction);
@@ -103,8 +103,11 @@ public class SignCommand extends AbstractCommand {
                 if (type == Type.WALL_SIGN) {
                     setWallSign(sign, bf, material);
                 }
-                else {
+                else if (type == Type.HANGING) {
                     setHangingSign(sign, bf, material);
+                }
+                else {
+                    setHangingWallSign(sign, bf, material);
                 }
             }
             else {
@@ -141,6 +144,13 @@ public class SignCommand extends AbstractCommand {
         sign.setBlockData(signMaterial.getModernData());
     }
 
+    public static void setHangingWallSign(Block sign, BlockFace bf, MaterialTag material) {
+        sign.setType(material == null ? Material.OAK_WALL_HANGING_SIGN : material.getMaterial(), false);
+        MaterialTag signMaterial = new MaterialTag(sign);
+        MaterialDirectional.getFrom(signMaterial).setFacing(bf);
+        sign.setBlockData(signMaterial.getModernData());
+    }
+
     public static boolean isStandingSign(Material material) {
         for (Material signType : Tag.STANDING_SIGNS.getValues()) {
             if (signType == material) {
@@ -171,7 +181,19 @@ public class SignCommand extends AbstractCommand {
         return false;
     }
 
+    public static boolean isHangingWallSign(Material material) {
+        if (!SIGN_SIDES_SUPPORTED) {
+            return false;
+        }
+        for (Material signType : Tag.WALL_HANGING_SIGNS.getValues()) {
+            if (signType == material) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean isAnySign(Material material) {
-        return isStandingSign(material) || isWallSign(material) || isHangingSign(material);
+        return isStandingSign(material) || isWallSign(material) || isHangingSign(material) || isHangingWallSign(material);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -5,6 +5,7 @@ import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.objects.properties.material.MaterialDirectional;
+import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.objects.core.ListTag;
@@ -21,7 +22,7 @@ public class SignCommand extends AbstractCommand {
 
     public SignCommand() {
         setName("sign");
-        setSyntax("sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)");
+        setSyntax("sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) (side:{both}/front/back) [<line>|...] [<location>] (direction:north/east/south/west)");
         setRequiredArguments(1, 5);
         isProcedural = false;
         autoCompile();
@@ -29,7 +30,7 @@ public class SignCommand extends AbstractCommand {
 
     // <--[command]
     // @Name Sign
-    // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) [<line>|...] [<location>] (direction:north/east/south/west)
+    // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) (side:{both}/front/back) [<line>|...] [<location>] (direction:north/east/south/west)
     // @Required 1
     // @Maximum 5
     // @Short Modifies a sign.
@@ -38,7 +39,8 @@ public class SignCommand extends AbstractCommand {
     // @Description
     // Modifies a sign that replaces the text shown on it. If no sign is at the location, it replaces the location with the modified sign.
     //
-    // Text lines 1-4 will show on the front of the sign, and lines 5-8 will show on the back (requires MC 1.20+).
+    // For MC 1.20+, optionally specify a side to set the text of. If 'both' is used, the first four entries in the 'line' argument will be used on the front, and the second four on the back.
+    // If 'front' or 'back' is specified, sets the lines on that side while leaving the other one as-is.
     //
     // Specify 'automatic' as a type to use whatever sign type and direction is already placed there.
     // If there is not already a sign there, defaults to a sign_post.
@@ -59,7 +61,11 @@ public class SignCommand extends AbstractCommand {
     //
     // @Usage
     // Use to edit some text on the front and back of an existing sign.
-    // - sign "Hi!|This is|the|front.|This|is|the|back." <context.location>
+    // - sign side:both "Hi!|This is|the|front.|This|is|the|back." <context.location>
+    //
+    // @Usage
+    // Use to edit some text on just the back of an existing sign.
+    // - sign side:back "This is|the back.|The front|is unchanged." <context.location>
     //
     // @Usage
     // Use to show the time on a sign and ensure that it points north.
@@ -78,9 +84,12 @@ public class SignCommand extends AbstractCommand {
 
     public enum Type {AUTOMATIC, SIGN_POST, WALL_SIGN, HANGING, HANGING_WALL}
 
+    public enum Side {BOTH, FRONT, BACK}
+
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("type") @ArgPrefixed @ArgDefaultText("automatic") Type type,
                                    @ArgName("material") @ArgPrefixed @ArgDefaultNull MaterialTag material,
+                                   @ArgName("side") @ArgPrefixed @ArgDefaultNull Side side,
                                    @ArgName("text") @ArgLinear @ArgDefaultNull ListTag text,
                                    @ArgName("location") @ArgLinear @ArgDefaultNull LocationTag location,
                                    @ArgName("direction") @ArgPrefixed @ArgDefaultNull String direction) {
@@ -126,8 +135,28 @@ public class SignCommand extends AbstractCommand {
                 setWallSign(sign, bf, material);
             }
         }
-        BlockState signState = sign.getState();
-        Utilities.setSignLines((Sign) signState, text.toArray(new String[8]));
+        Sign signBlock = (Sign) sign.getState();
+        String[] lines4 = text.toArray(new String[4]);
+        String[] lines8 = text.toArray(new String[8]);
+        if (!SIGN_SIDES_SUPPORTED || side == Side.FRONT) {
+            for (int n = 0; n < 4; n++) {
+                PaperAPITools.instance.setSignLine(signBlock, n, lines4[n]);
+            }
+        }
+        else if (side == Side.BACK) {
+            for (int n = 0; n < 4; n++) {
+                PaperAPITools.instance.setSignBackLine(signBlock, n, lines4[n]);
+            }
+        }
+        else {
+            for (int n = 0; n < 4; n++) {
+                PaperAPITools.instance.setSignLine(signBlock, n, lines8[n]);
+            }
+            for (int n = 4; n < 8; n++) {
+                PaperAPITools.instance.setSignBackLine(signBlock, n, lines8[n]);
+            }
+        }
+        signBlock.update();
     }
 
     public static void setWallSign(Block sign, BlockFace bf, MaterialTag material) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -88,22 +88,22 @@ public class SignCommand extends AbstractCommand {
     public enum Side {BOTH, FRONT, BACK}
 
     public static void autoExecute(ScriptEntry scriptEntry,
-                                   @ArgName("location") @ArgLinear ObjectTag locationObj,
                                    @ArgName("text") @ArgLinear ObjectTag textObj,
+                                   @ArgName("location") @ArgLinear ObjectTag locationObj,
                                    @ArgName("type") @ArgPrefixed @ArgDefaultText("automatic") Type type,
                                    @ArgName("material") @ArgPrefixed @ArgDefaultNull MaterialTag material,
                                    @ArgName("side") @ArgPrefixed @ArgDefaultNull Side side,
                                    @ArgName("direction") @ArgPrefixed @ArgDefaultNull String direction) {
-        LocationTag location;
         ListTag text;
-        if (!(locationObj instanceof LocationTag) && !(textObj instanceof ListTag)) {
+        LocationTag location;
+        if (!(textObj instanceof ListTag) && !(locationObj instanceof LocationTag) ) {
             Deprecations.outOfOrderArgs.warn(scriptEntry);
-            location = textObj.asType(LocationTag.class, scriptEntry.context);
             text = locationObj.asType(ListTag.class, scriptEntry.context);
+            location = textObj.asType(LocationTag.class, scriptEntry.context);
         }
         else {
-            location = locationObj.asType(LocationTag.class, scriptEntry.context);
             text = textObj.asType(ListTag.class, scriptEntry.context);
+            location = locationObj.asType(LocationTag.class, scriptEntry.context);
         }
         Block sign = location.getBlock();
         if (type != Type.AUTOMATIC || !isAnySign(sign.getType())) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -38,6 +38,8 @@ public class SignCommand extends AbstractCommand {
     // @Description
     // Modifies a sign that replaces the text shown on it. If no sign is at the location, it replaces the location with the modified sign.
     //
+    // Text lines 1-4 will show on the front of the sign, and lines 5-8 will show on the back (requires MC 1.20+).
+    //
     // Specify 'automatic' as a type to use whatever sign type and direction is already placed there.
     // If there is not already a sign there, defaults to a sign_post.
     //
@@ -54,6 +56,10 @@ public class SignCommand extends AbstractCommand {
     // @Usage
     // Use to edit some text on an existing sign.
     // - sign "Hello|this is|some|text" <context.location>
+    //
+    // @Usage
+    // Use to edit some text on the front and back of an existing sign.
+    // - sign "Hi!|This is|the|front.|This|is|the|back." <context.location>
     //
     // @Usage
     // Use to show the time on a sign and ensure that it points north.
@@ -86,7 +92,7 @@ public class SignCommand extends AbstractCommand {
         }
         Block sign = location.getBlock();
         if (type != Type.AUTOMATIC || !isAnySign(sign.getType())) {
-            if (type == Type.WALL_SIGN || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20) && type == Type.HANGING)) {
+            if (type == Type.WALL_SIGN || (SIGN_SIDES_SUPPORTED && type == Type.HANGING)) {
                 BlockFace bf;
                 if (direction != null) {
                     bf = Utilities.chooseSignRotation(direction);
@@ -118,7 +124,7 @@ public class SignCommand extends AbstractCommand {
             }
         }
         BlockState signState = sign.getState();
-        Utilities.setSignLines((Sign) signState, text.toArray(new String[4]));
+        Utilities.setSignLines((Sign) signState, text.toArray(new String[8]));
     }
 
     public static void setWallSign(Block sign, BlockFace bf, MaterialTag material) {
@@ -154,7 +160,7 @@ public class SignCommand extends AbstractCommand {
     }
 
     public static boolean isHangingSign(Material material) {
-        if (!NMSHandler.getVersion().isAtLeast(NMSVersion.v1_20)) {
+        if (!SIGN_SIDES_SUPPORTED) {
             return false;
         }
         for (Material signType : Tag.CEILING_HANGING_SIGNS.getValues()) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/SignCommand.java
@@ -7,11 +7,12 @@ import com.denizenscript.denizen.objects.MaterialTag;
 import com.denizenscript.denizen.objects.properties.material.MaterialDirectional;
 import com.denizenscript.denizen.utilities.PaperAPITools;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.Deprecations;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.*;
@@ -23,7 +24,7 @@ public class SignCommand extends AbstractCommand {
     public SignCommand() {
         setName("sign");
         setSyntax("sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) (side:{both}/front/back) [<line>|...] [<location>] (direction:north/east/south/west)");
-        setRequiredArguments(1, 5);
+        setRequiredArguments(1, 6);
         isProcedural = false;
         autoCompile();
     }
@@ -32,7 +33,7 @@ public class SignCommand extends AbstractCommand {
     // @Name Sign
     // @Syntax sign (type:{automatic}/sign_post/wall_sign/hanging/hanging_wall) (material:<material>) (side:{both}/front/back) [<line>|...] [<location>] (direction:north/east/south/west)
     // @Required 1
-    // @Maximum 5
+    // @Maximum 6
     // @Short Modifies a sign.
     // @Group world
     //
@@ -87,17 +88,22 @@ public class SignCommand extends AbstractCommand {
     public enum Side {BOTH, FRONT, BACK}
 
     public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("location") @ArgLinear ObjectTag locationObj,
+                                   @ArgName("text") @ArgLinear ObjectTag textObj,
                                    @ArgName("type") @ArgPrefixed @ArgDefaultText("automatic") Type type,
                                    @ArgName("material") @ArgPrefixed @ArgDefaultNull MaterialTag material,
                                    @ArgName("side") @ArgPrefixed @ArgDefaultNull Side side,
-                                   @ArgName("text") @ArgLinear @ArgDefaultNull ListTag text,
-                                   @ArgName("location") @ArgLinear @ArgDefaultNull LocationTag location,
                                    @ArgName("direction") @ArgPrefixed @ArgDefaultNull String direction) {
-        if (location == null) {
-            throw new InvalidArgumentsRuntimeException("Must specify a Sign location!");
+        LocationTag location;
+        ListTag text;
+        if (!(locationObj instanceof LocationTag) && !(textObj instanceof ListTag)) {
+            Deprecations.outOfOrderArgs.warn(scriptEntry);
+            location = textObj.asType(LocationTag.class, scriptEntry.context);
+            text = locationObj.asType(ListTag.class, scriptEntry.context);
         }
-        if (text == null) {
-            throw new InvalidArgumentsRuntimeException("Must specify sign text!");
+        else {
+            location = locationObj.asType(LocationTag.class, scriptEntry.context);
+            text = textObj.asType(ListTag.class, scriptEntry.context);
         }
         Block sign = location.getBlock();
         if (type != Type.AUTOMATIC || !isAnySign(sign.getType())) {
@@ -151,9 +157,7 @@ public class SignCommand extends AbstractCommand {
         else {
             for (int n = 0; n < 4; n++) {
                 PaperAPITools.instance.setSignLine(signBlock, n, lines8[n]);
-            }
-            for (int n = 4; n < 8; n++) {
-                PaperAPITools.instance.setSignBackLine(signBlock, n, lines8[n]);
+                PaperAPITools.instance.setSignBackLine(signBlock, n, lines8[n + 4]);
             }
         }
         signBlock.update();

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -379,6 +379,11 @@ public class Utilities {
         for (int n = 0; n < 4; n++) {
             PaperAPITools.instance.setSignLine(sign, n, lines[n]);
         }
+        if (SignCommand.SIGN_SIDES_SUPPORTED) {
+            for (int n = 4; n < 8; n++) {
+                PaperAPITools.instance.setSignBackLine(sign, n, lines[n]);
+            }
+        }
         sign.update();
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/Utilities.java
@@ -375,18 +375,6 @@ public class Utilities {
         return baseLocation.distanceSquared(theLocation) < theLeeway * theLeeway;
     }
 
-    public static void setSignLines(Sign sign, String[] lines) {
-        for (int n = 0; n < 4; n++) {
-            PaperAPITools.instance.setSignLine(sign, n, lines[n]);
-        }
-        if (SignCommand.SIGN_SIDES_SUPPORTED) {
-            for (int n = 4; n < 8; n++) {
-                PaperAPITools.instance.setSignBackLine(sign, n, lines[n]);
-            }
-        }
-        sign.update();
-    }
-
     public static BlockFace chooseSignRotation(Block signBlock) {
         BlockFace[] blockFaces = {BlockFace.EAST, BlockFace.NORTH, BlockFace.WEST, BlockFace.SOUTH};
         for (BlockFace blockFace : blockFaces) {
@@ -406,13 +394,12 @@ public class Utilities {
                 return blockFace;
             }
         }
-        switch (dirUpper.charAt(0)) {
-            case 'N': return BlockFace.NORTH;
-            case 'S': return BlockFace.SOUTH;
-            case 'E': return BlockFace.EAST;
-            case 'W': return BlockFace.WEST;
-        }
-        return BlockFace.SOUTH;
+        return switch (dirUpper.charAt(0)) {
+            case 'N' -> BlockFace.NORTH;
+            case 'E' -> BlockFace.EAST;
+            case 'W' -> BlockFace.WEST;
+            default -> BlockFace.SOUTH;
+        };
     }
 
     public static void setSignRotation(BlockState signState, String direction) {


### PR DESCRIPTION
Reported at https://discord.com/channels/315163488085475337/1517824624186888232
- Sign material checks now check the tag values rather than a hard-coded list.
- Modernized `sign` command to new command format.
- Added ability to set signs as `hanging` for MC 1.20+.