### PR TITLE
add item_name property

### DIFF
--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ComponentAdaptersRegistry.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ComponentAdaptersRegistry.java
@@ -9,5 +9,6 @@ public class ComponentAdaptersRegistry {
         DataComponentAdapter.register(new MaxDurabilityAdapter());
         DataComponentAdapter.register(new MaxStackSizeAdapter());
         DataComponentAdapter.register(new RarityAdapter());
+        DataComponentAdapter.register(new ItemNameAdapter());
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ComponentAdaptersRegistry.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ComponentAdaptersRegistry.java
@@ -6,9 +6,9 @@ public class ComponentAdaptersRegistry {
         DataComponentAdapter.register(new FoodAdapter());
         DataComponentAdapter.register(new GliderAdapter());
         DataComponentAdapter.register(new ItemModelAdapter());
+        DataComponentAdapter.register(new ItemNameAdapter());
         DataComponentAdapter.register(new MaxDurabilityAdapter());
         DataComponentAdapter.register(new MaxStackSizeAdapter());
         DataComponentAdapter.register(new RarityAdapter());
-        DataComponentAdapter.register(new ItemNameAdapter());
     }
 }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
@@ -1,0 +1,35 @@
+package com.denizenscript.denizen.paper.datacomponents;
+
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+
+public class ItemNameAdapter extends DataComponentAdapter.Valued<ElementTag, Component> {
+
+    // <--[property]
+    // @object ItemTag
+    // @name item_name
+    // @input ElementTag
+    // @description
+    // Controls the item's item name component. This exists under the item's <@link mechanism ItemTag.display> and persists if it is renamed in an anvil.
+    // See also <@link language Item Components>.
+    // @mechanism
+    // Provide no input to reset the item to its default value.
+    // -->
+
+    public ItemNameAdapter() {
+        super(ElementTag.class, DataComponentTypes.ITEM_NAME, "item_name");
+    }
+
+    @Override
+    public ElementTag toDenizen(Component value) {
+        return new ElementTag(LegacyComponentSerializer.legacyAmpersand().serialize(value));
+    }
+
+    @Override
+    public Component fromDenizen(ElementTag value, Mechanism mechanism) {
+        return Component.text(value.toString());
+    }
+}

--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
@@ -28,7 +28,7 @@ public class ItemNameAdapter extends DataComponentAdapter.Valued<ElementTag, Com
 
     @Override
     public ElementTag toDenizen(Component value) {
-        return new ElementTag(PaperModule.stringifyComponent(value));
+        return new ElementTag(PaperModule.stringifyComponent(value), true);
     }
 
     @Override

--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
@@ -14,7 +14,9 @@ public class ItemNameAdapter extends DataComponentAdapter.Valued<ElementTag, Com
     // @name item_name
     // @input ElementTag
     // @description
-    // Controls the item's item_name component. In effect, this changes its display name. Unlike <@link mechanism ItemTag.display>, this name cannot be changed by an anvil, but will be hidden when the display is set, such as with an anvil. That is, it will remain under the display name and be shown again if the display is removed.
+    // Controls the item's item_name component. In effect, this changes its display name.
+    // Unlike <@link mechanism ItemTag.display>, this name cannot be changed by an anvil, but will be hidden when the display is set, such as with an anvil.
+    // That is, it will remain under the display name and be shown again if the display is removed.
     // See also <@link language Item Components>.
     // @mechanism
     // Provide no input to reset the item to its default value.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
@@ -14,12 +14,14 @@ public class ItemNameAdapter extends DataComponentAdapter.Valued<ElementTag, Com
     // @name item_name
     // @input ElementTag
     // @description
-    // Controls the item's item_name component. In effect, this changes its display name.
-    // Unlike <@link mechanism ItemTag.display>, this name cannot be changed by an anvil, but will be hidden when the display is set, such as with an anvil.
-    // That is, it will remain under the display name and be shown again if the display is removed.
+    // Controls the item's default name.
+    // The item's default name cannot be modified by a player and is displayed when <@link mechanism ItemTag.display> is not set.
+    // If a display name is set, item_name will still retain its original value but will be hidden.
     // See also <@link language Item Components>.
     // @mechanism
     // Provide no input to reset the item to its default value.
