### PR TITLE
`server list ping` determination bug fix

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
@@ -40,7 +40,9 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
         this.<ServerListPingScriptEventPaperImpl, ListTag>registerDetermination("exclude_players", ListTag.class, (evt, context, list) -> {
             HashSet<UUID> exclusions = new HashSet<>();
             for (PlayerTag player : list.filter(PlayerTag.class, context)) {
-                exclusions.add(player.getUUID());
+                if (player.isOnline()) {
+                    exclusions.add(player.getUUID());
+                }
             }
             if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
                 Iterator<Player> players = evt.getEvent().iterator();
@@ -87,6 +89,7 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
 
         public static void excludeListedPlayers(PaperServerListPingEvent event, Set<UUID> exclude) {
             event.getListedPlayers().removeIf(listedPlayerInfo -> exclude.contains(listedPlayerInfo.id()));
+            event.setNumPlayers(event.getNumPlayers() - exclude.size());
         }
     }
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
@@ -98,6 +98,7 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
         }
 
         public static void excludeListedPlayers(PaperServerListPingEvent event, Set<UUID> exclude) {
+            int size = event.getListedPlayers().size();
             MutableInt counter = new MutableInt();
             event.getListedPlayers().removeIf(listedPlayerInfo -> {
                 if (exclude.contains(listedPlayerInfo.id())) {
@@ -106,7 +107,9 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
                 }
                 return false;
             });
-            event.setNumPlayers(event.getNumPlayers() - counter.intValue());
+            if (size == event.getNumPlayers()) {
+                event.setNumPlayers(event.getNumPlayers() - counter.intValue());
+            }
         }
     }
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
@@ -15,7 +15,6 @@ import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
 import net.md_5.bungee.api.ChatColor;
-import org.apache.commons.lang3.mutable.MutableInt;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.profile.PlayerTextures;
@@ -71,6 +70,17 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
             ListedPlayersEditor.setListedPlayerInfo(evt.getEvent(), text);
             return true;
         });
+        this.<ServerListPingScriptEventPaperImpl, ElementTag>registerOptionalDetermination("player_count", ElementTag.class, (evt, context, input) -> {
+            if (!CoreConfiguration.allowRestrictedActions) {
+                Debug.echoError("Cannot use 'player_count' in list ping event: 'Allow restricted actions' is disabled in Denizen config.yml.");
+                return false;
+            }
+            if (input.isInt()) {
+                evt.getEvent().setNumPlayers(input.asInt());
+                return true;
+            }
+            return false;
+        });
     }
 
     public PaperServerListPingEvent getEvent() {
@@ -87,15 +97,7 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
         }
 
         public static void excludeListedPlayers(PaperServerListPingEvent event, Set<UUID> exclude) {
-            MutableInt counter = new MutableInt(0);
-            event.getListedPlayers().removeIf(listedPlayerInfo -> {
-                if (exclude.contains(listedPlayerInfo.id())) {
-                    counter.increment();
-                    return true;
-                }
-                return false;
-            });
-            event.setNumPlayers(event.getNumPlayers() - counter.intValue());
+            event.getListedPlayers().removeIf(listedPlayerInfo -> exclude.contains(listedPlayerInfo.id()));
         }
     }
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
@@ -15,6 +15,7 @@ import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
 import net.md_5.bungee.api.ChatColor;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.profile.PlayerTextures;
@@ -97,7 +98,15 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
         }
 
         public static void excludeListedPlayers(PaperServerListPingEvent event, Set<UUID> exclude) {
-            event.getListedPlayers().removeIf(listedPlayerInfo -> exclude.contains(listedPlayerInfo.id()));
+            MutableInt counter = new MutableInt();
+            event.getListedPlayers().removeIf(listedPlayerInfo -> {
+                if (exclude.contains(listedPlayerInfo.id())) {
+                    counter.increment();
+                    return true;
+                }
+                return false;
+            });
+            event.setNumPlayers(event.getNumPlayers() - counter.intValue());
         }
     }
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/events/ServerListPingScriptEventPaperImpl.java
@@ -15,6 +15,7 @@ import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
 import net.md_5.bungee.api.ChatColor;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.profile.PlayerTextures;
