### PR TITLE
Map command - radius argument fix

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/MapCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/item/MapCommand.java
@@ -98,7 +98,7 @@ public class MapCommand extends AbstractCommand {
                                    @ArgName("resize") boolean resize,
                                    @ArgName("script") @ArgPrefixed @ArgDefaultNull ScriptTag script,
                                    @ArgName("dot") @ArgPrefixed @ArgDefaultNull ColorTag dot,
-                                   @ArgName("radius") @ArgPrefixed @ArgDefaultText("-1") int radius,
+                                   @ArgName("radius") @ArgPrefixed @ArgDefaultText("1") int radius,
                                    @ArgName("x") @ArgPrefixed @ArgDefaultText("0") double x,
                                    @ArgName("y") @ArgPrefixed @ArgDefaultText("0") double y,
                                    @ArgName("width") @ArgPrefixed @ArgDefaultText("-1") int width,


### PR DESCRIPTION
Reported at https://discord.com/channels/315163488085475337/1011496047811506227/1519021304529817721
## Changes:
- This used to default to one when not specified.
 ```patch
- dmr.addObject(new MapDot(x.asString(), y.asString(), "true", false, radius == null ? "1" : radius.toString(), dot.toString()));
   ```