+    // @tag
+    // By default, this will return the item's vanilla display name.
     // -->
 
     public ItemNameAdapter() {

--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
@@ -14,7 +14,7 @@ public class ItemNameAdapter extends DataComponentAdapter.Valued<ElementTag, Com
     // @name item_name
     // @input ElementTag
     // @description
-    // Controls the item's item name component. This exists under the item's <@link mechanism ItemTag.display> and persists if it is renamed in an anvil.
+    // Controls the item's item_name component. In effect, this changes its display name. Unlike <@link mechanism ItemTag.display>, this name cannot be changed by an anvil, but will be hidden when the display is set, such as with an anvil. That is, it will remain under the display name and be shown again if the display is removed.
     // See also <@link language Item Components>.
     // @mechanism
     // Provide no input to reset the item to its default value.

--- a/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/datacomponents/ItemNameAdapter.java
@@ -4,7 +4,8 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.denizenscript.denizen.paper.PaperModule;
+import net.md_5.bungee.api.ChatColor;
 
 public class ItemNameAdapter extends DataComponentAdapter.Valued<ElementTag, Component> {
 
@@ -25,11 +26,11 @@ public class ItemNameAdapter extends DataComponentAdapter.Valued<ElementTag, Com
 
     @Override
     public ElementTag toDenizen(Component value) {
-        return new ElementTag(LegacyComponentSerializer.legacyAmpersand().serialize(value));
+        return new ElementTag(PaperModule.stringifyComponent(value));
     }
 
     @Override
     public Component fromDenizen(ElementTag value, Mechanism mechanism) {
-        return Component.text(value.toString());
+        return PaperModule.parseFormattedText(value.toString(), ChatColor.WHITE);
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemDisplayname.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemDisplayname.java
@@ -62,6 +62,7 @@ public class ItemDisplayname implements Property {
         // @group properties
         // @description
         // Returns the display name of the item, as set by plugin or an anvil.
+        // Use <@link property ItemTag.item_name> to get the item's item name component, which cannot be changed by an anvil.
         // -->
         if (attribute.startsWith("display")) {
             if (hasDisplayName()) {
@@ -77,6 +78,7 @@ public class ItemDisplayname implements Property {
         // @group properties
         // @description
         // Returns whether the item has a custom set display name.
+        // Use <@link property ItemTag.item_name> for the item's item_display component, which also controls its name.
         // -->
         if (attribute.startsWith("has_display")) {
             return new ElementTag(hasDisplayName())
@@ -116,6 +118,7 @@ public class ItemDisplayname implements Property {
         // @description
         // Changes the item's display name.
         // Give no input to remove the item's display name.
+        // Use <@link property ItemTag.item_name> to set the item's item name component, which persists through changes to its display, and shows when no display is set.
         // @tags
         // <ItemTag.display>
         // -->

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemDisplayname.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/item/ItemDisplayname.java
@@ -62,7 +62,7 @@ public class ItemDisplayname implements Property {
         // @group properties
         // @description
         // Returns the display name of the item, as set by plugin or an anvil.
-        // Use <@link property ItemTag.item_name> to get the item's item name component, which cannot be changed by an anvil.
+        // See also <@link property ItemTag.item_name>.
         // -->
         if (attribute.startsWith("display")) {
             if (hasDisplayName()) {
@@ -78,7 +78,7 @@ public class ItemDisplayname implements Property {
         // @group properties
         // @description
         // Returns whether the item has a custom set display name.
-        // Use <@link property ItemTag.item_name> for the item's item_display component, which also controls its name.
+        // See also <@link property ItemTag.item_name>.
         // -->
         if (attribute.startsWith("has_display")) {
             return new ElementTag(hasDisplayName())
@@ -118,7 +118,7 @@ public class ItemDisplayname implements Property {
         // @description
         // Changes the item's display name.
         // Give no input to remove the item's display name.
-        // Use <@link property ItemTag.item_name> to set the item's item name component, which persists through changes to its display, and shows when no display is set.
+        // See also <@link property ItemTag.item_name> to set the item's default name, which cannot be changed by players.
         // @tags
         // <ItemTag.display>
         // -->


### PR DESCRIPTION
For https://discord.com/channels/315163488085475337/1362329776475603057. Works as expected on 26.2 and 26.1.

Considered mentioning this property in the item.display documentation since this is probably to be preferred for most use-cases, but didn't want to mess with other files.