@@ -40,9 +41,7 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
         this.<ServerListPingScriptEventPaperImpl, ListTag>registerDetermination("exclude_players", ListTag.class, (evt, context, list) -> {
             HashSet<UUID> exclusions = new HashSet<>();
             for (PlayerTag player : list.filter(PlayerTag.class, context)) {
-                if (player.isOnline()) {
-                    exclusions.add(player.getUUID());
-                }
+                exclusions.add(player.getUUID());
             }
             if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_19)) {
                 Iterator<Player> players = evt.getEvent().iterator();
@@ -88,8 +87,15 @@ public class ServerListPingScriptEventPaperImpl extends ListPingScriptEvent {
         }
 
         public static void excludeListedPlayers(PaperServerListPingEvent event, Set<UUID> exclude) {
-            event.getListedPlayers().removeIf(listedPlayerInfo -> exclude.contains(listedPlayerInfo.id()));
-            event.setNumPlayers(event.getNumPlayers() - exclude.size());
+            MutableInt counter = new MutableInt(0);
+            event.getListedPlayers().removeIf(listedPlayerInfo -> {
+                if (exclude.contains(listedPlayerInfo.id())) {
+                    counter.increment();
+                    return true;
+                }
+                return false;
+            });
+            event.setNumPlayers(event.getNumPlayers() - counter.intValue());
         }
     }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
@@ -46,8 +46,9 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
     // "ICON:<ElementTag>" of a file path to an icon image, to change the icon that will display.
     // "PROTOCOL_VERSION:<ElementTag(Number)>" to change the protocol ID number of the server's version (only on Paper).
     // "VERSION_NAME:<ElementTag>" to change the server's version name (only on Paper).
-    // "EXCLUDE_PLAYERS:<ListTag(PlayerTag)>" to exclude a set of players from showing in the player count or preview of online players (only on Paper).
+    // "EXCLUDE_PLAYERS:<ListTag(PlayerTag)>" to exclude a set of players from showing in the preview of online players (only on Paper).
     // "ALTERNATE_PLAYER_TEXT:<ListTag>" to set custom text for the player list section of the server status (only on Paper). (Requires "Allow restricted actions" in Denizen/config.yml). Usage of this to present lines that look like player names (but aren't) is forbidden.
+    // "PLAYER_COUNT:<ElementTag(Number)>" to set the amount of players that are online (only on Paper). (Requires "Allow restricted actions" in Denizen/config.yml). Usage of this to display a higher number of players than are actually connected is forbidden.
     // "MOTD:<ElementTag>" to change the MOTD that will show.
     //
     // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/server/ListPingScriptEvent.java
@@ -46,7 +46,7 @@ public class ListPingScriptEvent extends BukkitScriptEvent implements Listener {
     // "ICON:<ElementTag>" of a file path to an icon image, to change the icon that will display.
     // "PROTOCOL_VERSION:<ElementTag(Number)>" to change the protocol ID number of the server's version (only on Paper).
     // "VERSION_NAME:<ElementTag>" to change the server's version name (only on Paper).
-    // "EXCLUDE_PLAYERS:<ListTag(PlayerTag)>" to exclude a set of players from showing in the preview of online players (only on Paper).
+    // "EXCLUDE_PLAYERS:<ListTag(PlayerTag)>" to exclude a set of players from showing in the player count or preview of online players (only on Paper).
     // "ALTERNATE_PLAYER_TEXT:<ListTag>" to set custom text for the player list section of the server status (only on Paper). (Requires "Allow restricted actions" in Denizen/config.yml). Usage of this to present lines that look like player names (but aren't) is forbidden.
     // "PLAYER_COUNT:<ElementTag(Number)>" to set the amount of players that are online (only on Paper). (Requires "Allow restricted actions" in Denizen/config.yml). Usage of this to display a higher number of players than are actually connected is forbidden.
     // "MOTD:<ElementTag>" to change the MOTD that will show.


### PR DESCRIPTION
Fixes a bug where the number of players on the server wouldn't update when changed with the `EXCLUDE_PLAYERS` determination.

Reported at https://discord.com/channels/315163488085475337/1522089160108675073